### PR TITLE
Fusion phase 1 — bibliothèque SnapShelf dans Pinpoint

### DIFF
--- a/Pinpoint/AppDelegate.swift
+++ b/Pinpoint/AppDelegate.swift
@@ -8,6 +8,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var editorController: EditorWindowController?
     private var regionController: RegionSelectionController?
     private var settingsController: SettingsWindowController?
+    private var shelfController: ShelfWindowController?
     private let recentMenu = NSMenu()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -38,6 +39,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         fullScreenItem.target = self
         menu.addItem(fullScreenItem)
         menu.addItem(.separator())
+
+        let shelfItem = NSMenuItem(title: "Étagère…", action: #selector(openShelf), keyEquivalent: "")
+        shelfItem.target = self
+        menu.addItem(shelfItem)
 
         let recentItem = NSMenuItem(title: "Captures récentes", action: nil, keyEquivalent: "")
         recentMenu.delegate = self
@@ -126,6 +131,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         NSApp.activate(ignoringOtherApps: true)
         settingsController?.showWindow(nil)
         settingsController?.window?.makeKeyAndOrderFront(nil)
+    }
+
+    @objc private func openShelf() {
+        if shelfController == nil {
+            shelfController = ShelfWindowController()
+        }
+        NSApp.activate(ignoringOtherApps: true)
+        shelfController?.showWindow(nil)
+        shelfController?.window?.makeKeyAndOrderFront(nil)
     }
 
     // MARK: - Capture flow

--- a/Pinpoint/Shelf/Models/ScreenshotDateFilter.swift
+++ b/Pinpoint/Shelf/Models/ScreenshotDateFilter.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+enum ScreenshotDateFilter: String, CaseIterable, Identifiable {
+    case all
+    case today
+    case yesterday
+    case last7Days
+    case last30Days
+    case thisWeek
+    case thisMonth
+    case older
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .all:
+            return "All"
+        case .today:
+            return "Today"
+        case .yesterday:
+            return "Yesterday"
+        case .last7Days:
+            return "Last 7 Days"
+        case .last30Days:
+            return "Last 30 Days"
+        case .thisWeek:
+            return "This Week"
+        case .thisMonth:
+            return "This Month"
+        case .older:
+            return "Older"
+        }
+    }
+
+    func matches(_ item: ScreenshotItem, calendar: Calendar = .current) -> Bool {
+        switch self {
+        case .all:
+            return true
+        case .today:
+            return calendar.isDateInToday(item.createdAt)
+        case .yesterday:
+            return calendar.isDateInYesterday(item.createdAt)
+        case .last7Days:
+            return matchesRecentDays(item, days: 7, calendar: calendar)
+        case .last30Days:
+            return matchesRecentDays(item, days: 30, calendar: calendar)
+        case .thisWeek:
+            return ScreenshotSection.section(for: item.createdAt, calendar: calendar) == .thisWeek
+        case .thisMonth:
+            return ScreenshotSection.section(for: item.createdAt, calendar: calendar) == .thisMonth
+        case .older:
+            return ScreenshotSection.section(for: item.createdAt, calendar: calendar) == .older
+        }
+    }
+
+    private func matchesRecentDays(_ item: ScreenshotItem, days: Int, calendar: Calendar) -> Bool {
+        guard let startDate = calendar.date(byAdding: .day, value: -(days - 1), to: calendar.startOfDay(for: .now)) else {
+            return false
+        }
+
+        return item.createdAt >= startDate
+    }
+}

--- a/Pinpoint/Shelf/Models/ScreenshotItem.swift
+++ b/Pinpoint/Shelf/Models/ScreenshotItem.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct ScreenshotItem: Identifiable, Hashable, Sendable {
+    let id: URL
+    let url: URL
+    let filename: String
+    let createdAt: Date
+    let fileExtension: String
+
+    init(url: URL, createdAt: Date) {
+        self.id = url
+        self.url = url
+        self.filename = url.lastPathComponent
+        self.createdAt = createdAt
+        self.fileExtension = url.pathExtension.lowercased()
+    }
+}

--- a/Pinpoint/Shelf/Models/ScreenshotSection.swift
+++ b/Pinpoint/Shelf/Models/ScreenshotSection.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+enum ScreenshotSection: String, CaseIterable, Identifiable {
+    case today
+    case yesterday
+    case thisWeek
+    case thisMonth
+    case older
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .today:
+            return "Today"
+        case .yesterday:
+            return "Yesterday"
+        case .thisWeek:
+            return "This Week"
+        case .thisMonth:
+            return "This Month"
+        case .older:
+            return "Older"
+        }
+    }
+
+    static func section(for date: Date, calendar: Calendar = .current) -> Self {
+        if calendar.isDateInToday(date) {
+            return .today
+        }
+
+        if calendar.isDateInYesterday(date) {
+            return .yesterday
+        }
+
+        if calendar.isDate(date, equalTo: .now, toGranularity: .weekOfYear) {
+            return .thisWeek
+        }
+
+        if calendar.isDate(date, equalTo: .now, toGranularity: .month) {
+            return .thisMonth
+        }
+
+        return .older
+    }
+}

--- a/Pinpoint/Shelf/Models/ScreenshotSortOrder.swift
+++ b/Pinpoint/Shelf/Models/ScreenshotSortOrder.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+enum ScreenshotSortOrder: String, CaseIterable, Identifiable {
+    case newestFirst
+    case oldestFirst
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .newestFirst:
+            return "Newest"
+        case .oldestFirst:
+            return "Oldest"
+        }
+    }
+
+    func sort(_ items: [ScreenshotItem]) -> [ScreenshotItem] {
+        switch self {
+        case .newestFirst:
+            return items.sorted { $0.createdAt > $1.createdAt }
+        case .oldestFirst:
+            return items.sorted { $0.createdAt < $1.createdAt }
+        }
+    }
+}

--- a/Pinpoint/Shelf/Services/ScreenshotService.swift
+++ b/Pinpoint/Shelf/Services/ScreenshotService.swift
@@ -1,0 +1,162 @@
+import AppKit
+import Foundation
+
+actor ScreenshotService {
+    private let fileManager = FileManager.default
+    private let supportedExtensions = Set(["png", "jpg", "jpeg"])
+
+    func scanFolder(at folderURL: URL) throws -> [ScreenshotItem] {
+        let keys: Set<URLResourceKey> = [
+            .isRegularFileKey,
+            .contentModificationDateKey,
+            .creationDateKey
+        ]
+
+        let urls = try fileManager.contentsOfDirectory(
+            at: folderURL,
+            includingPropertiesForKeys: Array(keys),
+            options: [.skipsHiddenFiles]
+        )
+
+        return try urls.compactMap { url in
+            try screenshotItemIfSupported(at: url, resourceKeys: keys)
+        }
+        .sorted { $0.createdAt > $1.createdAt }
+    }
+
+    func resolveChangedItems(at urls: [URL], watchedFolderURL: URL) async -> [URL: ScreenshotItem?] {
+        var results: [URL: ScreenshotItem?] = [:]
+
+        for url in urls {
+            guard url.deletingLastPathComponent() == watchedFolderURL || url == watchedFolderURL else {
+                continue
+            }
+
+            if url == watchedFolderURL {
+                results[url] = nil
+                continue
+            }
+
+            let item = await stableScreenshotItemIfSupported(at: url)
+            results[url] = item
+        }
+
+        return results
+    }
+
+    func delete(_ item: ScreenshotItem) throws {
+        var resultingItemURL: NSURL?
+        try fileManager.trashItem(at: item.url, resultingItemURL: &resultingItemURL)
+    }
+
+    func move(_ item: ScreenshotItem, to destinationFolder: URL) throws -> URL {
+        let destinationURL = uniqueDestinationURL(for: item.url, in: destinationFolder)
+        try fileManager.moveItem(at: item.url, to: destinationURL)
+        return destinationURL
+    }
+
+    func rename(_ item: ScreenshotItem, to newName: String) throws -> URL {
+        let sanitized = sanitizedFilename(newName, originalExtension: item.fileExtension)
+        let destinationURL = item.url.deletingLastPathComponent().appendingPathComponent(sanitized)
+        let finalURL = uniqueDestinationURL(for: destinationURL, in: destinationURL.deletingLastPathComponent())
+        try fileManager.moveItem(at: item.url, to: finalURL)
+        return finalURL
+    }
+
+    nonisolated func revealInFinder(_ item: ScreenshotItem) {
+        NSWorkspace.shared.activateFileViewerSelecting([item.url])
+    }
+
+    nonisolated func revealInFinder(_ items: [ScreenshotItem]) {
+        NSWorkspace.shared.activateFileViewerSelecting(items.map(\.url))
+    }
+
+    private func stableScreenshotItemIfSupported(at url: URL) async -> ScreenshotItem? {
+        guard supportedExtensions.contains(url.pathExtension.lowercased()) else {
+            return nil
+        }
+
+        let keys: Set<URLResourceKey> = [
+            .isRegularFileKey,
+            .fileSizeKey,
+            .contentModificationDateKey,
+            .creationDateKey
+        ]
+
+        var previousSize: Int?
+
+        for attempt in 0..<6 {
+            do {
+                let values = try url.resourceValues(forKeys: keys)
+
+                guard values.isRegularFile == true else {
+                    return nil
+                }
+
+                let currentSize = values.fileSize ?? 0
+                let createdAt = values.creationDate ?? values.contentModificationDate ?? .distantPast
+                let item = ScreenshotItem(url: url, createdAt: createdAt)
+
+                if let previousSize, previousSize == currentSize, currentSize > 0 {
+                    return item
+                }
+
+                previousSize = currentSize
+            } catch {
+                return nil
+            }
+
+            if attempt < 5 {
+                try? await Task.sleep(for: .milliseconds(150))
+            }
+        }
+
+        return nil
+    }
+
+    private func screenshotItemIfSupported(
+        at url: URL,
+        resourceKeys: Set<URLResourceKey>
+    ) throws -> ScreenshotItem? {
+        let values = try url.resourceValues(forKeys: resourceKeys)
+
+        guard values.isRegularFile == true else {
+            return nil
+        }
+
+        let pathExtension = url.pathExtension.lowercased()
+        guard supportedExtensions.contains(pathExtension) else {
+            return nil
+        }
+
+        let createdAt = values.creationDate ?? values.contentModificationDate ?? .distantPast
+        return ScreenshotItem(url: url, createdAt: createdAt)
+    }
+
+    private func sanitizedFilename(_ name: String, originalExtension: String) -> String {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let baseName = trimmed.isEmpty ? "Screenshot" : trimmed
+
+        if (baseName as NSString).pathExtension.isEmpty {
+            return "\(baseName).\(originalExtension)"
+        }
+
+        return baseName
+    }
+
+    private func uniqueDestinationURL(for originalURL: URL, in folderURL: URL) -> URL {
+        let fileExtension = originalURL.pathExtension
+        let filename = originalURL.deletingPathExtension().lastPathComponent
+        var candidate = folderURL.appendingPathComponent(originalURL.lastPathComponent)
+        var index = 2
+
+        while fileManager.fileExists(atPath: candidate.path) {
+            let suffix = " \(index)"
+            let name = fileExtension.isEmpty ? "\(filename)\(suffix)" : "\(filename)\(suffix).\(fileExtension)"
+            candidate = folderURL.appendingPathComponent(name)
+            index += 1
+        }
+
+        return candidate
+    }
+}

