### PR TITLE
fix(editor): prevent tool picker from shifting in narrow windows

### DIFF
--- a/Pinpoint/EditorView.swift
+++ b/Pinpoint/EditorView.swift
@@ -80,6 +80,11 @@ struct EditorView: View {
 
     private var toolbar: some View {
         HStack(spacing: 10) {
+            // `fixedSize()` locks the segmented picker to its intrinsic
+            // width so it can't be squeezed when the trailing hint grows
+            // (e.g. switching to Rectangle). Without it, a growing hint in
+            // a narrow window shrank the picker and shifted the Crop button
+            // left — see "Drag to draw a rectangle" being the longest hint.
             Picker("Tool", selection: $tool) {
                 ForEach(EditorTool.allCases) { tool in
                     Label(tool.label, systemImage: tool.symbol).tag(tool)
@@ -87,13 +92,18 @@ struct EditorView: View {
             }
             .pickerStyle(.segmented)
             .labelsHidden()
-            .frame(maxWidth: 320)
+            .fixedSize()
 
             Spacer()
 
+            // Hint yields first when the row is tight (layoutPriority -1),
+            // truncating instead of pushing the picker/buttons around.
             Text(toolHint)
                 .font(.caption)
                 .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .layoutPriority(-1)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)


### PR DESCRIPTION
## What this PR does

Fixes a layout glitch in the editor toolbar: in narrow windows, the segmented tool picker (Marker / Arrow / Rectangle) was being squeezed and the trailing hint text pushed it around when the hint got longer (e.g. switching to *“Drag to draw a rectangle”*, the longest hint).

## The fix

- **Picker:** replace `.frame(maxWidth: 320)` with `.fixedSize()`, locking the segmented picker to its intrinsic width so it can't be compressed.
- **Hint text:** add `.lineLimit(1)`, `.truncationMode(.tail)`, and `.layoutPriority(-1)` so the hint yields first when the row is tight, truncating instead of pushing the picker around.

Result: the picker and its neighbors stay locked in place regardless of window width; only the hint truncates.

## Files

- `Pinpoint/EditorView.swift` — toolbar layout only (11 lines).

## Verification

Per AGENTS.md, "it compiles" is the bar:
```bash
xcodegen generate && xcodebuild -scheme Pinpoint -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
```

Manual smoke test:
1. Open the editor on a fresh capture.
2. Drag the window narrower.
3. Switch tools (Marker → Arrow → Rectangle) and confirm the segmented picker no longer changes width and stays put.
4. Confirm the hint truncates with an ellipsis instead of shifting the toolbar.

## Notes

- Branch isolated (`pr/tool-picker-layout`), single commit, rebased on `main`.
- Layout-only change, no behavior or model impact.