### PR TITLE
Historique des captures

### DIFF
--- a/Pinpoint/AppDelegate.swift
+++ b/Pinpoint/AppDelegate.swift
@@ -2,10 +2,12 @@ import AppKit
 import SwiftUI
 import KeyboardShortcuts
 
-final class AppDelegate: NSObject, NSApplicationDelegate {
+@MainActor
+final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var statusItem: NSStatusItem!
     private var editorController: EditorWindowController?
     private var regionController: RegionSelectionController?
+    private let recentMenu = NSMenu()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         setupStatusItem()
@@ -36,6 +38,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(fullScreenItem)
         menu.addItem(.separator())
 
+        let recentItem = NSMenuItem(title: "Captures récentes", action: nil, keyEquivalent: "")
+        recentMenu.delegate = self
+        recentItem.submenu = recentMenu
+        menu.addItem(recentItem)
+        menu.addItem(.separator())
+
         let settingsItem = NSMenuItem(title: "Réglages…", action: #selector(openSettings), keyEquivalent: ",")
         settingsItem.target = self
         menu.addItem(settingsItem)
@@ -45,13 +53,65 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         statusItem.menu = menu
     }
 
+    // MARK: - Recent captures submenu
+
+    func menuNeedsUpdate(_ menu: NSMenu) {
+        guard menu === recentMenu else { return }
+        rebuildRecentMenu()
+    }
+
+    private func rebuildRecentMenu() {
+        recentMenu.removeAllItems()
+
+        let records = CaptureHistory.shared.records
+        guard !records.isEmpty else {
+            let empty = NSMenuItem(title: "Aucune capture récente", action: nil, keyEquivalent: "")
+            empty.isEnabled = false
+            recentMenu.addItem(empty)
+            return
+        }
+
+        for record in records {
+            let item = NSMenuItem(title: title(for: record), action: #selector(openRecent(_:)), keyEquivalent: "")
+            item.target = self
+            item.representedObject = record.id.uuidString
+            recentMenu.addItem(item)
+        }
+
+        recentMenu.addItem(.separator())
+        let clear = NSMenuItem(title: "Vider l’historique", action: #selector(clearHistory), keyEquivalent: "")
+        clear.target = self
+        recentMenu.addItem(clear)
+    }
+
+    private func title(for record: CaptureRecord) -> String {
+        let when = record.date.formatted(date: .abbreviated, time: .shortened)
+        return "\(when) · \(record.width)×\(record.height)"
+    }
+
+    @objc private func openRecent(_ sender: NSMenuItem) {
+        guard let idString = sender.representedObject as? String,
+              let id = UUID(uuidString: idString),
+              let record = CaptureHistory.shared.records.first(where: { $0.id == id }),
+              let image = CaptureHistory.shared.image(for: record) else { return }
+        presentEditor(image: image, recordID: record.id,
+                      pins: record.pins, shapes: record.shapes, context: record.context)
+    }
+
+    @objc private func clearHistory() {
+        CaptureHistory.shared.clear()
+    }
+
+    // MARK: - Capture actions
+
     @objc private func captureFromMenu() { startCapture() }
 
     @objc private func captureFullScreen() {
         Task { @MainActor in
             do {
                 let image = try await ScreenCapture.captureDisplayUnderCursor()
-                presentEditor(with: image)
+                let record = CaptureHistory.shared.add(image: image)
+                presentEditor(image: image, recordID: record?.id)
             } catch {
                 presentCaptureError(error)
             }
@@ -87,7 +147,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
             do {
                 let image = try await ScreenCapture.captureRegion(region)
-                presentEditor(with: image)
+                let record = CaptureHistory.shared.add(image: image)
+                presentEditor(image: image, recordID: record?.id)
             } catch {
                 presentCaptureError(error)
             }
@@ -95,8 +156,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @MainActor
-    private func presentEditor(with image: NSImage) {
-        let controller = EditorWindowController(image: image)
+    private func presentEditor(image: NSImage, recordID: UUID?,
+                               pins: [Pin] = [], shapes: [Markup] = [], context: String = "") {
+        let controller = EditorWindowController(
+            image: image,
+            initialPins: pins,
+            initialShapes: shapes,
+            initialContext: context,
+            onPersist: { pins, shapes, context in
+                guard let recordID else { return }
+                CaptureHistory.shared.update(id: recordID, pins: pins, shapes: shapes, context: context)
+            }
+        )
         editorController = controller
         controller.onClose = { [weak self] in self?.editorController = nil }
         NSApp.activate(ignoringOtherApps: true)

--- a/Pinpoint/CaptureHistory.swift
+++ b/Pinpoint/CaptureHistory.swift
@@ -1,0 +1,118 @@
+import AppKit
+
+/// Persists recent captures (raw PNG + annotation state) under Application
+/// Support, newest first, capped to `maxEntries`. Backed by a JSON index.
+@MainActor
+final class CaptureHistory {
+    static let shared = CaptureHistory()
+
+    private let maxEntries = 15
+    private let fileManager = FileManager.default
+
+    private(set) var records: [CaptureRecord] = []
+
+    private lazy var directory: URL = {
+        let base = (try? fileManager.url(for: .applicationSupportDirectory, in: .userDomainMask,
+                                         appropriateFor: nil, create: true))
+            ?? fileManager.temporaryDirectory
+        return base.appendingPathComponent("Pinpoint/Captures", isDirectory: true)
+    }()
+
+    private var indexURL: URL { directory.appendingPathComponent("index.json") }
+
+    init() {
+        try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        load()
+    }
+
+    // MARK: - Mutations
+
+    /// Saves the raw image and prepends a new record. Returns it (or nil if the
+    /// PNG couldn't be written).
+    @discardableResult
+    func add(image: NSImage) -> CaptureRecord? {
+        guard let png = pngData(from: image) else { return nil }
+        let id = UUID()
+        let fileName = "\(id.uuidString).png"
+        do {
+            try png.write(to: directory.appendingPathComponent(fileName))
+        } catch {
+            return nil
+        }
+
+        let record = CaptureRecord(
+            id: id,
+            date: Date(),
+            imageFileName: fileName,
+            width: Int(image.size.width.rounded()),
+            height: Int(image.size.height.rounded()),
+            pins: [],
+            shapes: [],
+            context: ""
+        )
+        records.insert(record, at: 0)
+        prune()
+        saveIndex()
+        return record
+    }
+
+    /// Updates the annotation state of an existing record.
+    func update(id: UUID, pins: [Pin], shapes: [Markup], context: String) {
+        guard let index = records.firstIndex(where: { $0.id == id }) else { return }
+        records[index].pins = pins
+        records[index].shapes = shapes
+        records[index].context = context
+        saveIndex()
+    }
+
+    func clear() {
+        for record in records {
+            try? fileManager.removeItem(at: directory.appendingPathComponent(record.imageFileName))
+        }
+        records.removeAll()
+        saveIndex()
+    }
+
+    // MARK: - Reads
+
+    /// Rebuilds the NSImage at its native pixel size (PNG reload alone would use
+    /// the file's DPI, which can differ from the captured pixel dimensions).
+    func image(for record: CaptureRecord) -> NSImage? {
+        let url = directory.appendingPathComponent(record.imageFileName)
+        guard let data = try? Data(contentsOf: url),
+              let rep = NSBitmapImageRep(data: data) else { return nil }
+        let image = NSImage(size: NSSize(width: record.width, height: record.height))
+        image.addRepresentation(rep)
+        return image
+    }
+
+    // MARK: - Persistence
+
+    private func load() {
+        guard let data = try? Data(contentsOf: indexURL),
+              let decoded = try? JSONDecoder().decode([CaptureRecord].self, from: data) else { return }
+        // Keep only records whose image file still exists.
+        records = decoded.filter {
+            fileManager.fileExists(atPath: directory.appendingPathComponent($0.imageFileName).path)
+        }
+    }
+
+    private func saveIndex() {
+        guard let data = try? JSONEncoder().encode(records) else { return }
+        try? data.write(to: indexURL)
+    }
+
+    private func prune() {
+        guard records.count > maxEntries else { return }
+        for record in records[maxEntries...] {
+            try? fileManager.removeItem(at: directory.appendingPathComponent(record.imageFileName))
+        }
+        records.removeLast(records.count - maxEntries)
+    }
+
+    private func pngData(from image: NSImage) -> Data? {
+        guard let tiff = image.tiffRepresentation,
+              let rep = NSBitmapImageRep(data: tiff) else { return nil }
+        return rep.representation(using: .png, properties: [:])
+    }
+}

--- a/Pinpoint/CaptureRecord.swift
+++ b/Pinpoint/CaptureRecord.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// A persisted capture: the raw image (stored as a PNG file alongside) plus the
+/// annotation state, so it can be reopened from "Captures récentes" exactly as
+/// it was left.
+struct CaptureRecord: Codable, Identifiable, Equatable {
+    let id: UUID
+    let date: Date
+    /// PNG file name within the history directory.
+    let imageFileName: String
+    /// Pixel dimensions of the capture (used to rebuild the NSImage at native size).
+    let width: Int
+    let height: Int
+    var pins: [Pin]
+    var shapes: [Markup]
+    var context: String
+}

--- a/Pinpoint/EditorView.swift
+++ b/Pinpoint/EditorView.swift
@@ -26,6 +26,9 @@ enum EditorTool: String, CaseIterable, Identifiable {
 struct EditorView: View {
     let image: NSImage
     var onClose: () -> Void
+    /// Called with the current annotation state so it can be persisted to
+    /// history (on copy and when the editor closes).
+    var onPersist: ([Pin], [Markup], String) -> Void
 
     @AppStorage(PinStyle.storageKey) private var pinStyle: PinStyle = .disc
 
@@ -38,6 +41,22 @@ struct EditorView: View {
     @State private var draft: Markup?
     @State private var dragStartPosition: CGPoint?
     @State private var didCopy = false
+
+    init(
+        image: NSImage,
+        initialPins: [Pin] = [],
+        initialShapes: [Markup] = [],
+        initialContext: String = "",
+        onPersist: @escaping ([Pin], [Markup], String) -> Void = { _, _, _ in },
+        onClose: @escaping () -> Void
+    ) {
+        self.image = image
+        self.onPersist = onPersist
+        self.onClose = onClose
+        _pins = State(initialValue: initialPins)
+        _shapes = State(initialValue: initialShapes)
+        _context = State(initialValue: initialContext)
+    }
 
     var body: some View {
         HSplitView {
@@ -53,6 +72,7 @@ struct EditorView: View {
                 .frame(minWidth: 260, idealWidth: 280, maxWidth: 360)
         }
         .frame(minWidth: 680, minHeight: 440)
+        .onDisappear { onPersist(pins, shapes, context) }
     }
 
     // MARK: - Toolbar
@@ -358,6 +378,7 @@ struct EditorView: View {
 
     private func copy() {
         Exporter.copyToPasteboard(base: image, pins: pins, shapes: shapes, context: context, style: pinStyle)
+        onPersist(pins, shapes, context)
         withAnimation { didCopy = true }
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) {
             withAnimation { didCopy = false }

--- a/Pinpoint/EditorWindowController.swift
+++ b/Pinpoint/EditorWindowController.swift
@@ -5,7 +5,13 @@ import SwiftUI
 final class EditorWindowController: NSWindowController, NSWindowDelegate {
     var onClose: (() -> Void)?
 
-    init(image: NSImage) {
+    init(
+        image: NSImage,
+        initialPins: [Pin] = [],
+        initialShapes: [Markup] = [],
+        initialContext: String = "",
+        onPersist: @escaping ([Pin], [Markup], String) -> Void = { _, _, _ in }
+    ) {
         // Size the window to the image, capped to a comfortable on-screen size.
         let maxSize = NSSize(width: 1100, height: 760)
         let imgSize = image.size
@@ -27,7 +33,13 @@ final class EditorWindowController: NSWindowController, NSWindowDelegate {
         super.init(window: window)
         window.delegate = self
 
-        let root = EditorView(image: image) { [weak window] in
+        let root = EditorView(
+            image: image,
+            initialPins: initialPins,
+            initialShapes: initialShapes,
+            initialContext: initialContext,
+            onPersist: onPersist
+        ) { [weak window] in
             window?.close()
         }
         window.contentView = NSHostingView(rootView: root)

--- a/Pinpoint/Markup.swift
+++ b/Pinpoint/Markup.swift
@@ -7,13 +7,13 @@ import Foundation
 /// agent-ready text — they're purely visual emphasis. Coordinates are
 /// normalized (0...1) in image space, top-left origin (same convention as
 /// `Pin`), so they scale with the canvas and export correctly.
-struct Markup: Identifiable, Equatable {
-    enum Kind: Equatable {
+struct Markup: Identifiable, Equatable, Codable {
+    enum Kind: String, Equatable, Codable {
         case arrow
         case rectangle
     }
 
-    let id = UUID()
+    var id = UUID()
     var kind: Kind
     /// Arrow: tail. Rectangle: one corner.
     var start: CGPoint

--- a/Pinpoint/Pin.swift
+++ b/Pinpoint/Pin.swift
@@ -3,8 +3,8 @@ import Foundation
 
 /// A numbered marker placed on the captured image.
 /// `position` is normalized (0...1) in image space, top-left origin.
-struct Pin: Identifiable, Equatable {
-    let id = UUID()
+struct Pin: Identifiable, Equatable, Codable {
+    var id = UUID()
     var number: Int
     var position: CGPoint
     var note: String = ""

--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ App macOS native, Swift / SwiftUI + ScreenCaptureKit. Vit dans la barre de menus
 - Accent **vermillon** `#FF4D2E` + **3 styles de repères** réglables (disque plein,
   pin pointeur, contour léger) appliqués à l’écran **et** à l’export
 - **⌘C** / bouton → copie l’image annotée (PNG) **et** le texte dans le presse-papier
+- **Historique** : sous-menu « Captures récentes » (15 dernières, persistées dans
+  Application Support avec leurs annotations) → rouvre une capture telle qu’elle était
 
-Pas encore : historique des captures. Voir `PROMPTS.md`.
+Pistes futures : capture de fenêtre, export fichier, partage. Voir `PROMPTS.md`.
 
 ## Build
 
@@ -66,6 +68,8 @@ Pinpoint/
     RegionSelectionController.swift # overlay multi-écran + résolution des coordonnées
     RegionSelectionView.swift  # dessin de l’assombrissement + rectangle + dimensions
     CaptureRegion.swift        # modèle : display cible + rect (points, top-left) + scale
+    CaptureRecord.swift        # modèle persisté d’une capture (image + annotations + date)
+    CaptureHistory.swift       # store des captures récentes (Application Support + index JSON)
     ScreenCapture.swift        # ScreenCaptureKit : capture région (sourceRect) ou plein écran
     Pin.swift                  # modèle d’un repère numéroté
     Markup.swift               # modèle d’une annotation flèche / rectangle


### PR DESCRIPTION
Ajoute l'historique des captures (itération #3 du plan).

- Les **15 dernières captures** sont persistées dans Application Support (PNG brut + index JSON) avec leur **état d'annotation complet** (repères, flèches/rectangles, instructions).
- Sous-menu **« Captures récentes »** (reconstruit à l'ouverture via `NSMenuDelegate`) qui **rouvre une capture telle qu'elle était laissée** ; **« Vider l'historique »** pour purger.
- `Pin`/`Markup` deviennent `Codable` ; `CaptureRecord`/`CaptureHistory` gèrent le stockage et reconstruisent la `NSImage` à la **résolution native** au rechargement.
- L'éditeur persiste son état à la copie et à la fermeture (`onPersist`). `AppDelegate` passe `@MainActor`.

## Vérification
`BUILD SUCCEEDED` local + CI. Tests d'exécution à faire côté auteur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)