--- a/Pinpoint/Shelf/Services/ScreenshotWatcher.swift
+++ b/Pinpoint/Shelf/Services/ScreenshotWatcher.swift
@@ -1,0 +1,140 @@
+import CoreServices
+import Foundation
+
+struct ScreenshotWatcherEvent: Sendable {
+    let changedURLs: [URL]
+    let requiresFullRescan: Bool
+}
+
+final class ScreenshotWatcher {
+    private let queue = DispatchQueue(label: "com.snapshelf.watcher", qos: .utility)
+    private var stream: FSEventStreamRef?
+    private var pendingURLs = Set<URL>()
+    private var pendingFullRescan = false
+    private var debounceWorkItem: DispatchWorkItem?
+
+    func startMonitoring(
+        folderURL: URL,
+        onEvent: @escaping @Sendable (ScreenshotWatcherEvent) -> Void
+    ) {
+        stopMonitoring()
+
+        let callback = Self.makeCallback()
+        var context = FSEventStreamContext(
+            version: 0,
+            info: Unmanaged.passUnretained(self).toOpaque(),
+            retain: nil,
+            release: nil,
+            copyDescription: nil
+        )
+
+        let flags = FSEventStreamCreateFlags(
+            kFSEventStreamCreateFlagUseCFTypes |
+            kFSEventStreamCreateFlagFileEvents |
+            kFSEventStreamCreateFlagNoDefer
+        )
+
+        guard let stream = FSEventStreamCreate(
+            kCFAllocatorDefault,
+            callback,
+            &context,
+            [folderURL.path] as CFArray,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+            0.25,
+            flags
+        ) else {
+            return
+        }
+
+        self.stream = stream
+        FSEventStreamSetDispatchQueue(stream, queue)
+        FSEventStreamStart(stream)
+
+        self.onEvent = onEvent
+    }
+
+    func stopMonitoring() {
+        debounceWorkItem?.cancel()
+        debounceWorkItem = nil
+        pendingURLs.removeAll()
+        pendingFullRescan = false
+        onEvent = nil
+
+        guard let stream else { return }
+
+        FSEventStreamStop(stream)
+        FSEventStreamInvalidate(stream)
+        FSEventStreamRelease(stream)
+        self.stream = nil
+    }
+
+    deinit {
+        stopMonitoring()
+    }
+
+    private var onEvent: (@Sendable (ScreenshotWatcherEvent) -> Void)?
+
+    private static func makeCallback() -> FSEventStreamCallback {
+        { _, info, eventCount, eventPaths, eventFlags, _ in
+            guard let info else { return }
+            let watcher = Unmanaged<ScreenshotWatcher>.fromOpaque(info).takeUnretainedValue()
+            watcher.handleEvents(
+                count: eventCount,
+                eventPaths: unsafeBitCast(eventPaths, to: NSArray.self),
+                eventFlags: eventFlags
+            )
+        }
+    }
+
+    private func handleEvents(
+        count: Int,
+        eventPaths: NSArray,
+        eventFlags: UnsafePointer<FSEventStreamEventFlags>
+    ) {
+        guard let onEvent else { return }
+
+        var requiresFullRescan = false
+        var changedURLs = Set<URL>()
+
+        for index in 0..<count {
+            let flags = eventFlags[index]
+
+            if flags & UInt32(kFSEventStreamEventFlagMustScanSubDirs) != 0 ||
+                flags & UInt32(kFSEventStreamEventFlagRootChanged) != 0 {
+                requiresFullRescan = true
+            }
+
+            guard let path = eventPaths[index] as? String else {
+                requiresFullRescan = true
+                continue
+            }
+
+            changedURLs.insert(URL(fileURLWithPath: path))
+        }
+
+        pendingFullRescan = pendingFullRescan || requiresFullRescan
+        pendingURLs.formUnion(changedURLs)
+        scheduleDelivery(onEvent: onEvent)
+    }
+
+    private func scheduleDelivery(onEvent: @escaping @Sendable (ScreenshotWatcherEvent) -> Void) {
+        debounceWorkItem?.cancel()
+
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+
+            let event = ScreenshotWatcherEvent(
+                changedURLs: Array(self.pendingURLs),
+                requiresFullRescan: self.pendingFullRescan
+            )
+
+            self.pendingURLs.removeAll()
+            self.pendingFullRescan = false
+
+            onEvent(event)
+        }
+
+        debounceWorkItem = workItem
+        queue.asyncAfter(deadline: .now() + 0.2, execute: workItem)
+    }
+}

--- a/Pinpoint/Shelf/Services/ThumbnailService.swift
+++ b/Pinpoint/Shelf/Services/ThumbnailService.swift
@@ -1,0 +1,48 @@
+import AppKit
+import Foundation
+import QuickLookThumbnailing
+
+actor ThumbnailService {
+    static let shared = ThumbnailService()
+
+    private let generator = QLThumbnailGenerator.shared
+    private var cache: [URL: NSImage] = [:]
+
+    func thumbnail(for url: URL, size: CGSize = CGSize(width: 220, height: 180), scale: CGFloat = 2) async -> NSImage? {
+        if let cached = cache[url] {
+            return cached
+        }
+
+        let request = QLThumbnailGenerator.Request(
+            fileAt: url,
+            size: size,
+            scale: scale,
+            representationTypes: .thumbnail
+        )
+
+        let image = await withCheckedContinuation { (continuation: CheckedContinuation<NSImage?, Never>) in
+            generator.generateBestRepresentation(for: request) { representation, error in
+                guard error == nil else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+
+                continuation.resume(returning: representation?.nsImage)
+            }
+        }
+
+        if let image {
+            cache[url] = image
+        }
+
+        return image
+    }
+
+    func removeCachedThumbnail(for url: URL) {
+        cache[url] = nil
+    }
+
+    func reset() {
+        cache.removeAll()
+    }
+}

