### PR TITLE
Étagère : passerelle « Éditer dans Pinpoint » + titres personnalisés

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ Package.resolved
 
 # Throwaway demo page used only to stage hero screenshots
 .capture-demo/
+
+# Throwaway Remotion project for the demo GIF
+.demo-remotion/

--- a/Pinpoint/AppDelegate.swift
+++ b/Pinpoint/AppDelegate.swift
@@ -5,6 +5,9 @@ import KeyboardShortcuts
 extension Notification.Name {
     /// Posted by the shelf to open Pinpoint's unified settings window.
     static let pinpointOpenSettings = Notification.Name("pinpointOpenSettings")
+    /// Posted by the shelf to reopen one of its screenshots in the annotation
+    /// editor, as if it had just been captured. The file `URL` rides in `object`.
+    static let pinpointOpenInEditor = Notification.Name("pinpointOpenInEditor")
 }
 
 @MainActor
@@ -32,6 +35,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         // unified settings window instead.
         center.addObserver(self, selector: #selector(openSettings),
                            name: .pinpointOpenSettings, object: nil)
+        // The shelf's "Edit in Pinpoint" action posts this with a file URL so an
+        // existing screenshot can be annotated through the normal editor flow.
+        center.addObserver(self, selector: #selector(openInEditor(_:)),
+                           name: .pinpointOpenInEditor, object: nil)
         // Menu-bar app (LSUIElement = accessory): become a regular app while a
         // content window is on screen, so it shows in the Dock and ⌘Tab, and
         // drop back to accessory once everything is closed.
@@ -207,6 +214,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         }
     }
 
+    /// Reopens an existing shelf screenshot in the editor as a fresh capture:
+    /// loads the file, records it in the capture history, and presents the editor.
+    @objc private func openInEditor(_ notification: Notification) {
+        guard let url = notification.object as? URL else { return }
+        guard let image = Self.loadImage(at: url) else {
+            presentImportError()
+            return
+        }
+        let record = CaptureHistory.shared.add(image: image)
+        presentEditor(image: image, recordID: record?.id)
+    }
+
+    /// Loads a bitmap at its native pixel size. `NSImage(contentsOf:)` would honor
+    /// the file's DPI, shrinking Retina screenshots (e.g. ⌘⇧4) to half size; this
+    /// keeps the editor canvas at full resolution, like `CaptureHistory.image(for:)`.
+    private static func loadImage(at url: URL) -> NSImage? {
+        guard let data = try? Data(contentsOf: url),
+              let rep = NSBitmapImageRep(data: data) else { return nil }
+        let image = NSImage(size: NSSize(width: rep.pixelsWide, height: rep.pixelsHigh))
+        image.addRepresentation(rep)
+        return image
+    }
+
     @MainActor
     private func presentEditor(image: NSImage, recordID: UUID?,
                                pins: [Pin] = [], shapes: [Markup] = [], context: String = "") {
@@ -234,6 +264,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         alert.informativeText = String(
             localized: "capture.error.body",
             defaultValue: "\(error.localizedDescription)\n\nMake sure Pinpoint has the “Screen Recording” permission in System Settings ▸ Privacy & Security, then relaunch the app."
+        )
+        alert.alertStyle = .warning
+        NSApp.activate(ignoringOtherApps: true)
+        alert.runModal()
+    }
+
+    @MainActor
+    private func presentImportError() {
+        let alert = NSAlert()
+        alert.messageText = String(localized: "shelf.openInEditor.error.title",
+                                   defaultValue: "Couldn’t open this screenshot")
+        alert.informativeText = String(
+            localized: "shelf.openInEditor.error.body",
+            defaultValue: "Pinpoint couldn’t read the image file. It may have been moved or deleted."
         )
         alert.alertStyle = .warning
         NSApp.activate(ignoringOtherApps: true)

--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -1,6 +1,38 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "Double-click to edit the title" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Double-cliquez pour modifier le titre" } }
+      }
+    },
+    "Edit in Pinpoint" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Éditer dans Pinpoint" } }
+      }
+    },
+    "Edit title…" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Modifier le titre…" } }
+      }
+    },
+    "Title" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Titre" } }
+      }
+    },
+    "shelf.openInEditor.error.body" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Pinpoint couldn’t read the image file. It may have been moved or deleted." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Pinpoint n’a pas pu lire le fichier image. Il a peut-être été déplacé ou supprimé." } }
+      }
+    },
+    "shelf.openInEditor.error.title" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Couldn’t open this screenshot" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Impossible d’ouvrir cette capture" } }
+      }
+    },
     "(no description)" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "(sans description)" } }

