### PR TITLE
Add delay before capture

### DIFF
--- a/Pinpoint/AppDelegate.swift
+++ b/Pinpoint/AppDelegate.swift
@@ -16,6 +16,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var statusItem: NSStatusItem!
     private var editorController: EditorWindowController?
     private var regionController: RegionSelectionController?
+    private var countdownController: CountdownController?
     private var settingsController: SettingsWindowController?
     private var shelfController: ShelfWindowController?
     private let recentMenu = NSMenu()
@@ -213,6 +214,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             // Let the overlay fully disappear before the screenshot, so the dim
             // layer isn't part of the captured pixels.
             try? await Task.sleep(nanoseconds: 80_000_000)
+
+            // Pré-délai optionnel : HUD cliquable-transparent pour laisser
+            // l'utilisateur disposer l'UI ou ouvrir un menu. Échap annule.
+            let delay = CaptureDelay.current
+            if delay.seconds > 0 {
+                let screen = NSScreen.screens.first { $0.displayID == region.displayID }
+                let controller = CountdownController()
+                countdownController = controller
+                let completed = await controller.run(seconds: delay.seconds, on: screen)
+                countdownController = nil
+                guard completed else { return } // Échap pendant le décompte
+            }
 
             do {
                 let image = try await ScreenCapture.captureRegion(region)

--- a/Pinpoint/CaptureDelay.swift
+++ b/Pinpoint/CaptureDelay.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Pré-délai optionnel avant une capture de région (design system §…).
+/// Persisté dans UserDefaults via `@AppStorage(CaptureDelay.storageKey)` pour
+/// garder la fenêtre Réglages et le chemin de capture synchronisés — même
+/// motif que `PinStyle`.
+enum CaptureDelay: String, CaseIterable, Identifiable {
+    /// Aucune pause (comportement par défaut, capture immédiate).
+    case off
+    case threeSeconds = "3s"
+    case fiveSeconds = "5s"
+    case tenSeconds = "10s"
+
+    var id: String { rawValue }
+
+    static let storageKey = "captureDelay"
+
+    /// Nombre entier de secondes à attendre avant la capture (0 si désactivé).
+    var seconds: Int {
+        switch self {
+        case .off: return 0
+        case .threeSeconds: return 3
+        case .fiveSeconds: return 5
+        case .tenSeconds: return 10
+        }
+    }
+
+    /// Lecture hors SwiftUI (chemin de capture) : retourne `.off` si la valeur
+    /// stockée est absente ou invalide.
+    static var current: CaptureDelay {
+        CaptureDelay(rawValue: UserDefaults.standard.string(forKey: storageKey) ?? "") ?? .off
+    }
+
+    var label: String {
+        switch self {
+        case .off: return String(localized: "Off")
+        case .threeSeconds: return String(localized: "3 seconds")
+        case .fiveSeconds: return String(localized: "5 seconds")
+        case .tenSeconds: return String(localized: "10 seconds")
+        }
+    }
+}

--- a/Pinpoint/CountdownController.swift
+++ b/Pinpoint/CountdownController.swift
@@ -1,0 +1,151 @@
+import AppKit
+
+/// Affiche un compte à rebours cliquable-transparent (HUD) pendant le délai de
+/// capture, pour laisser l'utilisateur disposer l'UI ou ouvrir un menu avant
+/// la prise de vue.
+///
+/// Le HUD est `ignoresMouseEvents = true` et non actif : les clics traversent
+/// vers les fenêtres/menus situés dessous (cas clé : ouvrir un menu pendant le
+/// compte à rebours pour le capturer). Pinpoint se désactive pour que l'app
+/// ciblée reste au premier plan. Échap annule la capture.
+@MainActor
+final class CountdownController {
+    private var window: CountdownWindow?
+    private var view: CountdownView?
+    private var cancelled = false
+    private var escLocalMonitor: Any?
+    private var escGlobalMonitor: Any?
+
+    /// Attend `seconds` secondes en affichant le décompte sur `screen`.
+    /// Retourne `false` si l'utilisateur a appuyé sur Échap, `true` sinon.
+    /// Sans effet si `seconds <= 0`.
+    func run(seconds: Int, on screen: NSScreen?) async -> Bool {
+        guard seconds > 0 else { return true }
+        cancelled = false
+        show(on: screen ?? NSScreen.main ?? NSScreen.screens.first)
+        startEscMonitor()
+        defer {
+            stopEscMonitor()
+            window?.orderOut(nil)
+            window = nil
+        }
+
+        for n in stride(from: seconds, through: 1, by: -1) {
+            guard !cancelled else { return false }
+            view?.number = n
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+        }
+        return !cancelled
+    }
+
+    // MARK: - Presentation
+
+    private func show(on screen: NSScreen?) {
+        guard let screen else { return }
+        let size: CGFloat = 220
+        let frame = NSRect(
+            x: screen.frame.midX - size / 2,
+            y: screen.frame.midY - size / 2,
+            width: size,
+            height: size
+        )
+        let window = CountdownWindow(
+            contentRect: frame,
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        window.level = .statusBar
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.hasShadow = false
+        window.ignoresMouseEvents = true   // cliquable-transparent
+        window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+
+        let view = CountdownView(frame: NSRect(origin: .zero, size: frame.size))
+        window.contentView = view
+        self.window = window
+        self.view = view
+
+        // Laisse l'app ciblée au premier plan (menus accessibles sans clic de
+        // réactivation). `orderFront` sans `makeKey` ni `NSApp.activate`.
+        NSApp.deactivate()
+        window.orderFront(nil)
+    }
+
+    // MARK: - Esc cancel
+
+    private func startEscMonitor() {
+        // Moniteur local : couvre le cas où Pinpoint a encore le focus clavier.
+        escLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            if event.keyCode == 53 { self?.cancel() } // Esc
+            return event
+        }
+        // Moniteur global : couvre le cas où l'utilisateur a cliqué dans une
+        // autre app pour ouvrir un menu (Échap vient de cette app). Le rappel
+        // peut être invoqué hors main actor : on rebascule dessus via `cancel`.
+        // Note : peut nécessiter la permission « Input Monitoring » ; si elle
+        // manque, le décompte se termine simplement (dégradation silencieuse).
+        escGlobalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            if event.keyCode == 53 { self?.cancel() } // Esc
+        }
+    }
+
+    /// Marque le décompte comme annulé. Comme cette méthode est isolée sur le
+    /// main actor (classe `@MainActor`), l'appeler depuis le moniteur global —
+    /// dont le handler tourne hors main thread — rebascule automatiquement sur
+    /// le main actor, évitant la course de données sur `cancelled`.
+    private func cancel() {
+        cancelled = true
+    }
+
+    private func stopEscMonitor() {
+        if let escLocalMonitor { NSEvent.removeMonitor(escLocalMonitor); self.escLocalMonitor = nil }
+        if let escGlobalMonitor { NSEvent.removeMonitor(escGlobalMonitor); self.escGlobalMonitor = nil }
+    }
+}
+
+// MARK: - View
+
+private final class CountdownView: NSView {
+    var number: Int = 0 { didSet { needsDisplay = true } }
+
+    override var isFlipped: Bool { false }
+    override var acceptsFirstResponder: Bool { false }
+
+    override func draw(_ dirtyRect: NSRect) {
+        let text = "\(number)" as NSString
+        let font = NSFont.systemFont(ofSize: 130, weight: .bold)
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: NSColor.white
+        ]
+        let textSize = text.size(withAttributes: attrs)
+        let pad: CGFloat = 30
+        let side = max(textSize.width, textSize.height) + pad * 2 // carré → cercle
+        let rect = NSRect(
+            x: bounds.midX - side / 2,
+            y: bounds.midY - side / 2,
+            width: side,
+            height: side
+        )
+        NSColor.pinpointVermillon.withAlphaComponent(0.92).setFill()
+        NSBezierPath(ovalIn: rect).fill()
+
+        let textOrigin = CGPoint(
+            x: rect.midX - textSize.width / 2,
+            y: rect.midY - textSize.height / 2
+        )
+        text.draw(at: textOrigin, withAttributes: attrs)
+    }
+}
+
+// MARK: - Window
+
+/// Fenêtre cliquable-transparent pour le HUD de décompte. Pas `canBecomeKey`
+/// (on ne veut PAS voler le focus clavier) — cf. `OverlayWindow` dans
+/// `RegionSelectionController.swift` pour le motif inverse (sélection de région).
+private final class CountdownWindow: NSWindow {
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+}