--- a/Pinpoint/Shelf/Stores/ScreenshotStore.swift
+++ b/Pinpoint/Shelf/Stores/ScreenshotStore.swift
@@ -1,0 +1,410 @@
+import AppKit
+import Combine
+import Foundation
+import ServiceManagement
+
+@MainActor
+final class ScreenshotStore: ObservableObject {
+    @Published private(set) var screenshots: [ScreenshotItem] = []
+    @Published var selectedDateFilter: ScreenshotDateFilter = .all
+    @Published var selectedSortOrder: ScreenshotSortOrder = .newestFirst
+    @Published var showsFavoritesOnly = false
+    @Published private(set) var watchedFolderURL: URL
+    @Published private(set) var isLoading = false
+    @Published private(set) var launchAtLoginEnabled = false
+    @Published private(set) var followsSystemScreenshotLocation: Bool
+    @Published private(set) var favoritePaths: Set<String>
+    @Published var lastErrorMessage: String?
+
+    private let service = ScreenshotService()
+    private let watcher = ScreenshotWatcher()
+    private let defaults = UserDefaults.standard
+    private let watchedFolderBookmarkKey = "watchedFolderBookmark"
+    private let followSystemLocationKey = "followSystemScreenshotLocation"
+    private let favoritePathsKey = "favoriteScreenshotPaths"
+
+    init() {
+        let followsSystemScreenshotLocation = defaults.bool(forKey: followSystemLocationKey)
+        self.followsSystemScreenshotLocation = followsSystemScreenshotLocation
+        self.favoritePaths = Set(defaults.stringArray(forKey: favoritePathsKey) ?? [])
+        self.watchedFolderURL = followsSystemScreenshotLocation
+            ? ScreenshotLocationResolver.currentLocation()
+            : (Self.loadPersistedFolder() ?? Self.defaultWatchedFolder())
+        self.launchAtLoginEnabled = Self.currentLaunchAtLoginState()
+    }
+
+    var filteredScreenshots: [ScreenshotItem] {
+        let filtered = screenshots.filter { item in
+            let matchesDate = selectedDateFilter.matches(item)
+            let matchesFavorites = showsFavoritesOnly == false || isFavorite(item)
+            return matchesDate && matchesFavorites
+        }
+        return selectedSortOrder.sort(filtered)
+    }
+
+    var groupedScreenshots: [(section: ScreenshotSection, items: [ScreenshotItem])] {
+        ScreenshotSection.allCases.compactMap { section in
+            let items = filteredScreenshots.filter { ScreenshotSection.section(for: $0.createdAt) == section }
+            return items.isEmpty ? nil : (section, items)
+        }
+    }
+
+    func start() async {
+        if followsSystemScreenshotLocation {
+            applyCurrentSystemScreenshotLocation()
+        }
+        await refresh()
+        startWatcher()
+    }
+
+    func refresh() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            screenshots = try await service.scanFolder(at: watchedFolderURL)
+            pruneMissingFavorites()
+            lastErrorMessage = nil
+        } catch {
+            screenshots = []
+            lastErrorMessage = "Could not read \(watchedFolderURL.lastPathComponent)."
+        }
+    }
+
+    func chooseWatchedFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.canCreateDirectories = true
+        panel.prompt = "Choose Folder"
+        panel.directoryURL = watchedFolderURL
+
+        guard panel.runModal() == .OK, let url = panel.url else {
+            return
+        }
+
+        if followsSystemScreenshotLocation {
+            setFollowsSystemScreenshotLocation(false)
+        }
+
+        setWatchedFolder(url)
+    }
+
+    func setWatchedFolder(_ url: URL) {
+        watchedFolderURL = url
+        persistWatchedFolder(url)
+        Task {
+            await refresh()
+            startWatcher()
+        }
+    }
+
+    func delete(_ item: ScreenshotItem) {
+        performMutation(removing: item) { [self] in
+            try await self.service.delete(item)
+        }
+    }
+
+    func move(_ item: ScreenshotItem) {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.canCreateDirectories = true
+        panel.prompt = "Move"
+        panel.directoryURL = item.url.deletingLastPathComponent()
+
+        guard panel.runModal() == .OK, let folderURL = panel.url else {
+            return
+        }
+
+        Task {
+            do {
+                let destinationURL = try await service.move(item, to: folderURL)
+                updateFavoritePath(from: item.url.path, to: destinationURL.path)
+                await ThumbnailService.shared.removeCachedThumbnail(for: item.url)
+                await refresh()
+            } catch {
+                lastErrorMessage = "Could not update \(item.filename)."
+            }
+        }
+    }
+
+    func move(_ items: [ScreenshotItem]) {
+        guard let referenceItem = items.first else {
+            return
+        }
+
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.canCreateDirectories = true
+        panel.prompt = "Move"
+        panel.directoryURL = referenceItem.url.deletingLastPathComponent()
+
+        guard panel.runModal() == .OK, let folderURL = panel.url else {
+            return
+        }
+
+        Task {
+            for item in items {
+                do {
+                    let destinationURL = try await service.move(item, to: folderURL)
+                    updateFavoritePath(from: item.url.path, to: destinationURL.path)
+                    await ThumbnailService.shared.removeCachedThumbnail(for: item.url)
+                } catch {
+                    lastErrorMessage = "Could not move \(item.filename)."
+                }
+            }
+
+            await refresh()
+        }
+    }
+
+    func rename(_ item: ScreenshotItem, to newName: String) {
+        Task {
+            do {
+                let destinationURL = try await service.rename(item, to: newName)
+                updateFavoritePath(from: item.url.path, to: destinationURL.path)
+                await ThumbnailService.shared.removeCachedThumbnail(for: item.url)
+                await refresh()
+            } catch {
+                lastErrorMessage = "Could not update \(item.filename)."
+            }
+        }
+    }
+
+    func revealInFinder(_ item: ScreenshotItem) {
+        service.revealInFinder(item)
+    }
+
+    func revealInFinder(_ items: [ScreenshotItem]) {
+        service.revealInFinder(items)
+    }
+
+    func quickLook(_ item: ScreenshotItem) {
+        quickLook([item], current: item)
+    }
+
+    func quickLook(_ items: [ScreenshotItem], current: ScreenshotItem? = nil) {
+        QuickLookPreviewController.shared.preview(items.map(\.url), currentURL: current?.url)
+    }
+
+    func copyImage(_ item: ScreenshotItem) {
+        guard let image = NSImage(contentsOf: item.url) else {
+            lastErrorMessage = "Could not copy \(item.filename)."
+            return
+        }
+
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+
+        if pasteboard.writeObjects([image]) == false {
+            lastErrorMessage = "Could not copy \(item.filename)."
+            return
+        }
+
+        lastErrorMessage = nil
+    }
+
+    func copyFiles(_ items: [ScreenshotItem]) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+
+        let urls = items.map(\.url) as [NSURL]
+        if pasteboard.writeObjects(urls) == false {
+            lastErrorMessage = "Could not copy the selected files."
+            return
+        }
+
+        lastErrorMessage = nil
+    }
+
+    func copyPaths(_ items: [ScreenshotItem]) {
+        let paths = items.map(\.url.path).joined(separator: "\n")
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(paths, forType: .string)
+        lastErrorMessage = nil
+    }
+
+    func isFavorite(_ item: ScreenshotItem) -> Bool {
+        favoritePaths.contains(item.url.path)
+    }
+
+    func toggleFavorite(_ item: ScreenshotItem) {
+        setFavorite(isFavorite(item) == false, for: [item])
+    }
+
+    func setFavorite(_ isFavorite: Bool, for items: [ScreenshotItem]) {
+        let paths = items.map { $0.url.path }
+
+        if isFavorite {
+            favoritePaths.formUnion(paths)
+        } else {
+            favoritePaths.subtract(paths)
+        }
+
+        persistFavoritePaths()
+        objectWillChange.send()
+    }
+
+    func delete(_ items: [ScreenshotItem]) {
+        Task {
+            for item in items {
+                do {
+                    try await service.delete(item)
+                    favoritePaths.remove(item.url.path)
+                    await ThumbnailService.shared.removeCachedThumbnail(for: item.url)
+                } catch {
+                    lastErrorMessage = "Could not update \(item.filename)."
+                }
+            }
+
+            persistFavoritePaths()
+            await refresh()
+        }
+    }
+
+    func setLaunchAtLogin(enabled: Bool) {
+        do {
+            if enabled {
+                try SMAppService.mainApp.register()
+            } else {
+                try SMAppService.mainApp.unregister()
+            }
+
+            launchAtLoginEnabled = enabled
+            lastErrorMessage = nil
+        } catch {
+            launchAtLoginEnabled = Self.currentLaunchAtLoginState()
+            lastErrorMessage = "Could not update Launch at Login."
+        }
+    }
+
+    func setFollowsSystemScreenshotLocation(_ enabled: Bool) {
+        followsSystemScreenshotLocation = enabled
+        defaults.set(enabled, forKey: followSystemLocationKey)
+
+        if enabled {
+            applyCurrentSystemScreenshotLocation()
+        }
+    }
+
+    func applyCurrentSystemScreenshotLocation() {
+        let systemURL = ScreenshotLocationResolver.currentLocation()
+        setWatchedFolder(systemURL)
+    }
+
+    private func performMutation(removing item: ScreenshotItem, operation: @escaping @Sendable () async throws -> Void) {
+        Task {
+            do {
+                try await operation()
+                await ThumbnailService.shared.removeCachedThumbnail(for: item.url)
+                await refresh()
+            } catch {
+                lastErrorMessage = "Could not update \(item.filename)."
+            }
+        }
+    }
+
+    private func startWatcher() {
+        watcher.startMonitoring(folderURL: watchedFolderURL) { [weak self] event in
+            Task { @MainActor [weak self] in
+                await self?.handleWatcherEvent(event)
+            }
+        }
+    }
+
+    private func handleWatcherEvent(_ event: ScreenshotWatcherEvent) async {
+        if event.requiresFullRescan || event.changedURLs.contains(watchedFolderURL) {
+            await refresh()
+            return
+        }
+
+        let results = await service.resolveChangedItems(at: event.changedURLs, watchedFolderURL: watchedFolderURL)
+        applyIncrementalChanges(results)
+    }
+
+    private func applyIncrementalChanges(_ changes: [URL: ScreenshotItem?]) {
+        guard changes.isEmpty == false else {
+            return
+        }
+
+        var updated = Dictionary(uniqueKeysWithValues: screenshots.map { ($0.url, $0) })
+
+        for (url, item) in changes {
+            if let item {
+                updated[url] = item
+            } else {
+                updated.removeValue(forKey: url)
+                favoritePaths.remove(url.path)
+            }
+        }
+
+        screenshots = updated.values.sorted { $0.createdAt > $1.createdAt }
+        persistFavoritePaths()
+        lastErrorMessage = nil
+    }
+
+    private func updateFavoritePath(from oldPath: String, to newPath: String) {
+        guard favoritePaths.contains(oldPath) else {
+            return
+        }
+
+        favoritePaths.remove(oldPath)
+        favoritePaths.insert(newPath)
+        persistFavoritePaths()
+    }
+
+    private func pruneMissingFavorites() {
+        let pruned = favoritePaths.filter { FileManager.default.fileExists(atPath: $0) }
+        guard pruned != favoritePaths else {
+            return
+        }
+
+        favoritePaths = pruned
+        persistFavoritePaths()
+    }
+
+    private func persistFavoritePaths() {
+        defaults.set(Array(favoritePaths).sorted(), forKey: favoritePathsKey)
+    }
+
+    private func persistWatchedFolder(_ url: URL) {
+        do {
+            let bookmark = try url.bookmarkData(options: .minimalBookmark, includingResourceValuesForKeys: nil, relativeTo: nil)
+            defaults.set(bookmark, forKey: watchedFolderBookmarkKey)
+        } catch {
+            lastErrorMessage = "Could not save watched folder."
+        }
+    }
+
+    private static func loadPersistedFolder() -> URL? {
+        let defaults = UserDefaults.standard
+        guard let data = defaults.data(forKey: "watchedFolderBookmark") else {
+            return nil
+        }
+
+        var isStale = false
+        return try? URL(
+            resolvingBookmarkData: data,
+            options: .withoutUI,
+            relativeTo: nil,
+            bookmarkDataIsStale: &isStale
+        )
+    }
+
+    private static func defaultWatchedFolder() -> URL {
+        let systemLocation = ScreenshotLocationResolver.currentLocation()
+
+        if FileManager.default.fileExists(atPath: systemLocation.path) {
+            return systemLocation
+        }
+
+        return FileManager.default.urls(for: .desktopDirectory, in: .userDomainMask).first ?? URL(fileURLWithPath: NSHomeDirectory())
+    }
+
+    private static func currentLaunchAtLoginState() -> Bool {
+        SMAppService.mainApp.status == .enabled
+    }
+}

