### PR TITLE
Corrige la boucle de contraintes à l'ouverture des Réglages

### DIFF
--- a/Pinpoint/PinpointApp.swift
+++ b/Pinpoint/PinpointApp.swift
@@ -44,6 +44,6 @@ struct SettingsView: View {
             }
         }
         .padding(20)
-        .frame(width: 380)
+        .frame(minWidth: 360)
     }
 }

--- a/Pinpoint/SettingsWindowController.swift
+++ b/Pinpoint/SettingsWindowController.swift
@@ -7,13 +7,22 @@ import SwiftUI
 /// scene (`showSettingsWindow:`), which doesn't work for menu-bar (`LSUIElement`)
 /// apps and logs "Please use SettingsLink…". Presenting our own window — the same
 /// way the editor window is shown — opens reliably and avoids that path entirely.
+///
+/// The window uses a fixed content size + `NSHostingView` (not
+/// `NSWindow(contentViewController:)`), because letting the window auto-size to a
+/// SwiftUI `Form` triggers a constraint-update loop ("more Update Constraints
+/// passes than there are views").
 final class SettingsWindowController: NSWindowController {
     init() {
-        let hosting = NSHostingController(rootView: SettingsView())
-        let window = NSWindow(contentViewController: hosting)
-        window.styleMask = [.titled, .closable]
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 380, height: 280),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
         window.title = "Réglages Pinpoint"
         window.isReleasedWhenClosed = false
+        window.contentView = NSHostingView(rootView: SettingsView())
 
         super.init(window: window)
         window.center()


### PR DESCRIPTION
Suite de la PR #3 : l'ouverture des Réglages levait `NSGenericException` (« more Update Constraints passes than there are views ») et la fenêtre ne s'affichait pas.

**Cause** : `NSWindow(contentViewController:)` + `NSHostingController` autour d'un `Form` SwiftUI fait auto-dimensionner la fenêtre sur son contenu → boucle de mise à jour des contraintes.

**Fix** : fenêtre à **taille fixe** + `window.contentView = NSHostingView(SettingsView())` — exactement le pattern de `EditorWindowController` (qui fonctionne). `SettingsView` passe de `.frame(width:)` figé à `.frame(minWidth:)` flexible.

✅ Vérifié en exécution : la fenêtre des réglages s'ouvre correctement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)