### PR TITLE
Bundle id app.croustibat.Pinpoint + version 0.2.0

### DIFF
--- a/Pinpoint/Info.plist
+++ b/Pinpoint/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ Dans Xcode :
    annuler) → l’éditeur s’ouvre avec la région capturée.
 
 > Astuce : grâce au `DEVELOPMENT_TEAM` fixe + au bundle id stable
-> (`app.pinpoint.Pinpoint`), macOS mémorise l’autorisation d’un build à l’autre.
+> (`app.croustibat.Pinpoint`), macOS mémorise l’autorisation d’un build à l’autre.
 > Si une autorisation reste « bloquée » après un changement d’identité, repars à zéro :
-> `tccutil reset ScreenCapture app.pinpoint.Pinpoint`, puis relance et ré-accorde.
+> `tccutil reset ScreenCapture app.croustibat.Pinpoint`, puis relance et ré-accorde.
 
 ## Structure
 

--- a/project.yml
+++ b/project.yml
@@ -1,6 +1,6 @@
 name: Pinpoint
 options:
-  bundleIdPrefix: app.pinpoint
+  bundleIdPrefix: app.croustibat
   createIntermediateGroups: true
   deploymentTarget:
     macOS: "15.0"
@@ -28,9 +28,9 @@ targets:
         NSHumanReadableCopyright: "© 2026 Baptiste Bouillot"
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: app.pinpoint.Pinpoint
-        MARKETING_VERSION: "0.1.0"
-        CURRENT_PROJECT_VERSION: "1"
+        PRODUCT_BUNDLE_IDENTIFIER: app.croustibat.Pinpoint
+        MARKETING_VERSION: "0.2.0"
+        CURRENT_PROJECT_VERSION: "2"
         GENERATE_INFOPLIST_FILE: NO
         SWIFT_VERSION: "5.0"
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
- Bundle identifier → `app.croustibat.Pinpoint` (préfixe `app.croustibat`).
- Version → **0.2.0** (build 2).

⚠️ Le changement de bundle id fait que macOS voit une nouvelle app → l'autorisation « Enregistrement de l'écran » devra être ré-accordée une fois.

🤖 Generated with [Claude Code](https://claude.com/claude-code)