--- a/Pinpoint/Shelf/Utilities/PreviewSampleData.swift
+++ b/Pinpoint/Shelf/Utilities/PreviewSampleData.swift
@@ -1,0 +1,59 @@
+import AppKit
+import Foundation
+
+enum PreviewSampleData {
+    static let items: [ScreenshotItem] = makeItems()
+    @MainActor
+    static let store: ScreenshotStore = {
+        let store = ScreenshotStore()
+        store.setWatchedFolder(sampleFolderURL)
+        return store
+    }()
+
+    private static let sampleFolderURL: URL = {
+        let folder = FileManager.default.temporaryDirectory.appendingPathComponent("SnapShelfPreview", isDirectory: true)
+        try? FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        return folder
+    }()
+
+    private static func makeItems() -> [ScreenshotItem] {
+        let definitions: [(String, NSColor, TimeInterval)] = [
+            ("Screenshot 2026-03-27 at 09.14.12.png", .systemBlue, 0),
+            ("Screenshot 2026-03-27 at 08.50.21.png", .systemGreen, -900),
+            ("Screenshot 2026-03-26 at 18.02.08.png", .systemOrange, -86_400),
+            ("Screenshot 2026-03-23 at 14.11.03.png", .systemPink, -6 * 86_400),
+            ("Screenshot 2026-03-11 at 10.21.55.png", .systemPurple, -18 * 86_400),
+            ("Screenshot 2026-02-19 at 11.07.32.png", .systemTeal, -38 * 86_400)
+        ]
+
+        return definitions.compactMap { name, color, offset in
+            let url = sampleFolderURL.appendingPathComponent(name)
+
+            if FileManager.default.fileExists(atPath: url.path) == false {
+                let image = NSImage(size: NSSize(width: 1440, height: 900))
+                image.lockFocus()
+                color.setFill()
+                NSBezierPath(rect: NSRect(origin: .zero, size: image.size)).fill()
+
+                let title = NSString(string: "SnapShelf")
+                title.draw(
+                    at: NSPoint(x: 56, y: 56),
+                    withAttributes: [
+                        .foregroundColor: NSColor.white,
+                        .font: NSFont.systemFont(ofSize: 96, weight: .bold)
+                    ]
+                )
+                image.unlockFocus()
+
+                if let tiffData = image.tiffRepresentation,
+                   let rep = NSBitmapImageRep(data: tiffData),
+                   let pngData = rep.representation(using: .png, properties: [:]) {
+                    try? pngData.write(to: url)
+                }
+            }
+
+            let date = Date().addingTimeInterval(offset)
+            return ScreenshotItem(url: url, createdAt: date)
+        }
+    }
+}

