### PR TITLE
Corrige l'ouverture des Réglages (macOS 14+)

### DIFF
--- a/Pinpoint/AppDelegate.swift
+++ b/Pinpoint/AppDelegate.swift
@@ -7,6 +7,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var statusItem: NSStatusItem!
     private var editorController: EditorWindowController?
     private var regionController: RegionSelectionController?
+    private var settingsController: SettingsWindowController?
     private let recentMenu = NSMenu()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -119,12 +120,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
 
     @objc private func openSettings() {
-        NSApp.activate(ignoringOtherApps: true)
-        if #available(macOS 14.0, *) {
-            NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
-        } else {
-            NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
+        if settingsController == nil {
+            settingsController = SettingsWindowController()
         }
+        NSApp.activate(ignoringOtherApps: true)
+        settingsController?.showWindow(nil)
+        settingsController?.window?.makeKeyAndOrderFront(nil)
     }
 
     // MARK: - Capture flow

--- a/Pinpoint/SettingsWindowController.swift
+++ b/Pinpoint/SettingsWindowController.swift
@@ -1,0 +1,24 @@
+import AppKit
+import SwiftUI
+
+/// Hosts the SwiftUI settings UI in a plain AppKit window.
+///
+/// macOS 14+ deprecated the programmatic way to open the SwiftUI `Settings`
+/// scene (`showSettingsWindow:`), which doesn't work for menu-bar (`LSUIElement`)
+/// apps and logs "Please use SettingsLink…". Presenting our own window — the same
+/// way the editor window is shown — opens reliably and avoids that path entirely.
+final class SettingsWindowController: NSWindowController {
+    init() {
+        let hosting = NSHostingController(rootView: SettingsView())
+        let window = NSWindow(contentViewController: hosting)
+        window.styleMask = [.titled, .closable]
+        window.title = "Réglages Pinpoint"
+        window.isReleasedWhenClosed = false
+
+        super.init(window: window)
+        window.center()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+}

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Pinpoint/
     Theme.swift                # palette vermillon (NSColor + Color)
     EditorWindowController.swift  # fenêtre AppKit qui héberge l’éditeur SwiftUI
     EditorView.swift           # canvas d’annotation + panneau latéral
+    SettingsWindowController.swift # fenêtre AppKit des réglages (contourne le bug SettingsLink macOS 14+)
     Exporter.swift             # rendu PNG annoté + texte + copie presse-papier
 ```
 


### PR DESCRIPTION
**Bug** : cliquer « Réglages… » n'ouvrait rien et logguait *« Please use SettingsLink for opening the Settings scene »*.

**Cause** : macOS 14+ a déprécié `showSettingsWindow:` ; pour une app menu-bar (`LSUIElement`), ce chemin n'ouvre pas la fenêtre et `SettingsLink` (SwiftUI) suppose un contexte de fenêtre absent.

**Fix** : présenter les réglages dans une fenêtre AppKit maison (`SettingsWindowController` qui héberge `SettingsView` via `NSHostingController`), affichée comme la fenêtre d'éditeur (qui, elle, fonctionne). Fiable et sans message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)