--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -43,6 +43,21 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "1 sélectionnée" } }
       }
     },
+    "3 seconds" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "3 secondes" } }
+      }
+    },
+    "5 seconds" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "5 secondes" } }
+      }
+    },
+    "10 seconds" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "10 secondes" } }
+      }
+    },
     "Add to favorites" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Ajouter aux favoris" } }
@@ -106,6 +121,11 @@
     "Capture the whole screen" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Capturer tout l’écran" } }
+      }
+    },
+    "Capture timer" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Minuteur de capture" } }
       }
     },
     "capture.error.body" : {
@@ -207,6 +227,11 @@
     "Couldn’t update Launch at Login." : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Impossible de modifier le lancement au démarrage." } }
+      }
+    },
+    "Delay before capture:" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Délai avant capture :" } }
       }
     },
     "Delete" : {
@@ -419,7 +444,12 @@
     },
     "No screenshots" : {
       "localizations" : {
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Aucune capture" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Aucune capture d’écran" } }
+      }
+    },
+    "Off" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Désactivé" } }
       }
     },
     "Older" : {
@@ -440,6 +470,11 @@
     "Open shelf:" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Ouvrir l’étagère :" } }
+      }
+    },
+    "Pause before the screenshot so you can arrange UI elements or open a menu." : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Pause avant la capture pour disposer les éléments ou ouvrir un menu." } }
       }
     },
     "Pinpoint Settings" : {

--- a/Pinpoint/PinpointApp.swift
+++ b/Pinpoint/PinpointApp.swift
@@ -58,6 +58,7 @@ struct SettingsView: View {
 struct CaptureSettingsView: View {
     @AppStorage(PinStyle.storageKey) private var pinStyle: PinStyle = .disc
     @AppStorage("includeLegend") private var includeLegend = true
+    @AppStorage(CaptureDelay.storageKey) private var captureDelay: CaptureDelay = .off
 
     var body: some View {
         Form {
@@ -72,6 +73,16 @@ struct CaptureSettingsView: View {
                     }
                 }
                 Text(pinStyle.caption)
+                    .foregroundStyle(.secondary)
+                    .font(.callout)
+            }
+            Section("Capture timer") {
+                Picker("Delay before capture:", selection: $captureDelay) {
+                    ForEach(CaptureDelay.allCases) { delay in
+                        Text(delay.label).tag(delay)
+                    }
+                }
+                Text("Pause before the screenshot so you can arrange UI elements or open a menu.")
                     .foregroundStyle(.secondary)
                     .font(.callout)
             }


### PR DESCRIPTION
## Ce que fait cette PR

Ajoute un **délai optionnel avant la capture** : un minuteur configurable (désactivé / 3 s / 5 s / 10 s) déclenche un **compte à rebours visuel** sous forme de HUD transparent et cliquable, pour laisser à l'utilisateur le temps de disposer son UI ou d'ouvrir un menu avant la capture.

- **Annulable** avec `Échap` pendant le compte à rebours.
- **HUD transparent et cliquable** : on garde la possibilité d'interagir avec l'écran en dessous pendant le décompte.
- Réglage exposé dans les **Préférences** (`Settings`), valeur persistée dans `UserDefaults`.

## Comportement
1. L'utilisateur choisit un délai dans les Préférences (par défaut : désactivé).
2. Au déclenchement de la capture, si le délai > 0, le `CountdownController` affiche un HUD plein écran qui décompte les secondes.
3. `Échap` annule (aucune capture). Sinon, à 0, la capture régionale se lance comme aujourd'hui.

## Fichiers
- `Pinpoint/CaptureDelay.swift` *(nouveau)* — enum des durées, persistance `UserDefaults`, accès à `CaptureDelay.current`.
- `Pinpoint/CountdownController.swift` *(nouveau)* — affichage et logique d'annulation du compte à rebours (HUD transparent cliquable).
- `Pinpoint/AppDelegate.swift` — insertion du pré-délai dans le flux de capture régional (`run(seconds:on:)`, branche sur `Échap`).
- `Pinpoint/PinpointApp.swift` — exposition du réglage.
- `Pinpoint/Localizable.xcstrings` — chaînes FR/EN (minuteurs, labels, réglage).

> Note : la branche est isolée et ne contient que ce commit, rebasée sur `main`. Le catalogue `Localizable.xcstrings` a été résolu à la main pour ne contenir que les chaînes de cette fonctionnalité (aucune fuite d'autres fonctionnalités).

## Vérification

Le barème du repo (« it compiles »), via AGENTS.md :
```bash
xcodegen generate && xcodebuild -scheme Pinpoint -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
```

Smoke test manuel :
1. Préférences → délai = 5 s.
2. `⌘⇧1` → HUD visible, décompte 5…4…3…2…1.
3. `Échap` pendant le décompte → capture annulée.
4. Laisser finir → capture régionale normale se lance.
5. Réouvrir Préférences → valeur persistée.

## Notes
- Branche isolée (`pr/capture-delay`) ne contenant que ce commit, rebasée sur `main`.
- Conventions respectées : `String(localized:)` pour les chaînes UI, un fichier = une responsabilité (`CaptureDelay` pour la config, `CountdownController` pour la logique/UI), commentaires en français.