### PR TITLE
Sélection de région, annotations et style des repères

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main, develop]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build (macOS)
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+
+      - name: Build
+        run: >
+          xcodebuild
+          -scheme Pinpoint
+          -destination 'platform=macOS'
+          CODE_SIGNING_ALLOWED=NO
+          build

--- a/Pinpoint/EditorView.swift
+++ b/Pinpoint/EditorView.swift
@@ -1,24 +1,86 @@
 import SwiftUI
 
+/// Annotation tools the user can switch between in the editor.
+enum EditorTool: String, CaseIterable, Identifiable {
+    case pin, arrow, rectangle
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .pin: return "Repère"
+        case .arrow: return "Flèche"
+        case .rectangle: return "Rectangle"
+        }
+    }
+
+    var symbol: String {
+        switch self {
+        case .pin: return "mappin"
+        case .arrow: return "arrow.up.right"
+        case .rectangle: return "rectangle"
+        }
+    }
+}
+
 struct EditorView: View {
     let image: NSImage
     var onClose: () -> Void
 
     @State private var pins: [Pin] = []
+    @State private var shapes: [Markup] = []
     @State private var context: String = ""
+    @State private var tool: EditorTool = .pin
     @State private var selectedPinID: Pin.ID?
+    @State private var selectedShapeID: Markup.ID?
+    @State private var draft: Markup?
     @State private var didCopy = false
 
     var body: some View {
         HSplitView {
-            canvas
-                .frame(minWidth: 360, minHeight: 360)
-                .layoutPriority(1)
+            VStack(spacing: 0) {
+                toolbar
+                Divider()
+                canvas
+            }
+            .frame(minWidth: 360, minHeight: 360)
+            .layoutPriority(1)
 
             sidePanel
                 .frame(minWidth: 260, idealWidth: 280, maxWidth: 360)
         }
-        .frame(minWidth: 680, minHeight: 420)
+        .frame(minWidth: 680, minHeight: 440)
+    }
+
+    // MARK: - Toolbar
+
+    private var toolbar: some View {
+        HStack(spacing: 10) {
+            Picker("Outil", selection: $tool) {
+                ForEach(EditorTool.allCases) { tool in
+                    Label(tool.label, systemImage: tool.symbol).tag(tool)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .frame(maxWidth: 320)
+
+            Spacer()
+
+            Text(toolHint)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    private var toolHint: String {
+        switch tool {
+        case .pin: return "Clique pour poser un repère"
+        case .arrow: return "Glisse pour tracer une flèche"
+        case .rectangle: return "Glisse pour tracer un rectangle"
+        }
     }
 
     // MARK: - Canvas
@@ -36,6 +98,20 @@ struct EditorView: View {
                     .position(x: fitted.midX, y: fitted.midY)
                     .shadow(radius: 8, y: 2)
 
+                // Committed markups (display-only; selection happens in the panel).
+                ForEach(shapes) { shape in
+                    markupView(shape, in: fitted, selected: shape.id == selectedShapeID)
+                }
+                .allowsHitTesting(false)
+
+                // Live preview while drawing.
+                if let draft {
+                    markupView(draft, in: fitted, selected: true)
+                        .allowsHitTesting(false)
+                        .opacity(0.9)
+                }
+
+                // Numbered pins.
                 ForEach($pins) { $pin in
                     PinMarker(number: pin.number, selected: pin.id == selectedPinID)
                         .position(
@@ -45,29 +121,59 @@ struct EditorView: View {
                         .gesture(
                             DragGesture(minimumDistance: 0)
                                 .onChanged { value in
-                                    selectedPinID = pin.id
-                                    let nx = (value.location.x - fitted.minX) / fitted.width
-                                    let ny = (value.location.y - fitted.minY) / fitted.height
-                                    pin.position = CGPoint(
-                                        x: min(max(nx, 0), 1),
-                                        y: min(max(ny, 0), 1)
-                                    )
+                                    selectPin(pin.id)
+                                    pin.position = clamp01(normalize(value.location, in: fitted))
                                 }
                         )
+                        .allowsHitTesting(tool == .pin)
                 }
             }
             .contentShape(Rectangle())
-            .gesture(
-                SpatialTapGesture()
-                    .onEnded { value in
-                        let nx = (value.location.x - fitted.minX) / fitted.width
-                        let ny = (value.location.y - fitted.minY) / fitted.height
-                        guard (0...1).contains(nx), (0...1).contains(ny) else { return }
-                        let pin = Pin(number: pins.count + 1, position: CGPoint(x: nx, y: ny))
-                        pins.append(pin)
-                        selectedPinID = pin.id
-                    }
+            .gesture(canvasGesture(in: fitted))
+        }
+    }
+
+    /// One drag gesture for the whole canvas, branching on the active tool. A
+    /// zero-distance drag also captures plain clicks (used to drop pins).
+    private func canvasGesture(in fitted: CGRect) -> some Gesture {
+        DragGesture(minimumDistance: 0)
+            .onChanged { value in
+                switch tool {
+                case .pin:
+                    break
+                case .arrow, .rectangle:
+                    let kind: Markup.Kind = tool == .arrow ? .arrow : .rectangle
+                    updateDraft(kind: kind, value: value, in: fitted)
+                }
+            }
+            .onEnded { value in
+                switch tool {
+                case .pin:
+                    addPin(at: value.location, in: fitted)
+                case .arrow, .rectangle:
+                    commitDraft(value: value, in: fitted)
+                }
+            }
+    }
+
+    @ViewBuilder
+    private func markupView(_ shape: Markup, in fitted: CGRect, selected: Bool) -> some View {
+        let width: CGFloat = selected ? 5 : 3.5
+        switch shape.kind {
+        case .rectangle:
+            let r = absoluteRect(shape.rect, in: fitted)
+            RoundedRectangle(cornerRadius: 4)
+                .stroke(Color.accentColor, lineWidth: width)
+                .shadow(color: .black.opacity(0.25), radius: 1, y: 0.5)
+                .frame(width: r.width, height: r.height)
+                .position(x: r.midX, y: r.midY)
+        case .arrow:
+            ArrowShape(
+                start: absolutePoint(shape.start, in: fitted),
+                end: absolutePoint(shape.end, in: fitted)
             )
+            .stroke(Color.accentColor, style: StrokeStyle(lineWidth: width, lineCap: .round, lineJoin: .round))
+            .shadow(color: .black.opacity(0.25), radius: 1, y: 0.5)
         }
     }
 
@@ -75,20 +181,10 @@ struct EditorView: View {
 
     private var sidePanel: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("Repères")
-                .font(.headline)
-
-            if pins.isEmpty {
-                Text("Clique sur l’image pour poser un repère numéroté.")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-            } else {
-                ScrollView {
-                    VStack(spacing: 8) {
-                        ForEach($pins) { $pin in
-                            pinRow($pin)
-                        }
-                    }
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    pinsSection
+                    if !shapes.isEmpty { shapesSection }
                 }
             }
 
@@ -101,8 +197,6 @@ struct EditorView: View {
                 .frame(minHeight: 70, maxHeight: 120)
                 .overlay(RoundedRectangle(cornerRadius: 6).stroke(.quaternary))
 
-            Spacer(minLength: 0)
-
             Button(action: copy) {
                 Label(didCopy ? "Copié !" : "Copier pour l’agent",
                       systemImage: didCopy ? "checkmark.circle.fill" : "doc.on.clipboard")
@@ -113,6 +207,34 @@ struct EditorView: View {
             .keyboardShortcut("c", modifiers: [.command])
         }
         .padding(14)
+    }
+
+    private var pinsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Repères")
+                .font(.headline)
+
+            if pins.isEmpty {
+                Text("Clique sur l’image pour poser un repère numéroté.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach($pins) { $pin in
+                    pinRow($pin)
+                }
+            }
+        }
+    }
+
+    private var shapesSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Annotations")
+                .font(.headline)
+
+            ForEach(shapes) { shape in
+                shapeRow(shape)
+            }
+        }
     }
 
     private func pinRow(_ pin: Binding<Pin>) -> some View {
@@ -127,7 +249,7 @@ struct EditorView: View {
                 .textFieldStyle(.roundedBorder)
 
             Button {
-                remove(pin.wrappedValue)
+                removePin(pin.wrappedValue)
             } label: {
                 Image(systemName: "trash")
             }
@@ -139,19 +261,91 @@ struct EditorView: View {
             RoundedRectangle(cornerRadius: 8)
                 .fill(pin.wrappedValue.id == selectedPinID ? Color.accentColor.opacity(0.12) : Color.clear)
         )
-        .onTapGesture { selectedPinID = pin.wrappedValue.id }
+        .onTapGesture { selectPin(pin.wrappedValue.id) }
+    }
+
+    private func shapeRow(_ shape: Markup) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: shape.symbol)
+                .foregroundStyle(Color.accentColor)
+                .frame(width: 22, height: 22)
+
+            Text(shape.label)
+
+            Spacer()
+
+            Button {
+                removeShape(shape)
+            } label: {
+                Image(systemName: "trash")
+            }
+            .buttonStyle(.borderless)
+            .foregroundStyle(.secondary)
+        }
+        .padding(6)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(shape.id == selectedShapeID ? Color.accentColor.opacity(0.12) : Color.clear)
+        )
+        .onTapGesture { selectShape(shape.id) }
     }
 
     // MARK: - Actions
 
-    private func remove(_ pin: Pin) {
+    private func addPin(at location: CGPoint, in fitted: CGRect) {
+        let p = normalize(location, in: fitted)
+        guard (0...1).contains(p.x), (0...1).contains(p.y) else { return }
+        let pin = Pin(number: pins.count + 1, position: p)
+        pins.append(pin)
+        selectPin(pin.id)
+    }
+
+    private func updateDraft(kind: Markup.Kind, value: DragGesture.Value, in fitted: CGRect) {
+        let start = clamp01(normalize(value.startLocation, in: fitted))
+        let end = clamp01(normalize(value.location, in: fitted))
+        if draft == nil {
+            selectedPinID = nil
+            selectedShapeID = nil
+            draft = Markup(kind: kind, start: start, end: end)
+        } else {
+            draft?.end = end
+        }
+    }
+
+    private func commitDraft(value: DragGesture.Value, in fitted: CGRect) {
+        defer { draft = nil }
+        guard var shape = draft else { return }
+        shape.end = clamp01(normalize(value.location, in: fitted))
+        // Ignore accidental micro-drags.
+        guard hypot(shape.end.x - shape.start.x, shape.end.y - shape.start.y) > 0.01 else { return }
+        shapes.append(shape)
+        selectShape(shape.id)
+    }
+
+    private func selectPin(_ id: Pin.ID) {
+        selectedPinID = id
+        selectedShapeID = nil
+    }
+
+    private func selectShape(_ id: Markup.ID) {
+        selectedShapeID = id
+        selectedPinID = nil
+    }
+
+    private func removePin(_ pin: Pin) {
         pins.removeAll { $0.id == pin.id }
         // Renumber so the list stays 1..n.
         for index in pins.indices { pins[index].number = index + 1 }
+        if selectedPinID == pin.id { selectedPinID = nil }
+    }
+
+    private func removeShape(_ shape: Markup) {
+        shapes.removeAll { $0.id == shape.id }
+        if selectedShapeID == shape.id { selectedShapeID = nil }
     }
 
     private func copy() {
-        Exporter.copyToPasteboard(base: image, pins: pins, context: context)
+        Exporter.copyToPasteboard(base: image, pins: pins, shapes: shapes, context: context)
         withAnimation { didCopy = true }
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) {
             withAnimation { didCopy = false }
@@ -159,6 +353,31 @@ struct EditorView: View {
     }
 
     // MARK: - Geometry
+
+    private func normalize(_ point: CGPoint, in fitted: CGRect) -> CGPoint {
+        guard fitted.width > 0, fitted.height > 0 else { return .zero }
+        return CGPoint(
+            x: (point.x - fitted.minX) / fitted.width,
+            y: (point.y - fitted.minY) / fitted.height
+        )
+    }
+
+    private func clamp01(_ p: CGPoint) -> CGPoint {
+        CGPoint(x: min(max(p.x, 0), 1), y: min(max(p.y, 0), 1))
+    }
+
+    private func absolutePoint(_ p: CGPoint, in fitted: CGRect) -> CGPoint {
+        CGPoint(x: fitted.minX + p.x * fitted.width, y: fitted.minY + p.y * fitted.height)
+    }
+
+    private func absoluteRect(_ r: CGRect, in fitted: CGRect) -> CGRect {
+        CGRect(
+            x: fitted.minX + r.minX * fitted.width,
+            y: fitted.minY + r.minY * fitted.height,
+            width: r.width * fitted.width,
+            height: r.height * fitted.height
+        )
+    }
 
     private func fittedRect(imageSize: CGSize, in container: CGSize) -> CGRect {
         let inset: CGFloat = 16
@@ -171,6 +390,36 @@ struct EditorView: View {
             y: (container.height - size.height) / 2
         )
         return CGRect(origin: origin, size: size)
+    }
+}
+
+/// Straight line from `start` to `end` with an arrowhead at `end`. Uses
+/// absolute coordinates (it ignores the layout rect), so it must fill the same
+/// space as the canvas.
+struct ArrowShape: Shape {
+    var start: CGPoint
+    var end: CGPoint
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.move(to: start)
+        path.addLine(to: end)
+
+        let angle = atan2(end.y - start.y, end.x - start.x)
+        let headLength: CGFloat = 16
+        let spread = CGFloat.pi / 6.5
+
+        path.move(to: end)
+        path.addLine(to: CGPoint(
+            x: end.x - headLength * cos(angle - spread),
+            y: end.y - headLength * sin(angle - spread)
+        ))
+        path.move(to: end)
+        path.addLine(to: CGPoint(
+            x: end.x - headLength * cos(angle + spread),
+            y: end.y - headLength * sin(angle + spread)
+        ))
+        return path
     }
 }
 

--- a/Pinpoint/EditorView.swift
+++ b/Pinpoint/EditorView.swift
@@ -27,6 +27,8 @@ struct EditorView: View {
     let image: NSImage
     var onClose: () -> Void
 
+    @AppStorage(PinStyle.storageKey) private var pinStyle: PinStyle = .disc
+
     @State private var pins: [Pin] = []
     @State private var shapes: [Markup] = []
     @State private var context: String = ""
@@ -34,6 +36,7 @@ struct EditorView: View {
     @State private var selectedPinID: Pin.ID?
     @State private var selectedShapeID: Markup.ID?
     @State private var draft: Markup?
+    @State private var dragStartPosition: CGPoint?
     @State private var didCopy = false
 
     var body: some View {
@@ -113,24 +116,32 @@ struct EditorView: View {
 
                 // Numbered pins.
                 ForEach($pins) { $pin in
-                    PinMarker(number: pin.number, selected: pin.id == selectedPinID)
-                        .position(
-                            x: fitted.minX + pin.position.x * fitted.width,
-                            y: fitted.minY + pin.position.y * fitted.height
-                        )
-                        .gesture(
-                            DragGesture(minimumDistance: 0)
-                                .onChanged { value in
-                                    selectPin(pin.id)
-                                    pin.position = clamp01(normalize(value.location, in: fitted))
-                                }
-                        )
+                    let anchor = absolutePoint(pin.position, in: fitted)
+                    PinMarker(number: pin.number, style: pinStyle, selected: pin.id == selectedPinID)
+                        .position(x: anchor.x, y: anchor.y + PinMarker.anchorYOffset(pinStyle))
+                        .gesture(pinDrag($pin, in: fitted))
                         .allowsHitTesting(tool == .pin)
                 }
             }
             .contentShape(Rectangle())
             .gesture(canvasGesture(in: fitted))
         }
+    }
+
+    /// Drag-to-move a pin. Translation-based so grabbing anywhere on the marker
+    /// (e.g. the head of a pointer whose anchor is the tip) never makes it jump.
+    private func pinDrag(_ pin: Binding<Pin>, in fitted: CGRect) -> some Gesture {
+        DragGesture(minimumDistance: 0)
+            .onChanged { value in
+                selectPin(pin.wrappedValue.id)
+                let base = dragStartPosition ?? pin.wrappedValue.position
+                if dragStartPosition == nil { dragStartPosition = base }
+                pin.wrappedValue.position = clamp01(CGPoint(
+                    x: base.x + value.translation.width / fitted.width,
+                    y: base.y + value.translation.height / fitted.height
+                ))
+            }
+            .onEnded { _ in dragStartPosition = nil }
     }
 
     /// One drag gesture for the whole canvas, branching on the active tool. A
@@ -163,7 +174,7 @@ struct EditorView: View {
         case .rectangle:
             let r = absoluteRect(shape.rect, in: fitted)
             RoundedRectangle(cornerRadius: 4)
-                .stroke(Color.accentColor, lineWidth: width)
+                .stroke(Color.pinpointVermillon, lineWidth: width)
                 .shadow(color: .black.opacity(0.25), radius: 1, y: 0.5)
                 .frame(width: r.width, height: r.height)
                 .position(x: r.midX, y: r.midY)
@@ -172,7 +183,7 @@ struct EditorView: View {
                 start: absolutePoint(shape.start, in: fitted),
                 end: absolutePoint(shape.end, in: fitted)
             )
-            .stroke(Color.accentColor, style: StrokeStyle(lineWidth: width, lineCap: .round, lineJoin: .round))
+            .stroke(Color.pinpointVermillon, style: StrokeStyle(lineWidth: width, lineCap: .round, lineJoin: .round))
             .shadow(color: .black.opacity(0.25), radius: 1, y: 0.5)
         }
     }
@@ -204,6 +215,7 @@ struct EditorView: View {
             }
             .controlSize(.large)
             .buttonStyle(.borderedProminent)
+            .tint(.pinpointVermillon)
             .keyboardShortcut("c", modifiers: [.command])
         }
         .padding(14)
