### PR TITLE
feat(shelf): add ⌘A select-all and Esc exit-select-mode shortcuts

### DIFF
--- a/Pinpoint/Shelf/Views/Screens/ShelfView.swift
+++ b/Pinpoint/Shelf/Views/Screens/ShelfView.swift
@@ -372,7 +372,7 @@ struct ShelfView: View {
         case 51, 117:
             deleteFocusedItems()
             return nil
-        case 53: // Esc — quitte le mode sélection
+case 53: // Esc — exit selection mode
             if selectionMode {
                 selectionMode = false
                 selectedIDs.removeAll()

--- a/Pinpoint/Shelf/Views/Screens/ShelfView.swift
+++ b/Pinpoint/Shelf/Views/Screens/ShelfView.swift
@@ -339,6 +339,12 @@ struct ShelfView: View {
             return nil
         }
 
+        if commandPressed, event.charactersIgnoringModifiers?.lowercased() == "a" {
+            selectionMode = true
+            selectedIDs = Set(visibleItems.map(\.id))
+            return nil
+        }
+
         if event.charactersIgnoringModifiers?.lowercased() == "f" {
             toggleFavoriteFocusedItems()
             return nil
@@ -366,6 +372,13 @@ struct ShelfView: View {
         case 51, 117:
             deleteFocusedItems()
             return nil
+        case 53: // Esc — quitte le mode sélection
+            if selectionMode {
+                selectionMode = false
+                selectedIDs.removeAll()
+                return nil
+            }
+            return event
         default:
             return event
         }


### PR DESCRIPTION
## What this PR does

Adds two keyboard shortcuts to the Shelf window:

- **⌘A** — selects all visible items and enters selection mode.
- **Esc** — exits selection mode and clears the current selection.

These match familiar macOS selection conventions and make bulk actions (favorite, delete, drag) faster to set up without having to click each item.

## Implementation

Both shortcuts live in the existing `keyDown` handler in `ShelfView.swift`:

- `⌘A` — gated on `commandPressed` and the unmodified `"a"` key; sets `selectedIDs` to all `visibleItems` and flips `selectionMode = true`.
- `Esc` (keycode `53`) — when already in `selectionMode`, clears `selectedIDs` and exits; otherwise the event is passed through (returns `event`) so Esc keeps its default behavior outside selection mode.

## Files

- `Pinpoint/Shelf/Views/Screens/ShelfView.swift` — keyboard handling only (13 lines).

## Verification

Per AGENTS.md, "it compiles" is the bar:
```bash
xcodegen generate && xcodebuild -scheme Pinpoint -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
```

Manual smoke test:
1. Open the Shelf (`⌘⇧2`) with several screenshots present.
2. Press `⌘A` → all visible items become selected and the selection-mode chrome appears.
3. Press `Esc` → selection clears and selection mode exits.
4. Press `Esc` while *not* in selection mode → nothing unexpected happens (event passed through).

## Notes

- Branch isolated (`pr/shelf-select-all-shortcut`), single commit, rebased on `main`.
- Self-contained: relies only on symbols already in `main` (`selectionMode`, `selectedIDs`, `visibleItems`, `commandPressed`).