### PR TITLE
Landing : Vercel Web Analytics

### DIFF
--- a/landing/package-lock.json
+++ b/landing/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tailwindcss/postcss": "^4.3.1",
+        "@vercel/analytics": "^2.0.1",
         "astro": "^6.4.8",
         "tailwindcss": "^4.3.1"
       }
@@ -1990,6 +1991,48 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
       "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "license": "ISC"
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/anymatch": {
       "version": "3.1.3",

--- a/landing/package.json
+++ b/landing/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.3.1",
+    "@vercel/analytics": "^2.0.1",
     "astro": "^6.4.8",
     "tailwindcss": "^4.3.1"
   }

--- a/landing/src/layouts/Base.astro
+++ b/landing/src/layouts/Base.astro
@@ -1,5 +1,6 @@
 ---
 import '../styles/global.css';
+import Analytics from '@vercel/analytics/astro';
 import type { Lang } from '../i18n';
 
 interface Props {
@@ -29,6 +30,8 @@ const canonical = new URL(Astro.url.pathname, Astro.site);
     <meta property="og:image" content="/icon.png" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="theme-color" content="#0a0a0c" />
+
+    <Analytics />
   </head>
   <body class="min-h-screen overflow-x-hidden selection:bg-brand/30">
     <slot />


### PR DESCRIPTION
Ajoute le tracking des visites (Vercel Web Analytics, cookieless).

- `@vercel/analytics` + composant `<Analytics />` dans `Base.astro` (EN + FR)
- Web Analytics activé sur le projet Vercel `pinpoint`