--- a/Pinpoint/ScreenshotDetailWindowController.swift
+++ b/Pinpoint/ScreenshotDetailWindowController.swift
@@ -63,6 +63,9 @@ private struct ScreenshotDetailContainer: View {
             onCopyPath: { store.copyPaths([item]) },
             onMove: { store.move(item) },
             onDelete: { store.delete(item) },
+            onOpenInPinpoint: {
+                NotificationCenter.default.post(name: .pinpointOpenInEditor, object: item.url)
+            },
             onClose: onClose
         )
     }

--- a/Pinpoint/Shelf/Stores/ScreenshotStore.swift
+++ b/Pinpoint/Shelf/Stores/ScreenshotStore.swift
@@ -19,6 +19,7 @@ final class ScreenshotStore: ObservableObject {
     @Published private(set) var launchAtLoginEnabled = false
     @Published private(set) var followsSystemScreenshotLocation: Bool
     @Published private(set) var favoritePaths: Set<String>
+    @Published private(set) var customTitles: [String: String]
     @Published var lastErrorMessage: String?
 
     private let service = ScreenshotService()
@@ -27,11 +28,13 @@ final class ScreenshotStore: ObservableObject {
     private let watchedFolderBookmarkKey = "watchedFolderBookmark"
     private let followSystemLocationKey = "followSystemScreenshotLocation"
     private let favoritePathsKey = "favoriteScreenshotPaths"
+    private let customTitlesKey = "customScreenshotTitles"
 
     init() {
         let followsSystemScreenshotLocation = defaults.bool(forKey: followSystemLocationKey)
         self.followsSystemScreenshotLocation = followsSystemScreenshotLocation
         self.favoritePaths = Set(defaults.stringArray(forKey: favoritePathsKey) ?? [])
+        self.customTitles = (defaults.dictionary(forKey: customTitlesKey) as? [String: String]) ?? [:]
         self.watchedFolderURL = followsSystemScreenshotLocation
             ? ScreenshotLocationResolver.currentLocation()
             : (Self.loadPersistedFolder() ?? Self.defaultWatchedFolder())
@@ -69,6 +72,7 @@ final class ScreenshotStore: ObservableObject {
         do {
             screenshots = try await service.scanFolder(at: watchedFolderURL)
             pruneMissingFavorites()
+            pruneMissingCustomTitles()
             lastErrorMessage = nil
         } catch {
             screenshots = []
@@ -126,6 +130,7 @@ final class ScreenshotStore: ObservableObject {
             do {
                 let destinationURL = try await service.move(item, to: folderURL)
                 updateFavoritePath(from: item.url.path, to: destinationURL.path)
+                updateCustomTitlePath(from: item.url.path, to: destinationURL.path)
                 await ThumbnailService.shared.removeCachedThumbnail(for: item.url)
                 await refresh()
             } catch {
@@ -155,6 +160,7 @@ final class ScreenshotStore: ObservableObject {
                 do {
                     let destinationURL = try await service.move(item, to: folderURL)
                     updateFavoritePath(from: item.url.path, to: destinationURL.path)
+                    updateCustomTitlePath(from: item.url.path, to: destinationURL.path)
                     await ThumbnailService.shared.removeCachedThumbnail(for: item.url)
                 } catch {
                     lastErrorMessage = String(localized: "store.error.move", defaultValue: "Couldn’t move \(item.filename).")
@@ -170,6 +176,7 @@ final class ScreenshotStore: ObservableObject {
             do {
                 let destinationURL = try await service.rename(item, to: newName)
                 updateFavoritePath(from: item.url.path, to: destinationURL.path)
+                updateCustomTitlePath(from: item.url.path, to: destinationURL.path)
                 await ThumbnailService.shared.removeCachedThumbnail(for: item.url)
                 await refresh()
             } catch {
@@ -253,12 +260,39 @@ final class ScreenshotStore: ObservableObject {
         objectWillChange.send()
     }
 
+    /// The custom display title for an item, if one was set (independent of the
+    /// file name on disk).
+    func customTitle(for item: ScreenshotItem) -> String? {
+        customTitles[item.url.path]
+    }
+
+    /// The title to show in the UI: the custom title if set, otherwise the file
+    /// name.
+    func displayTitle(for item: ScreenshotItem) -> String {
+        let custom = customTitles[item.url.path]?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (custom?.isEmpty == false ? custom : nil) ?? item.filename
+    }
+
+    /// Sets a custom display title. An empty title — or one equal to the file
+    /// name — clears it, reverting to the file name. Never touches the file.
+    func setCustomTitle(_ title: String, for item: ScreenshotItem) {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty || trimmed == item.filename {
+            customTitles.removeValue(forKey: item.url.path)
+        } else {
+            customTitles[item.url.path] = trimmed
+        }
+        persistCustomTitles()
+        objectWillChange.send()
+    }
+
     func delete(_ items: [ScreenshotItem]) {
         Task {
             for item in items {
                 do {
                     try await service.delete(item)
                     favoritePaths.remove(item.url.path)
+                    customTitles.removeValue(forKey: item.url.path)
                     await ThumbnailService.shared.removeCachedThumbnail(for: item.url)
                 } catch {
                     lastErrorMessage = String(localized: "store.error.update", defaultValue: "Couldn’t update \(item.filename).")
@@ -266,6 +300,7 @@ final class ScreenshotStore: ObservableObject {
             }
 
             persistFavoritePaths()
+            persistCustomTitles()
             await refresh()
         }
     }
@@ -343,11 +378,13 @@ final class ScreenshotStore: ObservableObject {
             } else {
                 updated.removeValue(forKey: url)
                 favoritePaths.remove(url.path)
+                customTitles.removeValue(forKey: url.path)
             }
         }
 
         screenshots = updated.values.sorted { $0.createdAt > $1.createdAt }
         persistFavoritePaths()
+        persistCustomTitles()
         lastErrorMessage = nil
     }
 
@@ -361,6 +398,15 @@ final class ScreenshotStore: ObservableObject {
         persistFavoritePaths()
     }
 
+    private func updateCustomTitlePath(from oldPath: String, to newPath: String) {
+        guard let title = customTitles.removeValue(forKey: oldPath) else {
+            return
+        }
+
+        customTitles[newPath] = title
+        persistCustomTitles()
+    }
+
     private func pruneMissingFavorites() {
         let pruned = favoritePaths.filter { FileManager.default.fileExists(atPath: $0) }
         guard pruned != favoritePaths else {
@@ -371,8 +417,22 @@ final class ScreenshotStore: ObservableObject {
         persistFavoritePaths()
     }
 
+    private func pruneMissingCustomTitles() {
+        let pruned = customTitles.filter { FileManager.default.fileExists(atPath: $0.key) }
+        guard pruned.count != customTitles.count else {
+            return
+        }
+
+        customTitles = pruned
+        persistCustomTitles()
+    }
+
     private func persistFavoritePaths() {
         defaults.set(Array(favoritePaths).sorted(), forKey: favoritePathsKey)
+    }
+
+    private func persistCustomTitles() {
+        defaults.set(customTitles, forKey: customTitlesKey)
     }
 
     private func persistWatchedFolder(_ url: URL) {

--- a/Pinpoint/Shelf/Views/Components/ScreenshotCardView.swift
+++ b/Pinpoint/Shelf/Views/Components/ScreenshotCardView.swift
@@ -3,12 +3,15 @@ import SwiftUI
 
 struct ScreenshotCardView: View {
     let item: ScreenshotItem
+    let title: String
     let width: CGFloat
     let isFavorite: Bool
     let isSelected: Bool
     let isActive: Bool
     let selectionMode: Bool
     let onActivate: () -> Void
+    let onEditInPinpoint: () -> Void
+    let onSetTitle: (String) -> Void
     let onToggleFavorite: () -> Void
     let onSelect: () -> Void
     let onCopyImage: () -> Void
@@ -21,6 +24,9 @@ struct ScreenshotCardView: View {
     let onReveal: () -> Void
 
     @State private var thumbnail: NSImage?
+    @State private var isEditingTitle = false
+    @State private var draftTitle = ""
+    @FocusState private var titleFieldFocused: Bool
 
     private var thumbnailWidth: CGFloat {
         max(width - 16, 0)
@@ -46,28 +52,45 @@ struct ScreenshotCardView: View {
             .frame(height: 126)
             .clipShape(RoundedRectangle(cornerRadius: 14))
             .overlay(alignment: .topTrailing) {
-                Menu {
-                    Button("Open details", systemImage: "rectangle.portrait.and.arrow.right", action: onOpenDetails)
-                    Divider()
-                    Button("Quick Look", systemImage: "space", action: onQuickLook)
-                    Divider()
-                    Button(isFavorite ? String(localized: "Remove from favorites") : String(localized: "Add to favorites"), systemImage: isFavorite ? "star.slash" : "star", action: onToggleFavorite)
-                    Divider()
-                    Button("Copy image", systemImage: "doc.on.doc", action: onCopyImage)
-                    Button("Copy file path", systemImage: "link", action: onCopyPath)
-                    Divider()
-                    Button("Rename", systemImage: "pencil", action: onRename)
-                    Button("Move", systemImage: "folder", action: onMove)
-                    Button("Reveal in Finder", systemImage: "finder", action: onReveal)
-                    Divider()
-                    Button("Delete", systemImage: "trash", role: .destructive, action: onDelete)
-                } label: {
-                    Image(systemName: "ellipsis.circle.fill")
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundStyle(.white, .black.opacity(0.45))
-                        .padding(8)
+                HStack(spacing: 0) {
+                    if !selectionMode {
+                        Button(action: onEditInPinpoint) {
+                            Image(systemName: "pin.circle.fill")
+                                .font(.system(size: 16, weight: .semibold))
+                                .foregroundStyle(.white, .black.opacity(0.45))
+                                .padding(.vertical, 8)
+                                .padding(.leading, 8)
+                        }
+                        .buttonStyle(.plain)
+                        .help("Edit in Pinpoint")
+                    }
+
+                    Menu {
+                        Button("Edit in Pinpoint", systemImage: "pin.fill", action: onEditInPinpoint)
+                        Divider()
+                        Button("Open details", systemImage: "rectangle.portrait.and.arrow.right", action: onOpenDetails)
+                        Divider()
+                        Button("Quick Look", systemImage: "space", action: onQuickLook)
+                        Divider()
+                        Button(isFavorite ? String(localized: "Remove from favorites") : String(localized: "Add to favorites"), systemImage: isFavorite ? "star.slash" : "star", action: onToggleFavorite)
+                        Divider()
+                        Button("Copy image", systemImage: "doc.on.doc", action: onCopyImage)
+                        Button("Copy file path", systemImage: "link", action: onCopyPath)
+                        Divider()
+                        Button("Edit title…", systemImage: "textformat", action: beginTitleEdit)
+                        Button("Rename", systemImage: "pencil", action: onRename)
+                        Button("Move", systemImage: "folder", action: onMove)
+                        Button("Reveal in Finder", systemImage: "finder", action: onReveal)
+                        Divider()
+                        Button("Delete", systemImage: "trash", role: .destructive, action: onDelete)
+                    } label: {
+                        Image(systemName: "ellipsis.circle.fill")
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundStyle(.white, .black.opacity(0.45))
+                            .padding(8)
+                    }
+                    .menuStyle(.borderlessButton)
                 }
-                .menuStyle(.borderlessButton)
             }
             .overlay(alignment: .topLeading) {
                 if selectionMode {
@@ -87,10 +110,7 @@ struct ScreenshotCardView: View {
             }
 
             VStack(alignment: .leading, spacing: 4) {
-                Text(item.filename)
-                    .font(.system(size: 13, weight: .semibold))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
+                titleView
                     .frame(width: thumbnailWidth, alignment: .leading)
 
                 Text(item.createdAt, format: .dateTime.hour().minute())
@@ -124,6 +144,45 @@ struct ScreenshotCardView: View {
         .task(id: item.url) {
             thumbnail = await ThumbnailService.shared.thumbnail(for: item.url)
         }
+    }
+
+    @ViewBuilder
+    private var titleView: some View {
+        if isEditingTitle {
+            TextField("Title", text: $draftTitle)
+                .textFieldStyle(.roundedBorder)
+                .font(.system(size: 13, weight: .semibold))
+                .focused($titleFieldFocused)
+                .onAppear { titleFieldFocused = true }
+                .onSubmit(commitTitleEdit)
+                .onExitCommand(perform: cancelTitleEdit)
+                .onChange(of: titleFieldFocused) { _, focused in
+                    if !focused { commitTitleEdit() }
+                }
+        } else {
+            Text(title)
+                .font(.system(size: 13, weight: .semibold))
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .contentShape(Rectangle())
+                .onTapGesture(count: 2, perform: beginTitleEdit)
+                .help("Double-click to edit the title")
+        }
+    }
+
+    private func beginTitleEdit() {
+        draftTitle = title
+        isEditingTitle = true
+    }
+
+    private func commitTitleEdit() {
+        guard isEditingTitle else { return }
+        isEditingTitle = false
+        onSetTitle(draftTitle)
+    }
+
+    private func cancelTitleEdit() {
+        isEditingTitle = false
     }
 
     private var selectionBackground: some ShapeStyle {
@@ -164,12 +223,15 @@ struct ScreenshotCardView_Previews: PreviewProvider {
     static var previews: some View {
         ScreenshotCardView(
             item: PreviewSampleData.items.first!,
+            title: PreviewSampleData.items.first!.filename,
             width: 220,
             isFavorite: true,
             isSelected: false,
             isActive: true,
             selectionMode: false,
             onActivate: {},
+            onEditInPinpoint: {},
+            onSetTitle: { _ in },
             onToggleFavorite: {},
             onSelect: {},
             onCopyImage: {},

--- a/Pinpoint/Shelf/Views/Screens/ScreenshotDetailView.swift
+++ b/Pinpoint/Shelf/Views/Screens/ScreenshotDetailView.swift
@@ -14,6 +14,7 @@ struct ScreenshotDetailView: View {
     let onCopyPath: () -> Void
     let onMove: () -> Void
     let onDelete: () -> Void
+    let onOpenInPinpoint: () -> Void
     /// Set when hosted in a plain AppKit window, where `@Environment(\.dismiss)`
     /// is a no-op. Falls back to `dismiss` (used by previews).
     var onClose: (() -> Void)? = nil
@@ -132,6 +133,12 @@ struct ScreenshotDetailView: View {
             Text("Actions")
                 .font(.headline)
 
+            Button("Edit in Pinpoint", systemImage: "pin.fill") {
+                close()
+                onOpenInPinpoint()
+            }
+            .buttonStyle(.borderedProminent)
+
             HStack(spacing: 10) {
                 Button("Quick Look", systemImage: "space", action: onQuickLook)
                 Button("Reveal", systemImage: "finder", action: onReveal)
@@ -214,7 +221,8 @@ struct ScreenshotDetailView_Previews: PreviewProvider {
             onCopyImage: {},
             onCopyPath: {},
             onMove: {},
-            onDelete: {}
+            onDelete: {},
+            onOpenInPinpoint: {}
         )
         .environmentObject(PreviewSampleData.store)
     }

--- a/Pinpoint/Shelf/Views/Screens/ShelfView.swift
+++ b/Pinpoint/Shelf/Views/Screens/ShelfView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct ShelfView: View {
     var onOpenSettings: () -> Void = {}
+    var onOpenInPinpoint: (ScreenshotItem) -> Void = { _ in }
     var onOpenDetail: (ScreenshotItem) -> Void = { _ in }
 
     @EnvironmentObject private var store: ScreenshotStore
@@ -426,12 +427,15 @@ struct ShelfView: View {
             ForEach(items) { item in
                 ScreenshotCardView(
                     item: item,
+                    title: store.displayTitle(for: item),
                     width: cardWidth,
                     isFavorite: store.isFavorite(item),
                     isSelected: selectedIDs.contains(item.id),
                     isActive: activeItemID == item.id,
                     selectionMode: selectionMode,
                     onActivate: { activeItemID = item.id },
+                    onEditInPinpoint: { onOpenInPinpoint(item) },
+                    onSetTitle: { store.setCustomTitle($0, for: item) },
                     onToggleFavorite: { store.toggleFavorite(item) },
                     onSelect: { toggleSelection(for: item) },
                     onCopyImage: { store.copyImage(item) },

--- a/Pinpoint/ShelfWindowController.swift
+++ b/Pinpoint/ShelfWindowController.swift
@@ -31,6 +31,9 @@ final class ShelfWindowController: NSWindowController {
             onOpenSettings: {
                 NotificationCenter.default.post(name: .pinpointOpenSettings, object: nil)
             },
+            onOpenInPinpoint: { item in
+                NotificationCenter.default.post(name: .pinpointOpenInEditor, object: item.url)
+            },
             onOpenDetail: { [weak self] item in
                 self?.presentDetail(for: item)
             }


### PR DESCRIPTION
## Résumé

Pont entre l'**étagère** et l'**éditeur d'annotation** : une capture de l'étagère (y compris une capture `⌘⇧4` native) peut être rouverte dans Pinpoint comme une capture de région. C'est la **Phase 3** de la fusion SnapShelf (passerelle étagère→éditeur).

## Fonctionnalités

### Éditer dans Pinpoint
- Action **« Éditer dans Pinpoint »** sur chaque vignette : bouton `pin` direct (à gauche du menu ⋯) + entrée du menu ⋯, et bouton mis en avant dans la fenêtre détail.
- Poste une notification `.pinpointOpenInEditor` (URL du fichier) observée par `AppDelegate` → l'image est rechargée à sa **taille pixel native** (préserve le Retina), ajoutée à l'historique, puis ouverte dans l'éditeur — exactement le même flux qu'une capture de région.
- Alerte si le fichier est illisible (déplacé/supprimé).

### Titres personnalisés d'étagère
- La vignette affiche un **titre éditable** au lieu du nom de fichier brut.
- Édition **inline** (double-clic sur le titre) ou via le menu ⋯ « Modifier le titre… » (Entrée valide, Échap annule, validation à la perte de focus).
- Stockés en **métadonnée** (`UserDefaults`, calqués sur les favoris : suivi au rename/move, purge des fichiers disparus, suppression au delete). **Le fichier sur le disque n'est jamais renommé** (distinct de *Rename*). Titre vidé ⇒ retour au nom de fichier.

## Fichiers
`AppDelegate`, `ShelfWindowController`, `ScreenshotDetailWindowController`, `ScreenshotDetailView`, `ScreenshotCardView`, `ShelfView`, `ScreenshotStore`, `Localizable.xcstrings` (+ i18n FR).

## Tests
- ✅ Build Release universel (arm64 + x86_64) : **BUILD SUCCEEDED**.
- ✅ Installé/relancé en local via `scripts/install-local.sh` (signature Developer ID, autorisation « Enregistrement de l'écran » conservée).
- Validé en usage réel : bouton pin → ouverture de l'éditeur ; double-clic titre → renommage d'affichage persistant sans toucher au fichier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