--- a/Pinpoint/Shelf/Utilities/QuickLookPreviewController.swift
+++ b/Pinpoint/Shelf/Utilities/QuickLookPreviewController.swift
@@ -1,0 +1,48 @@
+import AppKit
+@preconcurrency import QuickLookUI
+
+final class QuickLookPreviewController: NSObject {
+    @MainActor
+    static let shared = QuickLookPreviewController()
+
+    private var items: [URL] = []
+    private var currentIndex = 0
+
+    @MainActor
+    func preview(_ urls: [URL], currentURL: URL? = nil) {
+        let existingURLs = urls.filter { FileManager.default.fileExists(atPath: $0.path) }
+        guard existingURLs.isEmpty == false else {
+            return
+        }
+
+        items = existingURLs
+        if let currentURL, let index = existingURLs.firstIndex(of: currentURL) {
+            currentIndex = index
+        } else {
+            currentIndex = 0
+        }
+
+        guard let panel = QLPreviewPanel.shared() else {
+            return
+        }
+
+        panel.dataSource = self
+        panel.delegate = self
+        panel.reloadData()
+        panel.currentPreviewItemIndex = currentIndex
+        panel.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+}
+
+extension QuickLookPreviewController: QLPreviewPanelDataSource {
+    func numberOfPreviewItems(in panel: QLPreviewPanel!) -> Int {
+        items.count
+    }
+
+    func previewPanel(_ panel: QLPreviewPanel!, previewItemAt index: Int) -> QLPreviewItem! {
+        items[index] as NSURL
+    }
+}
+
+extension QuickLookPreviewController: QLPreviewPanelDelegate {}

--- a/Pinpoint/Shelf/Utilities/ScreenshotLocationResolver.swift
+++ b/Pinpoint/Shelf/Utilities/ScreenshotLocationResolver.swift
@@ -1,0 +1,27 @@
+import CoreFoundation
+import Foundation
+
+enum ScreenshotLocationResolver {
+    static func currentLocation() -> URL {
+        if let location = CFPreferencesCopyAppValue(
+            "location" as CFString,
+            "com.apple.screencapture" as CFString
+        ) as? String,
+           location.isEmpty == false {
+            return URL(fileURLWithPath: (location as NSString).expandingTildeInPath, isDirectory: true)
+        }
+
+        let picturesScreenshots = FileManager.default
+            .urls(for: .picturesDirectory, in: .userDomainMask)
+            .first?
+            .appendingPathComponent("Screenshots", isDirectory: true)
+
+        if let picturesScreenshots,
+           FileManager.default.fileExists(atPath: picturesScreenshots.path) {
+            return picturesScreenshots
+        }
+
+        return FileManager.default.urls(for: .desktopDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+    }
+}

--- a/Pinpoint/Shelf/ViewModels/SettingsViewModel.swift
+++ b/Pinpoint/Shelf/ViewModels/SettingsViewModel.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+@MainActor
+final class SettingsViewModel: ObservableObject {
+    @Published private(set) var watchedFolderPath = ""
+    @Published private(set) var systemScreenshotFolderPath = ""
+    @Published var followSystemScreenshotLocation = false
+    @Published var launchAtLogin = false
+
+    func bind(to store: ScreenshotStore) {
+        watchedFolderPath = store.watchedFolderURL.path
+        systemScreenshotFolderPath = ScreenshotLocationResolver.currentLocation().path
+        followSystemScreenshotLocation = store.followsSystemScreenshotLocation
+        launchAtLogin = store.launchAtLoginEnabled
+    }
+
+    func syncFromStore(_ store: ScreenshotStore) {
+        watchedFolderPath = store.watchedFolderURL.path
+        systemScreenshotFolderPath = ScreenshotLocationResolver.currentLocation().path
+        followSystemScreenshotLocation = store.followsSystemScreenshotLocation
+        launchAtLogin = store.launchAtLoginEnabled
+    }
+}

--- a/Pinpoint/Shelf/Views/Components/MultiFileDragButton.swift
+++ b/Pinpoint/Shelf/Views/Components/MultiFileDragButton.swift
@@ -1,0 +1,139 @@
+import AppKit
+import SwiftUI
+
+struct MultiFileDragButton: NSViewRepresentable {
+    let items: [ScreenshotItem]
+    var compact = false
+
+    func makeNSView(context: Context) -> MultiFileDragNSButton {
+        let button = MultiFileDragNSButton()
+        button.setContentHuggingPriority(.required, for: .horizontal)
+        button.setContentCompressionResistancePriority(.required, for: .horizontal)
+        return button
+    }
+
+    func updateNSView(_ nsView: MultiFileDragNSButton, context: Context) {
+        nsView.configure(with: items, compact: compact)
+    }
+}
+
+final class MultiFileDragNSButton: NSButton, NSDraggingSource {
+    private var itemURLs: [URL] = []
+    private var mouseDownEvent: NSEvent?
+    private var hasStartedDrag = false
+    private var compact = false
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+
+        isBordered = false
+        bezelStyle = .regularSquare
+        focusRingType = .none
+        imagePosition = .imageLeading
+        imageScaling = .scaleNone
+        setButtonType(.momentaryChange)
+        wantsLayer = true
+        layer?.cornerRadius = 7
+        layer?.backgroundColor = NSColor.quaternaryLabelColor.withAlphaComponent(0.14).cgColor
+        contentTintColor = .labelColor
+        font = .systemFont(ofSize: NSFont.smallSystemFontSize, weight: .semibold)
+        image = NSImage(systemSymbolName: "hand.draw", accessibilityDescription: "Drag selected screenshots")
+        image?.isTemplate = true
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(with items: [ScreenshotItem], compact: Bool) {
+        itemURLs = items.map(\.url)
+        self.compact = compact
+        title = compact ? "" : (itemURLs.count == 1 ? "Drag File" : "Drag \(itemURLs.count) Files")
+        toolTip = "Drag the selected screenshots into another app"
+        isEnabled = itemURLs.isEmpty == false
+        alphaValue = isEnabled ? 1 : 0.45
+        invalidateIntrinsicContentSize()
+    }
+
+    override var intrinsicContentSize: NSSize {
+        if compact {
+            return NSSize(width: 30, height: 30)
+        }
+
+        let titleSize = attributedTitle.size()
+        return NSSize(width: titleSize.width + 42, height: 28)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        mouseDownEvent = event
+        hasStartedDrag = false
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard hasStartedDrag == false, itemURLs.isEmpty == false, let mouseDownEvent else {
+            return
+        }
+
+        hasStartedDrag = true
+        beginDraggingSession(with: draggingItems(), event: mouseDownEvent, source: self)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        mouseDownEvent = nil
+        hasStartedDrag = false
+    }
+
+    func draggingSession(_ session: NSDraggingSession, sourceOperationMaskFor context: NSDraggingContext) -> NSDragOperation {
+        .copy
+    }
+
+    func ignoreModifierKeys(for session: NSDraggingSession) -> Bool {
+        true
+    }
+
+    private func draggingItems() -> [NSDraggingItem] {
+        itemURLs.enumerated().map { index, url in
+            let item = NSDraggingItem(pasteboardWriter: url as NSURL)
+            item.setDraggingFrame(draggingFrame(for: index), contents: draggingImage(for: url, index: index))
+            return item
+        }
+    }
+
+    private func draggingFrame(for index: Int) -> CGRect {
+        let origin = CGPoint(x: bounds.minX + CGFloat(index * 8), y: bounds.minY - CGFloat(index * 4))
+        return CGRect(origin: origin, size: CGSize(width: 96, height: 96))
+    }
+
+    private func draggingImage(for url: URL, index: Int) -> NSImage {
+        let baseImage = NSWorkspace.shared.icon(forFile: url.path)
+        baseImage.size = NSSize(width: 96, height: 96)
+
+        guard index == 0, itemURLs.count > 1 else {
+            return baseImage
+        }
+
+        let composedImage = NSImage(size: baseImage.size)
+        composedImage.lockFocus()
+        baseImage.draw(in: NSRect(origin: .zero, size: baseImage.size))
+
+        let badgeRect = NSRect(x: 62, y: 66, width: 26, height: 22)
+        NSColor.controlAccentColor.setFill()
+        NSBezierPath(roundedRect: badgeRect, xRadius: 10, yRadius: 10).fill()
+
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 11, weight: .bold),
+            .foregroundColor: NSColor.white
+        ]
+        let badgeText = "\(itemURLs.count)" as NSString
+        let textSize = badgeText.size(withAttributes: attributes)
+        let textOrigin = NSPoint(
+            x: badgeRect.midX - (textSize.width / 2),
+            y: badgeRect.midY - (textSize.height / 2)
+        )
+        badgeText.draw(at: textOrigin, withAttributes: attributes)
+
+        composedImage.unlockFocus()
+        return composedImage
+    }
+}

--- a/Pinpoint/Shelf/Views/Components/ScreenshotCardView.swift
+++ b/Pinpoint/Shelf/Views/Components/ScreenshotCardView.swift
@@ -1,0 +1,187 @@
+import AppKit
+import SwiftUI
+
+struct ScreenshotCardView: View {
+    let item: ScreenshotItem
+    let width: CGFloat
+    let isFavorite: Bool
+    let isSelected: Bool
+    let isActive: Bool
+    let selectionMode: Bool
+    let onActivate: () -> Void
+    let onToggleFavorite: () -> Void
+    let onSelect: () -> Void
+    let onCopyImage: () -> Void
+    let onCopyPath: () -> Void
+    let onOpenDetails: () -> Void
+    let onDelete: () -> Void
+    let onQuickLook: () -> Void
+    let onMove: () -> Void
+    let onRename: () -> Void
+    let onReveal: () -> Void
+
+    @State private var thumbnail: NSImage?
+
+    private var thumbnailWidth: CGFloat {
+        max(width - 16, 0)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 14)
+                    .fill(.quaternary.opacity(0.35))
+
+                if let thumbnail {
+                    Image(nsImage: thumbnail)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: thumbnailWidth, height: 126)
+                } else {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+            .frame(width: thumbnailWidth, height: 126)
+            .frame(height: 126)
+            .clipShape(RoundedRectangle(cornerRadius: 14))
+            .overlay(alignment: .topTrailing) {
+                Menu {
+                    Button("Open Details", systemImage: "rectangle.portrait.and.arrow.right", action: onOpenDetails)
+                    Divider()
+                    Button("Quick Look", systemImage: "space", action: onQuickLook)
+                    Divider()
+                    Button(isFavorite ? "Remove Favorite" : "Favorite", systemImage: isFavorite ? "star.slash" : "star", action: onToggleFavorite)
+                    Divider()
+                    Button("Copy Image", systemImage: "doc.on.doc", action: onCopyImage)
+                    Button("Copy File Path", systemImage: "link", action: onCopyPath)
+                    Divider()
+                    Button("Rename", systemImage: "pencil", action: onRename)
+                    Button("Move", systemImage: "folder", action: onMove)
+                    Button("Reveal in Finder", systemImage: "finder", action: onReveal)
+                    Divider()
+                    Button("Delete", systemImage: "trash", role: .destructive, action: onDelete)
+                } label: {
+                    Image(systemName: "ellipsis.circle.fill")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(.white, .black.opacity(0.45))
+                        .padding(8)
+                }
+                .menuStyle(.borderlessButton)
+            }
+            .overlay(alignment: .topLeading) {
+                if selectionMode {
+                    Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundStyle(isSelected ? .white : .secondary, isSelected ? Color.accentColor : .clear)
+                        .padding(8)
+                } else {
+                    Button(action: onToggleFavorite) {
+                        Image(systemName: isFavorite ? "star.fill" : "star")
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundStyle(isFavorite ? .yellow : .secondary, .thinMaterial)
+                            .padding(8)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(item.filename)
+                    .font(.system(size: 13, weight: .semibold))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .frame(width: thumbnailWidth, alignment: .leading)
+
+                Text(item.createdAt, format: .dateTime.hour().minute())
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(width: thumbnailWidth, alignment: .leading)
+            }
+            .frame(width: thumbnailWidth, alignment: .leading)
+        }
+        .frame(width: width, alignment: .leading)
+        .padding(8)
+        .background(selectionBackground, in: RoundedRectangle(cornerRadius: 16))
+        .overlay {
+            RoundedRectangle(cornerRadius: 16)
+                .strokeBorder(activeBorderColor, lineWidth: isActive ? 2 : 0)
+        }
+        .contentShape(RoundedRectangle(cornerRadius: 16))
+        .onTapGesture {
+            onActivate()
+
+            guard selectionMode else { return }
+            onSelect()
+        }
+        .onTapGesture(count: 2) {
+            onActivate()
+            onOpenDetails()
+        }
+        .draggable(item.url) {
+            dragPreview
+        }
+        .task(id: item.url) {
+            thumbnail = await ThumbnailService.shared.thumbnail(for: item.url)
+        }
+    }
+
+    private var selectionBackground: some ShapeStyle {
+        isSelected ? AnyShapeStyle(Color.accentColor.opacity(0.18)) : AnyShapeStyle(.clear)
+    }
+
+    private var activeBorderColor: Color {
+        isSelected ? .accentColor : .accentColor.opacity(0.7)
+    }
+
+    @ViewBuilder
+    private var dragPreview: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Group {
+                if let thumbnail {
+                    Image(nsImage: thumbnail)
+                        .resizable()
+                        .scaledToFill()
+                } else {
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(.quaternary)
+                }
+            }
+            .frame(width: 160, height: 96)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+
+            Text(item.filename)
+                .font(.caption.weight(.semibold))
+                .lineLimit(1)
+        }
+        .padding(10)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14))
+        .frame(width: 180)
+    }
+}
+
+struct ScreenshotCardView_Previews: PreviewProvider {
+    static var previews: some View {
+        ScreenshotCardView(
+            item: PreviewSampleData.items.first!,
+            width: 220,
+            isFavorite: true,
+            isSelected: false,
+            isActive: true,
+            selectionMode: false,
+            onActivate: {},
+            onToggleFavorite: {},
+            onSelect: {},
+            onCopyImage: {},
+            onCopyPath: {},
+            onOpenDetails: {},
+            onDelete: {},
+            onQuickLook: {},
+            onMove: {},
+            onRename: {},
+            onReveal: {}
+        )
+        .padding()
+        .frame(width: 240)
+    }
+}