@@ -243,7 +255,7 @@ struct EditorView: View {
                 .font(.caption.bold())
                 .foregroundStyle(.white)
                 .frame(width: 22, height: 22)
-                .background(Circle().fill(Color.accentColor))
+                .background(Circle().fill(Color.pinpointVermillon))
 
             TextField("Décris ce repère…", text: pin.note)
                 .textFieldStyle(.roundedBorder)
@@ -259,7 +271,7 @@ struct EditorView: View {
         .padding(6)
         .background(
             RoundedRectangle(cornerRadius: 8)
-                .fill(pin.wrappedValue.id == selectedPinID ? Color.accentColor.opacity(0.12) : Color.clear)
+                .fill(pin.wrappedValue.id == selectedPinID ? Color.pinpointVermillon.opacity(0.12) : Color.clear)
         )
         .onTapGesture { selectPin(pin.wrappedValue.id) }
     }
@@ -267,7 +279,7 @@ struct EditorView: View {
     private func shapeRow(_ shape: Markup) -> some View {
         HStack(spacing: 8) {
             Image(systemName: shape.symbol)
-                .foregroundStyle(Color.accentColor)
+                .foregroundStyle(Color.pinpointVermillon)
                 .frame(width: 22, height: 22)
 
             Text(shape.label)
@@ -285,7 +297,7 @@ struct EditorView: View {
         .padding(6)
         .background(
             RoundedRectangle(cornerRadius: 8)
-                .fill(shape.id == selectedShapeID ? Color.accentColor.opacity(0.12) : Color.clear)
+                .fill(shape.id == selectedShapeID ? Color.pinpointVermillon.opacity(0.12) : Color.clear)
         )
         .onTapGesture { selectShape(shape.id) }
     }
@@ -345,7 +357,7 @@ struct EditorView: View {
     }
 
     private func copy() {
-        Exporter.copyToPasteboard(base: image, pins: pins, shapes: shapes, context: context)
+        Exporter.copyToPasteboard(base: image, pins: pins, shapes: shapes, context: context, style: pinStyle)
         withAnimation { didCopy = true }
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) {
             withAnimation { didCopy = false }
@@ -409,31 +421,95 @@ struct ArrowShape: Shape {
         let headLength: CGFloat = 16
         let spread = CGFloat.pi / 6.5
 
+        let leftAngle = angle - spread
+        let rightAngle = angle + spread
         path.move(to: end)
-        path.addLine(to: CGPoint(
-            x: end.x - headLength * cos(angle - spread),
-            y: end.y - headLength * sin(angle - spread)
-        ))
+        path.addLine(to: CGPoint(x: end.x - headLength * cos(leftAngle), y: end.y - headLength * sin(leftAngle)))
         path.move(to: end)
-        path.addLine(to: CGPoint(
-            x: end.x - headLength * cos(angle + spread),
-            y: end.y - headLength * sin(angle + spread)
-        ))
+        path.addLine(to: CGPoint(x: end.x - headLength * cos(rightAngle), y: end.y - headLength * sin(rightAngle)))
         return path
     }
 }
 
+/// Map-pin silhouette filling its rect: a circular head at the top tapering to
+/// a tip at the bottom-centre. Used for the `.pointer` marker style.
+struct PinShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        let diameter = rect.width
+        let radius = diameter / 2
+        let headCenter = CGPoint(x: rect.midX, y: rect.minY + radius)
+        let tip = CGPoint(x: rect.midX, y: rect.maxY)
+
+        var path = Path()
+        path.addEllipse(in: CGRect(x: rect.minX, y: rect.minY, width: diameter, height: diameter))
+        let baseY = headCenter.y + radius * 0.55
+        let halfWidth = radius * 0.7
+        path.move(to: CGPoint(x: headCenter.x - halfWidth, y: baseY))
+        path.addLine(to: tip)
+        path.addLine(to: CGPoint(x: headCenter.x + halfWidth, y: baseY))
+        path.closeSubpath()
+        return path
+    }
+}
+
+/// The numbered marker, rendered in one of the three design-system styles.
 struct PinMarker: View {
     let number: Int
+    var style: PinStyle = .disc
     var selected: Bool = false
 
+    static let headDiameter: CGFloat = 28
+    static let pointerHeight: CGFloat = 42
+
+    /// Vertical offset to apply when positioning the marker so its anchor lands
+    /// on the marked point: centred for disc/outline, tip-anchored for pointer.
+    static func anchorYOffset(_ style: PinStyle) -> CGFloat {
+        style == .pointer ? -(pointerHeight / 2) : 0
+    }
+
     var body: some View {
-        Text("\(number)")
-            .font(.system(size: 14, weight: .bold))
+        switch style {
+        case .disc: disc
+        case .outline: outline
+        case .pointer: pointer
+        }
+    }
+
+    private var numberText: some View {
+        Text("\(number)").font(.system(size: 14, weight: .bold))
+    }
+
+    private var disc: some View {
+        numberText
             .foregroundStyle(.white)
-            .frame(width: 28, height: 28)
-            .background(Circle().fill(Color.accentColor))
-            .overlay(Circle().stroke(.white, lineWidth: selected ? 3 : 2))
-            .shadow(radius: 2, y: 1)
+            .frame(width: Self.headDiameter, height: Self.headDiameter)
+            .background(Circle().fill(Color.pinpointVermillon))
+            .overlay(Circle().stroke(.white, lineWidth: selected ? 3.5 : 2.5))
+            .overlay(Circle().stroke(.black.opacity(0.18), lineWidth: 0.5))
+            .shadow(color: .black.opacity(0.35), radius: 2, y: 1)
+    }
+
+    private var outline: some View {
+        numberText
+            .foregroundStyle(Color.pinpointVermillon)
+            .frame(width: Self.headDiameter, height: Self.headDiameter)
+            .overlay(Circle().stroke(.white, lineWidth: selected ? 5 : 4))
+            .overlay(Circle().stroke(Color.pinpointVermillon, lineWidth: selected ? 3 : 2))
+            .shadow(color: .black.opacity(0.25), radius: 1.5, y: 0.5)
+    }
+
+    private var pointer: some View {
+        ZStack(alignment: .top) {
+            PinShape()
+                .fill(Color.pinpointVermillon)
+                .shadow(color: .black.opacity(0.35), radius: 2, y: 1)
+            Circle()
+                .stroke(.white, lineWidth: selected ? 3 : 2)
+                .frame(width: Self.headDiameter, height: Self.headDiameter)
+            numberText
+                .foregroundStyle(.white)
+                .frame(width: Self.headDiameter, height: Self.headDiameter)
+        }
+        .frame(width: Self.headDiameter, height: Self.pointerHeight)
     }
 }

--- a/Pinpoint/Exporter.swift
+++ b/Pinpoint/Exporter.swift
@@ -4,7 +4,7 @@ enum Exporter {
     /// Renders the base capture with markups (arrows/rectangles) and numbered
     /// pins drawn on top, at full image resolution. Markups are drawn first so
     /// numbered pins stay legible above them.
-    static func annotatedImage(base: NSImage, pins: [Pin], shapes: [Markup]) -> NSImage {
+    static func annotatedImage(base: NSImage, pins: [Pin], shapes: [Markup], style: PinStyle) -> NSImage {
         let size = base.size
         let result = NSImage(size: size)
         result.lockFocus()
@@ -19,12 +19,13 @@ enum Exporter {
 
         let radius = max(16, size.width * 0.014)
         for pin in pins {
-            // Pin position is top-left origin; NSImage drawing is bottom-left.
-            let center = CGPoint(
+            // Pin position is the marked point (top-left origin); NSImage
+            // drawing is bottom-left, so flip y.
+            let anchor = CGPoint(
                 x: pin.position.x * size.width,
                 y: (1 - pin.position.y) * size.height
             )
-            drawMarker(number: pin.number, at: center, radius: radius)
+            drawMarker(number: pin.number, anchor: anchor, radius: radius, style: style)
         }
 
         result.unlockFocus()
@@ -32,7 +33,7 @@ enum Exporter {
     }
 
     private static func drawMarkup(_ shape: Markup, in size: CGSize, lineWidth: CGFloat) {
-        NSColor.controlAccentColor.setStroke()
+        NSColor.pinpointVermillon.setStroke()
 
         // Normalized (top-left origin) → image space (bottom-left origin).
         func px(_ p: CGPoint) -> CGPoint {
@@ -80,24 +81,67 @@ enum Exporter {
         }
     }
 
-    private static func drawMarker(number: Int, at center: CGPoint, radius: CGFloat) {
-        let rect = NSRect(x: center.x - radius, y: center.y - radius,
-                          width: radius * 2, height: radius * 2)
+    /// Draws a numbered marker at `anchor` (image space) in the chosen style.
+    /// `anchor` is the marker centre for disc/outline and the tip for pointer —
+    /// matching the on-screen `PinMarker` so the export looks identical.
+    private static func drawMarker(number: Int, anchor: CGPoint, radius: CGFloat, style: PinStyle) {
+        let vermillon = NSColor.pinpointVermillon
+        let ringWidth = max(2, radius * 0.16)
 
-        let accent = NSColor.controlAccentColor
-        accent.setFill()
-        let circle = NSBezierPath(ovalIn: rect)
-        circle.fill()
+        switch style {
+        case .disc:
+            let rect = NSRect(x: anchor.x - radius, y: anchor.y - radius, width: radius * 2, height: radius * 2)
+            vermillon.setFill()
+            let circle = NSBezierPath(ovalIn: rect)
+            circle.fill()
+            NSColor.white.setStroke()
+            circle.lineWidth = ringWidth
+            circle.stroke()
+            drawNumber(number, center: anchor, radius: radius, color: .white)
 
-        NSColor.white.setStroke()
-        circle.lineWidth = max(2, radius * 0.14)
-        circle.stroke()
+        case .outline:
+            let rect = NSRect(x: anchor.x - radius, y: anchor.y - radius, width: radius * 2, height: radius * 2)
+            let collar = NSBezierPath(ovalIn: rect)
+            NSColor.white.setStroke()
+            collar.lineWidth = ringWidth * 1.7
+            collar.stroke()
+            let ring = NSBezierPath(ovalIn: rect)
+            vermillon.setStroke()
+            ring.lineWidth = ringWidth
+            ring.stroke()
+            drawNumber(number, center: anchor, radius: radius, color: vermillon)
 
+        case .pointer:
+            // Tip at the anchor; head above it (image space y grows upward).
+            let headCenter = CGPoint(x: anchor.x, y: anchor.y + radius * 2.0)
+            let baseY = headCenter.y - radius * 0.55
+            let halfWidth = radius * 0.7
+
+            let stem = NSBezierPath()
+            stem.move(to: CGPoint(x: headCenter.x - halfWidth, y: baseY))
+            stem.line(to: anchor)
+            stem.line(to: CGPoint(x: headCenter.x + halfWidth, y: baseY))
+            stem.close()
+            vermillon.setFill()
+            stem.fill()
+
+            let headRect = NSRect(x: headCenter.x - radius, y: headCenter.y - radius, width: radius * 2, height: radius * 2)
+            let head = NSBezierPath(ovalIn: headRect)
+            vermillon.setFill()
+            head.fill()
+            NSColor.white.setStroke()
+            head.lineWidth = ringWidth
+            head.stroke()
+            drawNumber(number, center: headCenter, radius: radius, color: .white)
+        }
+    }
+
+    private static func drawNumber(_ number: Int, center: CGPoint, radius: CGFloat, color: NSColor) {
         let label = "\(number)" as NSString
         let font = NSFont.systemFont(ofSize: radius * 1.05, weight: .bold)
         let attrs: [NSAttributedString.Key: Any] = [
             .font: font,
-            .foregroundColor: NSColor.white
+            .foregroundColor: color
         ]
         let textSize = label.size(withAttributes: attrs)
         let textRect = NSRect(
@@ -148,8 +192,8 @@ enum Exporter {
     }
 
     /// Puts the annotated PNG and the instruction text on the general pasteboard.
-    static func copyToPasteboard(base: NSImage, pins: [Pin], shapes: [Markup], context: String) {
-        let annotated = annotatedImage(base: base, pins: pins, shapes: shapes)
+    static func copyToPasteboard(base: NSImage, pins: [Pin], shapes: [Markup], context: String, style: PinStyle) {
+        let annotated = annotatedImage(base: base, pins: pins, shapes: shapes, style: style)
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
 

--- a/Pinpoint/Exporter.swift
+++ b/Pinpoint/Exporter.swift
@@ -1,15 +1,21 @@
 import AppKit
 
 enum Exporter {
-    /// Renders the base capture with numbered markers drawn on top, at full
-    /// image resolution.
-    static func annotatedImage(base: NSImage, pins: [Pin]) -> NSImage {
+    /// Renders the base capture with markups (arrows/rectangles) and numbered
+    /// pins drawn on top, at full image resolution. Markups are drawn first so
+    /// numbered pins stay legible above them.
+    static func annotatedImage(base: NSImage, pins: [Pin], shapes: [Markup]) -> NSImage {
         let size = base.size
         let result = NSImage(size: size)
         result.lockFocus()
 
         base.draw(in: NSRect(origin: .zero, size: size),
                   from: .zero, operation: .copy, fraction: 1.0)
+
+        let lineWidth = max(3, size.width * 0.004)
+        for shape in shapes {
+            drawMarkup(shape, in: size, lineWidth: lineWidth)
+        }
 
         let radius = max(16, size.width * 0.014)
         for pin in pins {
@@ -23,6 +29,55 @@ enum Exporter {
 
         result.unlockFocus()
         return result
+    }
+
+    private static func drawMarkup(_ shape: Markup, in size: CGSize, lineWidth: CGFloat) {
+        NSColor.controlAccentColor.setStroke()
+
+        // Normalized (top-left origin) → image space (bottom-left origin).
+        func px(_ p: CGPoint) -> CGPoint {
+            CGPoint(x: p.x * size.width, y: (1 - p.y) * size.height)
+        }
+
+        switch shape.kind {
+        case .rectangle:
+            let r = shape.rect
+            let rect = NSRect(
+                x: r.minX * size.width,
+                y: (1 - r.maxY) * size.height,
+                width: r.width * size.width,
+                height: r.height * size.height
+            )
+            let path = NSBezierPath(roundedRect: rect, xRadius: lineWidth, yRadius: lineWidth)
+            path.lineWidth = lineWidth
+            path.stroke()
+
+        case .arrow:
+            let start = px(shape.start)
+            let end = px(shape.end)
+            let path = NSBezierPath()
+            path.lineWidth = lineWidth
+            path.lineCapStyle = .round
+            path.lineJoinStyle = .round
+            path.move(to: start)
+            path.line(to: end)
+
+            let angle = atan2(end.y - start.y, end.x - start.x)
+            let headLength = max(14, size.width * 0.018)
+            let spread = CGFloat.pi / 6.5
+
+            let leftAngle = angle - spread
+            let rightAngle = angle + spread
+            let left = CGPoint(x: end.x - headLength * cos(leftAngle),
+                               y: end.y - headLength * sin(leftAngle))
+            let right = CGPoint(x: end.x - headLength * cos(rightAngle),
+                                y: end.y - headLength * sin(rightAngle))
+            path.move(to: end)
+            path.line(to: left)
+            path.move(to: end)
+            path.line(to: right)
+            path.stroke()
+        }
     }
 
     private static func drawMarker(number: Int, at center: CGPoint, radius: CGFloat) {
@@ -93,8 +148,8 @@ enum Exporter {
     }
 
     /// Puts the annotated PNG and the instruction text on the general pasteboard.
-    static func copyToPasteboard(base: NSImage, pins: [Pin], context: String) {
-        let annotated = annotatedImage(base: base, pins: pins)
+    static func copyToPasteboard(base: NSImage, pins: [Pin], shapes: [Markup], context: String) {
+        let annotated = annotatedImage(base: base, pins: pins, shapes: shapes)
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
 

--- a/Pinpoint/Markup.swift
+++ b/Pinpoint/Markup.swift
@@ -1,0 +1,46 @@
+import CoreGraphics
+import Foundation
+
+/// A non-numbered visual annotation (arrow or rectangle) drawn on the capture.
+///
+/// Unlike `Pin`, markups are not numbered and are not referenced in the
+/// agent-ready text — they're purely visual emphasis. Coordinates are
+/// normalized (0...1) in image space, top-left origin (same convention as
+/// `Pin`), so they scale with the canvas and export correctly.
+struct Markup: Identifiable, Equatable {
+    enum Kind: Equatable {
+        case arrow
+        case rectangle
+    }
+
+    let id = UUID()
+    var kind: Kind
+    /// Arrow: tail. Rectangle: one corner.
+    var start: CGPoint
+    /// Arrow: tip (where the arrowhead is). Rectangle: opposite corner.
+    var end: CGPoint
+
+    /// Order-independent normalized rect (for rectangle markups).
+    var rect: CGRect {
+        CGRect(
+            x: min(start.x, end.x),
+            y: min(start.y, end.y),
+            width: abs(end.x - start.x),
+            height: abs(end.y - start.y)
+        )
+    }
+
+    var label: String {
+        switch kind {
+        case .arrow: return "Flèche"
+        case .rectangle: return "Rectangle"
+        }
+    }
+
+    var symbol: String {
+        switch kind {
+        case .arrow: return "arrow.up.right"
+        case .rectangle: return "rectangle"
+        }
+    }
+}

--- a/Pinpoint/PinStyle.swift
+++ b/Pinpoint/PinStyle.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Visual style of the numbered markers (design system §03). Persisted in
+/// UserDefaults via `@AppStorage(PinStyle.storageKey)` so the editor and the
+/// Settings window stay in sync.
+enum PinStyle: String, CaseIterable, Identifiable {
+    /// Filled vermillon disc + white ring (the default).
+    case disc
+    /// Map-pin whose tip designates the exact pixel.
+    case pointer
+    /// Hollow ring that doesn't obscure the element underneath.
+    case outline
+
+    var id: String { rawValue }
+
+    static let storageKey = "pinStyle"
+
+    var label: String {
+        switch self {
+        case .disc: return "Disque plein"
+        case .pointer: return "Pin pointeur"
+        case .outline: return "Contour léger"
+        }
+    }
+
+    var caption: String {
+        switch self {
+        case .disc: return "Anneau blanc + ombre portée."
+        case .pointer: return "La pointe désigne le pixel exact."
+        case .outline: return "N’obscurcit pas l’élément visé."
+        }
+    }
+}

--- a/Pinpoint/PinpointApp.swift
+++ b/Pinpoint/PinpointApp.swift
@@ -20,10 +20,22 @@ struct PinpointApp: App {
 }
 
 struct SettingsView: View {
+    @AppStorage(PinStyle.storageKey) private var pinStyle: PinStyle = .disc
+
     var body: some View {
         Form {
             Section("Raccourci de capture") {
                 KeyboardShortcuts.Recorder("Capturer l’écran :", name: .capture)
+            }
+            Section("Style des repères") {
+                Picker("Style :", selection: $pinStyle) {
+                    ForEach(PinStyle.allCases) { style in
+                        Text(style.label).tag(style)
+                    }
+                }
+                Text(pinStyle.caption)
+                    .foregroundStyle(.secondary)
+                    .font(.callout)
             }
             Section {
                 Text("Pinpoint vit dans la barre de menus. Appuie sur le raccourci, annote, copie.")

--- a/Pinpoint/Theme.swift
+++ b/Pinpoint/Theme.swift
@@ -1,0 +1,18 @@
+import AppKit
+import SwiftUI
+
+/// Pinpoint's accent palette — vermillon, the marker colour. Chosen to stay
+/// legible on any capture rather than blend in like the system blue
+/// (design system §02). One source of truth for both AppKit (export) and
+/// SwiftUI (editor).
+extension NSColor {
+    static let pinpointVermillon = NSColor(srgbRed: 255.0 / 255, green: 77.0 / 255, blue: 46.0 / 255, alpha: 1)
+    static let pinpointVermillonLight = NSColor(srgbRed: 255.0 / 255, green: 106.0 / 255, blue: 69.0 / 255, alpha: 1)
+    static let pinpointVermillonDark = NSColor(srgbRed: 232.0 / 255, green: 53.0 / 255, blue: 15.0 / 255, alpha: 1)
+}
+
+extension Color {
+    static let pinpointVermillon = Color(nsColor: .pinpointVermillon)
+    static let pinpointVermillonLight = Color(nsColor: .pinpointVermillonLight)
+    static let pinpointVermillonDark = Color(nsColor: .pinpointVermillonDark)
+}

--- a/README.md
+++ b/README.md
@@ -12,11 +12,15 @@ App macOS native, Swift / SwiftUI + ScreenCaptureKit. Vit dans la barre de menus
   s’assombrit, trace un rectangle (dimensions affichées en live), `Échap` annule.
   Capture de la seule région choisie, à la résolution native (Retina, multi-écran).
 - Fallback **« Capturer tout l’écran »** (⌘⇧3) dans le menu de la barre de menus.
-- Éditeur : clic pour poser un repère, glisser pour le déplacer, note par repère
-- Champ « instructions pour l’agent »
+- Éditeur : barre d’outils **Repère / Flèche / Rectangle**. Clic pour poser un
+  repère numéroté (glisser pour le déplacer, note par repère) ; glisser pour tracer
+  une flèche ou un rectangle. Les flèches/rectangles sont visuels ; seuls les repères
+  numérotés sont référencés dans le texte agent.
+- Champ « instructions pour l’agent » + texte Markdown structuré (dimensions,
+  position de chaque repère en %)
 - **⌘C** / bouton → copie l’image annotée (PNG) **et** le texte dans le presse-papier
 
-Pas encore : flèches/rectangles d’annotation, réglage du style des repères,
+Pas encore : réglage du style des repères (vermillon + variantes),
 historique des captures. Voir `PROMPTS.md`.
 
 ## Build
@@ -62,7 +66,8 @@ Pinpoint/
     RegionSelectionView.swift  # dessin de l’assombrissement + rectangle + dimensions
     CaptureRegion.swift        # modèle : display cible + rect (points, top-left) + scale
     ScreenCapture.swift        # ScreenCaptureKit : capture région (sourceRect) ou plein écran
-    Pin.swift                  # modèle d’un repère
+    Pin.swift                  # modèle d’un repère numéroté
+    Markup.swift               # modèle d’une annotation flèche / rectangle
     EditorWindowController.swift  # fenêtre AppKit qui héberge l’éditeur SwiftUI
     EditorView.swift           # canvas d’annotation + panneau latéral
     Exporter.swift             # rendu PNG annoté + texte + copie presse-papier

--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ App macOS native, Swift / SwiftUI + ScreenCaptureKit. Vit dans la barre de menus
   numérotés sont référencés dans le texte agent.
 - Champ « instructions pour l’agent » + texte Markdown structuré (dimensions,
   position de chaque repère en %)
+- Accent **vermillon** `#FF4D2E` + **3 styles de repères** réglables (disque plein,
+  pin pointeur, contour léger) appliqués à l’écran **et** à l’export
 - **⌘C** / bouton → copie l’image annotée (PNG) **et** le texte dans le presse-papier
 
-Pas encore : réglage du style des repères (vermillon + variantes),
-historique des captures. Voir `PROMPTS.md`.
+Pas encore : historique des captures. Voir `PROMPTS.md`.
 
 ## Build
 
@@ -68,6 +69,8 @@ Pinpoint/
     ScreenCapture.swift        # ScreenCaptureKit : capture région (sourceRect) ou plein écran
     Pin.swift                  # modèle d’un repère numéroté
     Markup.swift               # modèle d’une annotation flèche / rectangle
+    PinStyle.swift             # styles de repères (disque / pointeur / contour) + clé @AppStorage
+    Theme.swift                # palette vermillon (NSColor + Color)
     EditorWindowController.swift  # fenêtre AppKit qui héberge l’éditeur SwiftUI
     EditorView.swift           # canvas d’annotation + panneau latéral
     Exporter.swift             # rendu PNG annoté + texte + copie presse-papier


### PR DESCRIPTION
Récapitulatif des itérations depuis le scaffold initial.

## Fonctionnalités
- **Sélection de région** (⌘⇧1) : overlay multi-écran qui assombrit, rectangle live avec dimensions, `Échap` annule. Capture de la seule région via ScreenCaptureKit (`sourceRect`), résolution native (Retina, multi-display). Fallback **plein écran** (⌘⇧3) dans le menu.
- **Annotations flèches & rectangles** : barre d'outils Repère / Flèche / Rectangle, preview live, modèle `Markup` séparé (non numéroté), rendu écran + export, liste « Annotations » dans le panneau.
- **Accent vermillon `#FF4D2E`** + **3 styles de repères** réglables et persistés (disque plein, pin pointeur tip-ancré, contour léger), appliqués à l'écran **et** à l'export.
- **Texte agent** en Markdown structuré (dimensions + position de chaque repère en %).

## Build / signature
- `DEVELOPMENT_TEAM` épinglé dans `project.yml` → signature stable, l'autorisation « Enregistrement de l'écran » (TCC) persiste d'un build à l'autre.
- CI GitHub Actions : `xcodegen generate` + `xcodebuild` (sans signature) sur macOS.

## Vérification
Chaque commit compile (`BUILD SUCCEEDED`). Tests manuels d'exécution faits côté auteur (capture de région confirmée).

🤖 Generated with [Claude Code](https://claude.com/claude-code)