### PR TITLE
Homebrew : cask, docs et auto-bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ isn't mine alone.
 
 ## Download
 
+### Homebrew
+
+```sh
+brew install --cask croustibat/tap/pinpoint
+```
+
+On Homebrew 6+ you'll be asked to trust the tap once first — run
+`brew trust croustibat/tap`, then re-run the install. See the
+[tap](https://github.com/croustibat/homebrew-tap) for details.
+
+### Direct download
+
 1. Grab the latest **`Pinpoint.dmg`** from the [releases page](https://github.com/croustibat/Pinpoint/releases/latest).
 2. Open it and drag **Pinpoint** into your Applications folder.
 3. Launch it — it lives in your menu bar. Signed with a Developer ID and notarized by Apple.
@@ -166,6 +178,14 @@ then:
 
 ```bash
 scripts/release.sh   # → build/dist/Pinpoint.dmg (signed, notarized, stapled)
+```
+
+Then publish the release and bump the Homebrew cask:
+
+```bash
+git tag vX.Y.Z && git push origin vX.Y.Z
+gh release create vX.Y.Z --latest build/dist/Pinpoint.dmg#Pinpoint.dmg
+scripts/update-cask.sh   # → pushes the version + sha256 to croustibat/homebrew-tap
 ```
 
 ## License

--- a/landing/src/components/Landing.astro
+++ b/landing/src/components/Landing.astro
@@ -197,7 +197,9 @@ const featureIcons = [
       </a>
       <a href={GITHUB_URL} class="text-sm font-medium text-zinc-400 underline-offset-4 transition hover:text-white hover:underline">{t.download.source}</a>
     </div>
-    <p class="mt-4 text-sm text-zinc-500">{t.download.req}</p>
+    <p class="mt-8 text-sm text-zinc-500">{t.download.brew}</p>
+    <code class="mt-2 inline-block rounded-lg border border-white/10 bg-white/[0.03] px-4 py-2 font-mono text-sm text-zinc-300">brew install --cask croustibat/tap/pinpoint</code>
+    <p class="mt-6 text-sm text-zinc-500">{t.download.req}</p>
   </div>
 </section>
 

--- a/landing/src/i18n.ts
+++ b/landing/src/i18n.ts
@@ -31,7 +31,7 @@ type Content = {
   features: { title: string; subtitle: string; items: { t: string; d: string }[] };
   tour: { title: string; subtitle: string; shelf: string; settings: string };
   agents: { eyebrow: string; title: string; body: string; sample: string };
-  download: { title: string; body: string; cta: string; req: string; source: string };
+  download: { title: string; body: string; cta: string; req: string; source: string; brew: string };
   footer: { tagline: string; rights: string; os: string };
 };
 
@@ -104,6 +104,7 @@ Make the CTA full-width on mobile and fix the icon alignment.`,
       cta: 'Download for macOS',
       req: 'macOS 15 or later · Apple Silicon & Intel',
       source: 'Browse the source on GitHub',
+      brew: 'Or install with Homebrew',
     },
     footer: { tagline: 'Capture. Mark. Prompt.', rights: '© 2026 Baptiste Bouillot', os: 'Open source' },
   },
@@ -176,6 +177,7 @@ Passe le bouton en pleine largeur sur mobile et corrige l’alignement de l’ic
       cta: 'Télécharger pour macOS',
       req: 'macOS 15 ou ultérieur · Apple Silicon & Intel',
       source: 'Voir le code source sur GitHub',
+      brew: 'Ou installe avec Homebrew',
     },
     footer: { tagline: 'Capture. Marque. Prompt.', rights: '© 2026 Baptiste Bouillot', os: 'Open source' },
   },

--- a/scripts/update-cask.sh
+++ b/scripts/update-cask.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Bumps the Homebrew cask (croustibat/homebrew-tap) to the freshly built release.
+#
+# Reads MARKETING_VERSION from project.yml and the sha256 of the notarized DMG
+# produced by scripts/release.sh, then updates, commits and pushes
+# Casks/pinpoint.rb in the tap repo.
+#
+# Run this AFTER scripts/release.sh and AFTER the GitHub release DMG is uploaded
+# (`gh release create v<version> … build/dist/Pinpoint.dmg`), so the cask URL
+# resolves for users. The sha256 is taken from the local DMG, which is byte-for-
+# byte the uploaded asset.
+#
+# Usage: scripts/update-cask.sh
+set -euo pipefail
+
+TAP_SLUG="${TAP_SLUG:-croustibat/homebrew-tap}"
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DMG="$ROOT/build/dist/Pinpoint.dmg"
+
+VERSION="$(grep -m1 'MARKETING_VERSION:' "$ROOT/project.yml" | sed -E 's/.*"([^"]+)".*/\1/')"
+[ -n "$VERSION" ] || { echo "✗ MARKETING_VERSION introuvable dans project.yml"; exit 1; }
+[ -f "$DMG" ] || { echo "✗ DMG introuvable: $DMG — lance d'abord scripts/release.sh"; exit 1; }
+
+SHA="$(shasum -a 256 "$DMG" | awk '{print $1}')"
+
+echo "▸ pinpoint $VERSION"
+echo "  sha256 $SHA"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+git clone --depth 1 "https://github.com/${TAP_SLUG}.git" "$WORK" >/dev/null 2>&1
+
+CASK="$WORK/Casks/pinpoint.rb"
+[ -f "$CASK" ] || { echo "✗ Cask absent du tap: $CASK"; exit 1; }
+
+sed -i '' -E "s/^  version \"[^\"]+\"/  version \"$VERSION\"/" "$CASK"
+sed -i '' -E "s/^  sha256 \"[^\"]+\"/  sha256 \"$SHA\"/" "$CASK"
+
+if git -C "$WORK" diff --quiet; then
+  echo "✓ Cask déjà à jour ($VERSION)"
+  exit 0
+fi
+
+git -C "$WORK" commit -qam "pinpoint $VERSION"
+git -C "$WORK" push -q origin HEAD
+echo "✓ Cask poussé: ${TAP_SLUG} → pinpoint $VERSION"


### PR DESCRIPTION
Ajoute la distribution Homebrew de Pinpoint via le tap perso [croustibat/homebrew-tap](https://github.com/croustibat/homebrew-tap).

## Contenu
- **Tap + cask** (repo séparé) : `brew install --cask croustibat/tap/pinpoint`, cask v0.3.0 validé (`brew audit --online` + `brew style` PASSED).
- **README** : section *Download* avec l'option Homebrew (+ note `brew trust` pour Homebrew 6) et l'étape de bump du cask dans *Release*.
- **Landing** : commande brew dans la section download (EN + FR), champ i18n `download.brew`. Build Astro OK (EN + FR).
- **scripts/update-cask.sh** : bump auto version + sha256 du cask à chaque release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)