--- a/Pinpoint/Shelf/Views/Components/SectionHeaderView.swift
+++ b/Pinpoint/Shelf/Views/Components/SectionHeaderView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct SectionHeaderView: View {
+    let title: String
+    let count: Int
+
+    var body: some View {
+        HStack {
+            Text(title)
+                .font(.headline)
+
+            Spacer()
+
+            Text("\(count)")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+        }
+    }
+}

--- a/Pinpoint/Shelf/Views/Screens/ScreenshotDetailView.swift
+++ b/Pinpoint/Shelf/Views/Screens/ScreenshotDetailView.swift
@@ -1,0 +1,246 @@
+import AppKit
+import SwiftUI
+
+struct ScreenshotDetailView: View {
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var store: ScreenshotStore
+
+    let item: ScreenshotItem
+    let isFavorite: Bool
+    let onToggleFavorite: () -> Void
+    let onQuickLook: () -> Void
+    let onReveal: () -> Void
+    let onCopyImage: () -> Void
+    let onCopyPath: () -> Void
+    let onMove: () -> Void
+    let onDelete: () -> Void
+
+    @State private var image: NSImage?
+    @State private var metadata = ScreenshotDetailMetadata.empty
+    @State private var renameValue = ""
+    @State private var showsRenameSheet = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    previewCard
+                    metadataSection
+                    actionsSection
+                }
+                .padding(20)
+            }
+        }
+        .frame(width: 760, height: 620)
+        .background(.background)
+        .task(id: item.id) {
+            await loadContent()
+        }
+        .sheet(isPresented: $showsRenameSheet) {
+            RenameDetailView(
+                filename: renameValue,
+                onCancel: { showsRenameSheet = false },
+                onSave: { newName in
+                    store.rename(item, to: newName)
+                    showsRenameSheet = false
+                }
+            )
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(item.filename)
+                    .font(.title3.weight(.semibold))
+                    .lineLimit(1)
+
+                Text(item.url.deletingLastPathComponent().lastPathComponent)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Button(action: onToggleFavorite) {
+                Image(systemName: isFavorite ? "star.fill" : "star")
+                    .foregroundStyle(isFavorite ? .yellow : .secondary)
+            }
+            .buttonStyle(.borderless)
+            .help(isFavorite ? "Remove Favorite" : "Favorite")
+
+            Button(action: { dismiss() }) {
+                Image(systemName: "xmark")
+            }
+            .buttonStyle(.borderless)
+            .help("Close")
+        }
+        .padding(16)
+    }
+
+    private var previewCard: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 22)
+                .fill(.quaternary.opacity(0.22))
+
+            if let image {
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFit()
+                    .padding(20)
+            } else {
+                ProgressView()
+                    .controlSize(.regular)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 360)
+        .clipShape(RoundedRectangle(cornerRadius: 22))
+    }
+
+    private var metadataSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Details")
+                .font(.headline)
+
+            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], alignment: .leading, spacing: 12) {
+                detailValue(title: "Captured", value: item.createdAt.formatted(date: .abbreviated, time: .shortened))
+                detailValue(title: "Dimensions", value: metadata.dimensionsText)
+                detailValue(title: "Format", value: item.fileExtension.uppercased())
+                detailValue(title: "File Size", value: metadata.fileSizeText)
+            }
+        }
+    }
+
+    private var actionsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Actions")
+                .font(.headline)
+
+            HStack(spacing: 10) {
+                Button("Quick Look", systemImage: "space", action: onQuickLook)
+                Button("Reveal", systemImage: "finder", action: onReveal)
+                Button("Copy Image", systemImage: "doc.on.doc", action: onCopyImage)
+                Button("Copy Path", systemImage: "link", action: onCopyPath)
+            }
+            .buttonStyle(.bordered)
+
+            HStack(spacing: 10) {
+                Button("Rename", systemImage: "pencil") {
+                    renameValue = item.filename
+                    showsRenameSheet = true
+                }
+                Button("Move", systemImage: "folder", action: onMove)
+                Button("Delete", systemImage: "trash", role: .destructive) {
+                    dismiss()
+                    onDelete()
+                }
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+
+    private func detailValue(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Text(value)
+                .font(.body.weight(.medium))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+        .background(.quaternary.opacity(0.18), in: RoundedRectangle(cornerRadius: 16))
+    }
+
+    private func loadContent() async {
+        image = NSImage(contentsOf: item.url)
+        metadata = ScreenshotDetailMetadata(url: item.url, image: image)
+    }
+}
+
+private struct ScreenshotDetailMetadata {
+    let dimensionsText: String
+    let fileSizeText: String
+
+    static let empty = ScreenshotDetailMetadata(dimensionsText: "Loading…", fileSizeText: "Loading…")
+
+    init(dimensionsText: String, fileSizeText: String) {
+        self.dimensionsText = dimensionsText
+        self.fileSizeText = fileSizeText
+    }
+
+    init(url: URL, image: NSImage?) {
+        if let image {
+            let size = image.size
+            dimensionsText = "\(Int(size.width)) × \(Int(size.height))"
+        } else {
+            dimensionsText = "Unknown"
+        }
+
+        if let values = try? url.resourceValues(forKeys: [.fileSizeKey]),
+           let fileSize = values.fileSize {
+            fileSizeText = ByteCountFormatter.string(fromByteCount: Int64(fileSize), countStyle: .file)
+        } else {
+            fileSizeText = "Unknown"
+        }
+    }
+}
+
+struct ScreenshotDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        ScreenshotDetailView(
+            item: PreviewSampleData.items.first!,
+            isFavorite: true,
+            onToggleFavorite: {},
+            onQuickLook: {},
+            onReveal: {},
+            onCopyImage: {},
+            onCopyPath: {},
+            onMove: {},
+            onDelete: {}
+        )
+        .environmentObject(PreviewSampleData.store)
+    }
+}
+
+private struct RenameDetailView: View {
+    let filename: String
+    let onCancel: () -> Void
+    let onSave: (String) -> Void
+
+    @State private var newName = ""
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Rename Screenshot")
+                .font(.title3.weight(.semibold))
+
+            TextField("Filename", text: $newName)
+                .textFieldStyle(.roundedBorder)
+                .focused($isFocused)
+
+            HStack {
+                Spacer()
+
+                Button("Cancel", action: onCancel)
+                Button("Save") {
+                    onSave(newName)
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(20)
+        .frame(width: 360)
+        .onAppear {
+            newName = filename
+            isFocused = true
+        }
+    }
+}

--- a/Pinpoint/Shelf/Views/Screens/SettingsView.swift
+++ b/Pinpoint/Shelf/Views/Screens/SettingsView.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+struct ShelfSettingsView: View {
+    @EnvironmentObject private var store: ScreenshotStore
+    @EnvironmentObject private var settings: SettingsViewModel
+
+    var body: some View {
+        Form {
+            Section("Screenshot Location") {
+                Toggle("Follow current macOS screenshot location", isOn: Binding(
+                    get: { store.followsSystemScreenshotLocation },
+                    set: { newValue in
+                        store.setFollowsSystemScreenshotLocation(newValue)
+                        settings.syncFromStore(store)
+                    }
+                ))
+
+                LabeledContent("macOS location") {
+                    Text(settings.systemScreenshotFolderPath)
+                        .textSelection(.enabled)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.trailing)
+                }
+
+                if store.followsSystemScreenshotLocation == false {
+                    Button("Use Current macOS Location") {
+                        store.applyCurrentSystemScreenshotLocation()
+                        settings.syncFromStore(store)
+                    }
+                }
+            }
+
+            Section("Watched Folder") {
+                HStack {
+                    Text(settings.watchedFolderPath)
+                        .textSelection(.enabled)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+
+                    Spacer()
+
+                    Button("Choose Folder") {
+                        store.chooseWatchedFolder()
+                        settings.syncFromStore(store)
+                    }
+                    .disabled(store.followsSystemScreenshotLocation)
+                }
+            }
+
+            Section("Launch") {
+                Toggle("Launch at login", isOn: Binding(
+                    get: { store.launchAtLoginEnabled },
+                    set: { newValue in
+                        store.setLaunchAtLogin(enabled: newValue)
+                        settings.syncFromStore(store)
+                    }
+                ))
+            }
+
+            if let error = store.lastErrorMessage {
+                Section {
+                    Text(error)
+                        .foregroundStyle(.red)
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .padding()
+        .onAppear {
+            settings.syncFromStore(store)
+        }
+    }
+}
+
+struct ShelfSettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        let store = ScreenshotStore()
+        let settings = SettingsViewModel()
+        settings.bind(to: store)
+
+        return ShelfSettingsView()
+            .environmentObject(store)
+            .environmentObject(settings)
+            .frame(width: 460, height: 280)
+    }
+}

--- a/Pinpoint/Shelf/Views/Screens/ShelfView.swift
+++ b/Pinpoint/Shelf/Views/Screens/ShelfView.swift
@@ -1,0 +1,578 @@
+import AppKit
+import SwiftUI
+
+struct ShelfView: View {
+    @Environment(\.openWindow) private var openWindow
+    @EnvironmentObject private var store: ScreenshotStore
+    @State private var renameTarget: ScreenshotItem?
+    @State private var selectionMode = false
+    @State private var selectedIDs = Set<URL>()
+    @State private var activeItemID: URL?
+    @State private var keyMonitor: Any?
+    private let gridSpacing: CGFloat = 14
+    private let gridPadding: CGFloat = 16
+    private let gridColumnCount = 2
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+
+            Divider()
+
+            content
+        }
+        .background(.background)
+        .sheet(item: $renameTarget) { item in
+            RenameScreenshotView(
+                filename: item.filename,
+                onCancel: { renameTarget = nil },
+                onSave: { newName in
+                    store.rename(item, to: newName)
+                    renameTarget = nil
+                }
+            )
+        }
+        .onAppear(perform: installKeyboardMonitor)
+        .onDisappear(perform: removeKeyboardMonitor)
+        .onChange(of: visibleItems.map(\.id), initial: true) { _, _ in
+            syncActiveItem()
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("SnapShelf")
+                        .font(.title3.weight(.semibold))
+
+                    Text(store.watchedFolderURL.lastPathComponent)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                if selectionMode {
+                    Button("Done") {
+                        selectionMode = false
+                        selectedIDs.removeAll()
+                    }
+                    .buttonStyle(.borderless)
+                } else {
+                    Button("Select") {
+                        selectionMode = true
+                    }
+                    .buttonStyle(.borderless)
+                }
+
+                Button {
+                    openSettingsWindow()
+                } label: {
+                    Image(systemName: "gearshape")
+                }
+                .buttonStyle(.borderless)
+
+                Button {
+                    Task { await store.refresh() }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .buttonStyle(.borderless)
+            }
+
+            HStack {
+                Menu {
+                    ForEach(ScreenshotDateFilter.allCases) { filter in
+                        Button {
+                            store.selectedDateFilter = filter
+                        } label: {
+                            if store.selectedDateFilter == filter {
+                                Label(filter.title, systemImage: "checkmark")
+                            } else {
+                                Text(filter.title)
+                            }
+                        }
+                    }
+                } label: {
+                    Label(store.selectedDateFilter.title, systemImage: "calendar")
+                }
+                .menuStyle(.borderlessButton)
+
+                Button {
+                    store.showsFavoritesOnly.toggle()
+                } label: {
+                    Label("Favorites", systemImage: store.showsFavoritesOnly ? "star.fill" : "star")
+                        .foregroundStyle(store.showsFavoritesOnly ? .yellow : .secondary)
+                }
+                .buttonStyle(.borderless)
+                .help("Show Favorites Only")
+
+                Spacer()
+
+                Menu {
+                    ForEach(ScreenshotSortOrder.allCases) { order in
+                        Button {
+                            store.selectedSortOrder = order
+                        } label: {
+                            if store.selectedSortOrder == order {
+                                Label(order.title, systemImage: "checkmark")
+                            } else {
+                                Text(order.title)
+                            }
+                        }
+                    }
+                } label: {
+                    Label(store.selectedSortOrder.title, systemImage: "arrow.up.arrow.down")
+                }
+                .menuStyle(.borderlessButton)
+            }
+            .font(.subheadline)
+
+            if selectionMode, selectedItems.isEmpty == false {
+                selectionBar
+            }
+        }
+        .padding(16)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if store.isLoading && store.screenshots.isEmpty {
+            ProgressView("Loading screenshots…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if store.groupedScreenshots.isEmpty {
+            VStack(spacing: 12) {
+                ContentUnavailableView(
+                    "No screenshots found",
+                    systemImage: "photo.on.rectangle.angled",
+                    description: Text("Drop screenshots into \(store.watchedFolderURL.lastPathComponent) or change the watched folder in Settings.")
+                )
+
+                if let error = store.lastErrorMessage {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding()
+        } else {
+            GeometryReader { proxy in
+                let cardWidth = gridCardWidth(for: proxy.size.width)
+                let columns = gridColumns(for: cardWidth)
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 22) {
+                        if let error = store.lastErrorMessage {
+                            Text(error)
+                                .font(.caption)
+                                .foregroundStyle(.red)
+                        }
+
+                        ForEach(store.groupedScreenshots, id: \.section.id) { group in
+                            if store.selectedDateFilter == .all {
+                                VStack(alignment: .leading, spacing: 12) {
+                                    SectionHeaderView(title: group.section.title, count: group.items.count)
+                                    screenshotGrid(items: group.items, columns: columns, cardWidth: cardWidth)
+                                }
+                            }
+                        }
+
+                        if store.selectedDateFilter != .all {
+                            screenshotGrid(items: store.filteredScreenshots, columns: columns, cardWidth: cardWidth)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(gridPadding)
+                }
+            }
+        }
+    }
+
+    private var selectedItems: [ScreenshotItem] {
+        store.screenshots.filter { selectedIDs.contains($0.id) }
+    }
+
+    private var visibleItems: [ScreenshotItem] {
+        store.filteredScreenshots
+    }
+
+    private var selectionBar: some View {
+        HStack(spacing: 12) {
+            Label(selectionSummaryText, systemImage: "checkmark.circle.fill")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            Spacer(minLength: 0)
+
+            HStack(spacing: 6) {
+                MultiFileDragButton(items: selectedItems, compact: true)
+                    .frame(width: 30, height: 30)
+
+                Button {
+                    store.quickLook(selectedItems, current: selectedItems.first)
+                } label: {
+                    Image(systemName: "space")
+                }
+                .help("Quick Look")
+                .keyboardShortcut(.space, modifiers: [])
+
+                Button {
+                    store.copyFiles(selectedItems)
+                } label: {
+                    Image(systemName: "doc.on.doc")
+                }
+                .help("Copy Files")
+                .keyboardShortcut("c")
+
+                Button {
+                    let items = selectedItems
+                    selectedIDs.removeAll()
+                    selectionMode = false
+                    store.move(items)
+                } label: {
+                    Image(systemName: "folder")
+                }
+                .help("Move Selection")
+
+                Menu {
+                    Button(allSelectedItemsAreFavorites ? "Remove Favorites" : "Favorite Selection", systemImage: allSelectedItemsAreFavorites ? "star.slash" : "star") {
+                        store.setFavorite(allSelectedItemsAreFavorites == false, for: selectedItems)
+                    }
+
+                    Divider()
+
+                    Button("Copy Paths", systemImage: "link") {
+                        store.copyPaths(selectedItems)
+                    }
+
+                    Button("Move to Folder", systemImage: "folder") {
+                        let items = selectedItems
+                        selectedIDs.removeAll()
+                        selectionMode = false
+                        store.move(items)
+                    }
+
+                    Button("Reveal in Finder", systemImage: "finder") {
+                        store.revealInFinder(selectedItems)
+                    }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                }
+                .help("More Actions")
+
+                Button(role: .destructive) {
+                    let items = selectedItems
+                    selectedIDs.removeAll()
+                    selectionMode = false
+                    store.delete(items)
+                } label: {
+                    Image(systemName: "trash")
+                }
+                .help("Delete Selection")
+                .keyboardShortcut(.delete, modifiers: [])
+
+                Button {
+                    selectedIDs.removeAll()
+                } label: {
+                    Image(systemName: "xmark")
+                }
+                .help("Clear Selection")
+            }
+            .buttonStyle(.bordered)
+        }
+        .font(.caption)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: 14))
+    }
+
+    private var selectionSummaryText: String {
+        selectedItems.count == 1 ? "1 selected" : "\(selectedItems.count) selected"
+    }
+
+    private func toggleSelection(for item: ScreenshotItem) {
+        activeItemID = item.id
+
+        if selectedIDs.contains(item.id) {
+            selectedIDs.remove(item.id)
+        } else {
+            selectedIDs.insert(item.id)
+        }
+    }
+
+    private func installKeyboardMonitor() {
+        guard keyMonitor == nil else {
+            return
+        }
+
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            handleKeyEvent(event)
+        }
+        syncActiveItem()
+    }
+
+    private func removeKeyboardMonitor() {
+        guard let keyMonitor else {
+            return
+        }
+
+        NSEvent.removeMonitor(keyMonitor)
+        self.keyMonitor = nil
+    }
+
+    private func handleKeyEvent(_ event: NSEvent) -> NSEvent? {
+        guard shouldHandleKeyEvent else {
+            return event
+        }
+
+        let commandPressed = event.modifierFlags.intersection(.deviceIndependentFlagsMask).contains(.command)
+
+        if commandPressed, event.charactersIgnoringModifiers?.lowercased() == "c" {
+            copyFocusedItems()
+            return nil
+        }
+
+        if event.charactersIgnoringModifiers?.lowercased() == "f" {
+            toggleFavoriteFocusedItems()
+            return nil
+        }
+
+        switch event.keyCode {
+        case 123:
+            moveActiveItem(horizontalStep: -1)
+            return nil
+        case 124:
+            moveActiveItem(horizontalStep: 1)
+            return nil
+        case 125:
+            moveActiveItem(verticalStep: gridColumnCount)
+            return nil
+        case 126:
+            moveActiveItem(verticalStep: -gridColumnCount)
+            return nil
+        case 49:
+            quickLookFocusedItem()
+            return nil
+        case 36, 76:
+            revealFocusedItem()
+            return nil
+        case 51, 117:
+            deleteFocusedItems()
+            return nil
+        default:
+            return event
+        }
+    }
+
+    private var shouldHandleKeyEvent: Bool {
+        guard visibleItems.isEmpty == false else {
+            return false
+        }
+
+        if renameTarget != nil {
+            return false
+        }
+
+        if let firstResponder = NSApp.keyWindow?.firstResponder, firstResponder is NSTextView {
+            return false
+        }
+
+        return true
+    }
+
+    private func syncActiveItem() {
+        guard visibleItems.isEmpty == false else {
+            activeItemID = nil
+            return
+        }
+
+        if let activeItemID, visibleItems.contains(where: { $0.id == activeItemID }) {
+            return
+        }
+
+        activeItemID = visibleItems.first?.id
+    }
+
+    private func moveActiveItem(horizontalStep: Int = 0, verticalStep: Int = 0) {
+        guard visibleItems.isEmpty == false else {
+            return
+        }
+
+        let currentIndex = visibleItems.firstIndex { $0.id == activeItemID } ?? 0
+        let rawTarget = currentIndex + horizontalStep + verticalStep
+        let clampedIndex = min(max(rawTarget, 0), visibleItems.count - 1)
+        activeItemID = visibleItems[clampedIndex].id
+    }
+
+    private func gridCardWidth(for totalWidth: CGFloat) -> CGFloat {
+        let contentWidth = max(totalWidth - (gridPadding * 2), 0)
+        let totalSpacing = CGFloat(gridColumnCount - 1) * gridSpacing
+        return floor((contentWidth - totalSpacing) / CGFloat(gridColumnCount))
+    }
+
+    private func gridColumns(for cardWidth: CGFloat) -> [GridItem] {
+        Array(repeating: GridItem(.fixed(cardWidth), spacing: gridSpacing), count: gridColumnCount)
+    }
+
+    @ViewBuilder
+    private func screenshotGrid(items: [ScreenshotItem], columns: [GridItem], cardWidth: CGFloat) -> some View {
+        LazyVGrid(columns: columns, alignment: .leading, spacing: gridSpacing) {
+            ForEach(items) { item in
+                ScreenshotCardView(
+                    item: item,
+                    width: cardWidth,
+                    isFavorite: store.isFavorite(item),
+                    isSelected: selectedIDs.contains(item.id),
+                    isActive: activeItemID == item.id,
+                    selectionMode: selectionMode,
+                    onActivate: { activeItemID = item.id },
+                    onToggleFavorite: { store.toggleFavorite(item) },
+                    onSelect: { toggleSelection(for: item) },
+                    onCopyImage: { store.copyImage(item) },
+                    onCopyPath: { store.copyPaths([item]) },
+                    onOpenDetails: { openDetailWindow(for: item) },
+                    onDelete: { store.delete(item) },
+                    onQuickLook: { store.quickLook(item) },
+                    onMove: { store.move(item) },
+                    onRename: {
+                        renameTarget = item
+                    },
+                    onReveal: { store.revealInFinder(item) }
+                )
+            }
+        }
+    }
+
+    private var focusedItem: ScreenshotItem? {
+        visibleItems.first { $0.id == activeItemID } ?? visibleItems.first
+    }
+
+    private var allSelectedItemsAreFavorites: Bool {
+        selectedItems.isEmpty == false && selectedItems.allSatisfy(store.isFavorite(_:))
+    }
+
+    private func copyFocusedItems() {
+        if selectionMode, selectedItems.isEmpty == false {
+            store.copyFiles(selectedItems)
+            return
+        }
+
+        guard let focusedItem else {
+            return
+        }
+
+        store.copyFiles([focusedItem])
+    }
+
+    private func quickLookFocusedItem() {
+        if selectionMode, selectedItems.isEmpty == false {
+            store.quickLook(selectedItems, current: focusedItem ?? selectedItems.first)
+            return
+        }
+
+        guard let focusedItem else {
+            return
+        }
+
+        store.quickLook(focusedItem)
+    }
+
+    private func revealFocusedItem() {
+        if selectionMode, selectedItems.isEmpty == false {
+            store.revealInFinder(selectedItems)
+            return
+        }
+
+        guard let focusedItem else {
+            return
+        }
+
+        store.revealInFinder(focusedItem)
+    }
+
+    private func deleteFocusedItems() {
+        if selectionMode, selectedItems.isEmpty == false {
+            let items = selectedItems
+            selectedIDs.removeAll()
+            selectionMode = false
+            store.delete(items)
+            return
+        }
+
+        guard let focusedItem else {
+            return
+        }
+
+        activeItemID = nil
+        store.delete(focusedItem)
+    }
+
+    private func toggleFavoriteFocusedItems() {
+        if selectionMode, selectedItems.isEmpty == false {
+            store.setFavorite(allSelectedItemsAreFavorites == false, for: selectedItems)
+            return
+        }
+
+        guard let focusedItem else {
+            return
+        }
+
+        store.toggleFavorite(focusedItem)
+    }
+
+    private func openSettingsWindow() {
+        NSApp.activate(ignoringOtherApps: true)
+        NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+    }
+
+    private func openDetailWindow(for item: ScreenshotItem) {
+        NSApp.activate(ignoringOtherApps: true)
+        openWindow(id: "screenshot-detail", value: item.id)
+    }
+}
+
+private struct RenameScreenshotView: View {
+    let filename: String
+    let onCancel: () -> Void
+    let onSave: (String) -> Void
+
+    @State private var newName = ""
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Rename Screenshot")
+                .font(.title3.weight(.semibold))
+
+            TextField("Filename", text: $newName)
+                .textFieldStyle(.roundedBorder)
+                .focused($isFocused)
+
+            HStack {
+                Spacer()
+
+                Button("Cancel", action: onCancel)
+                Button("Save") {
+                    onSave(newName)
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(20)
+        .frame(width: 360)
+        .onAppear {
+            newName = filename
+            isFocused = true
+        }
+    }
+}
+
+struct ShelfView_Previews: PreviewProvider {
+    static var previews: some View {
+        ShelfView()
+            .environmentObject(PreviewSampleData.store)
+            .frame(width: 440, height: 620)
+    }
+}

--- a/Pinpoint/ShelfWindowController.swift
+++ b/Pinpoint/ShelfWindowController.swift
@@ -1,0 +1,41 @@
+import AppKit
+import SwiftUI
+
+/// Hosts the screenshot library (SnapShelf's `ShelfView`) in a plain AppKit
+/// window, owning its store/view-model and starting the folder watcher.
+///
+/// Phase 1 of the SnapShelf → Pinpoint merge: the shelf is reachable from the
+/// menu without touching the capture/editor flows. (SnapShelf's own
+/// `MenuBarExtra`/`Settings`/`WindowGroup` scenes are intentionally not brought
+/// over — Pinpoint owns the menu bar and app lifecycle.)
+@MainActor
+final class ShelfWindowController: NSWindowController {
+    private let store = ScreenshotStore()
+    private let settingsViewModel = SettingsViewModel()
+
+    init() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 440, height: 620),
+            styleMask: [.titled, .closable, .resizable, .miniaturizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Étagère"
+        window.isReleasedWhenClosed = false
+        window.setFrameAutosaveName("PinpointShelfWindow")
+
+        let root = ShelfView()
+            .environmentObject(store)
+            .environmentObject(settingsViewModel)
+        window.contentView = NSHostingView(rootView: root)
+
+        super.init(window: window)
+        window.center()
+
+        settingsViewModel.bind(to: store)
+        Task { await store.start() }
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+}


### PR DESCRIPTION
Première phase de la fusion SnapShelf → Pinpoint (sur 4).

- Porte le navigateur de screenshots de SnapShelf dans la cible Pinpoint sous `Pinpoint/Shelf/` (Models, Services, Stores, ViewModels, Views, Utilities — aucune dépendance SPM).
- Scènes `@main`/`AppDelegate`/`MenuBarExtra` de SnapShelf **non** reprises : Pinpoint pilote le cycle de vie. `SettingsView` de SnapShelf renommé `ShelfSettingsView` (collision).
- Nouveau `ShelfWindowController` (possède `ScreenshotStore` + `SettingsViewModel`, lance le watcher FSEvents), ouvert via une entrée de menu **« Étagère… »**.
- **Non-sandboxé** : entitlements sandbox non repris. Flows capture/éditeur **intacts**.

## Vérification
Build + CI verts. **Runtime confirmé** : l'étagère s'ouvre et liste les screenshots récents.

Limites connues (Phase 2) : fenêtre détail (double-clic) pas encore portée ; étagère en fenêtre titrée (pas encore popover) ; réglages étagère pas encore fusionnés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)