### PR TITLE
Corrige la version remise à 1.0 par XcodeGen

### DIFF
--- a/Pinpoint/Info.plist
+++ b/Pinpoint/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.2.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>

--- a/project.yml
+++ b/project.yml
@@ -23,6 +23,11 @@ targets:
       properties:
         CFBundleDisplayName: Pinpoint
         CFBundleName: Pinpoint
+        # Version comes from the build settings below. Must be declared here,
+        # otherwise `xcodegen generate` rewrites Info.plist with its defaults
+        # (CFBundleShortVersionString=1.0 / CFBundleVersion=1) on every run.
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
         # Menu-bar only app: no Dock icon, no main window.
         LSUIElement: true
         NSHumanReadableCopyright: "© 2026 Baptiste Bouillot"


### PR DESCRIPTION
Le bloc `info:` de project.yml fait régénérer Info.plist par XcodeGen ; faute de clés de version listées, il réécrivait 1.0/1 à chaque `xcodegen generate` → tous les builds sortaient en 1.0. Les versions sont maintenant déclarées dans `info.properties` ($(MARKETING_VERSION)/$(CURRENT_PROJECT_VERSION)). Vérifié : app en 0.2.0 (build 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)