### PR TITLE
Sélection de région multi-écran : un overlay par moniteur

### DIFF
--- a/Pinpoint/RegionSelectionController.swift
+++ b/Pinpoint/RegionSelectionController.swift
@@ -1,13 +1,17 @@
 import AppKit
 
-/// Presents a full-screen dimming overlay (one borderless window spanning all
-/// screens) and lets the user drag a rectangle to pick a capture region.
+/// Presents a full-screen dimming overlay (one borderless window per screen)
+/// and lets the user drag a rectangle to pick a capture region.
 ///
-/// Mirrors `EditorWindowController`: this file owns presentation and the window;
-/// `RegionSelectionView` owns drawing and event handling.
+/// One window per `NSScreen` is required because, with "Displays have separate
+/// Spaces" (the macOS default), a single window spanning the union of all
+/// screens only renders reliably on the primary display.
+///
+/// Mirrors `EditorWindowController`: this file owns presentation and the
+/// windows; `RegionSelectionView` owns drawing and event handling.
 @MainActor
 final class RegionSelectionController {
-    private var window: OverlayWindow?
+    private var windows: [OverlayWindow] = []
     private var continuation: CheckedContinuation<CaptureRegion?, Never>?
 
     /// Shows the overlay and resolves with the chosen region, or `nil` if the
@@ -22,33 +26,49 @@ final class RegionSelectionController {
     // MARK: - Presentation
 
     private func present() {
-        let unionFrame = NSScreen.screens.reduce(CGRect.null) { $0.union($1.frame) }
-        guard !unionFrame.isNull else { finish(nil); return }
+        let screens = NSScreen.screens
+        guard !screens.isEmpty else { finish(nil); return }
 
-        let window = OverlayWindow(
-            contentRect: unionFrame,
-            styleMask: .borderless,
-            backing: .buffered,
-            defer: false
-        )
-        window.level = .screenSaver
-        window.isOpaque = false
-        window.backgroundColor = .clear
-        window.hasShadow = false
-        window.ignoresMouseEvents = false
-        window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+        // The window under the pointer becomes key so Esc works immediately and
+        // owns the hint; the others just dim their screen (AppKit routes a drag
+        // to the window that got the mouseDown, so the anchor screen owns it).
+        let cursor = NSEvent.mouseLocation
+        let keyScreen = screens.first { NSMouseInRect(cursor, $0.frame, false) } ?? NSScreen.main
 
-        let view = RegionSelectionView(frame: NSRect(origin: .zero, size: unionFrame.size))
-        view.onComplete = { [weak self] globalRect, anchor in
-            self?.finish(Self.resolve(globalRect: globalRect, anchor: anchor))
-        }
-        view.onCancel = { [weak self] in self?.finish(nil) }
-        window.contentView = view
-
-        self.window = window
         NSApp.activate(ignoringOtherApps: true)
-        window.makeKeyAndOrderFront(nil)
-        window.makeFirstResponder(view)
+
+        for screen in screens {
+            let window = OverlayWindow(
+                contentRect: screen.frame,
+                styleMask: .borderless,
+                backing: .buffered,
+                defer: false
+            )
+            window.level = .screenSaver
+            window.isOpaque = false
+            window.backgroundColor = .clear
+            window.hasShadow = false
+            window.ignoresMouseEvents = false
+            window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+
+            let view = RegionSelectionView(frame: NSRect(origin: .zero, size: screen.frame.size))
+            view.showsHint = (screen == keyScreen)
+            view.onComplete = { [weak self] globalRect, anchor in
+                self?.finish(Self.resolve(globalRect: globalRect, anchor: anchor))
+            }
+            view.onCancel = { [weak self] in self?.finish(nil) }
+            window.contentView = view
+
+            windows.append(window)
+
+            if screen == keyScreen {
+                window.makeKeyAndOrderFront(nil)
+                window.makeFirstResponder(view)
+            } else {
+                window.orderFront(nil)
+            }
+        }
+
         NSCursor.crosshair.push()
     }
 
@@ -56,8 +76,8 @@ final class RegionSelectionController {
         guard let continuation else { return }
         self.continuation = nil
         NSCursor.pop()
-        window?.orderOut(nil)
-        window = nil
+        for window in windows { window.orderOut(nil) }
+        windows.removeAll()
         continuation.resume(returning: region)
     }
 

--- a/Pinpoint/RegionSelectionView.swift
+++ b/Pinpoint/RegionSelectionView.swift
@@ -10,6 +10,9 @@ final class RegionSelectionView: NSView {
     var onComplete: ((CGRect, CGPoint) -> Void)?
     /// Called when the user cancels (Esc, or a click without a real drag).
     var onCancel: (() -> Void)?
+    /// Whether to draw the "drag a rectangle" hint. With one view per screen,
+    /// only the view under the pointer sets this, so the hint shows just once.
+    var showsHint: Bool = true
 
     private var anchor: CGPoint?  // view-local
     private var current: CGPoint? // view-local
@@ -74,7 +77,7 @@ final class RegionSelectionView: NSView {
 
         guard let sel = selectionRect?.intersection(bounds), sel.width > 0, sel.height > 0 else {
             bounds.fill()
-            drawHint()
+            if showsHint { drawHint() }
             return
         }
 


### PR DESCRIPTION
## Problème

Sur un setup multi-écran, l'overlay de sélection de région ne s'affichait que sur l'écran **principal** ; les autres écrans n'étaient ni assombris ni sélectionnables (issue #26).

**Cause racine** : `RegionSelectionController.present()` créait **une seule** fenêtre `OverlayWindow` couvrant l'union de tous les écrans. Avec « Displays have separate Spaces » (le défaut macOS), une fenêtre unique ne se rend de façon fiable que sur l'écran principal.

## Fix

Présenter **une fenêtre overlay par `NSScreen`** au lieu d'une seule sur l'union :

- `present()` boucle sur `NSScreen.screens` et crée une `OverlayWindow` + une `RegionSelectionView` par écran, chacune à `screen.frame`. Les fenêtres sont stockées dans un tableau (`windows: [OverlayWindow]`).
- **Focus / Esc** : la fenêtre de l'écran **sous le curseur** au lancement devient key (`makeKeyAndOrderFront` + `makeFirstResponder`) pour qu'Esc marche immédiatement ; les autres sont ordonnées au premier plan sans devenir key.
- **Drag inter-écran** : AppKit route tout le drag vers la fenêtre qui a reçu le `mouseDown`, donc la vue de l'écran d'ancrage possède la sélection et produit le rect global correct. `resolve()` reste **inchangé**.
- **Teardown** : `finish()` ferme **toutes** les fenêtres, vide le tableau, fait un seul `NSCursor.pop()` et resume la continuation une seule fois (garde `continuation == nil` conservé).
- **Garde** : `NSScreen.screens` vide → `finish(nil)`.

**Retouche `RegionSelectionView`** : nouveau flag `showsHint` — le hint « Drag a rectangle · Esc to cancel » n'est activé que sur la vue de l'écran sous le curseur, pour ne l'afficher qu'une seule fois au lieu d'un par écran.

L'API publique `selectRegion() async -> CaptureRegion?` est inchangée ; `CaptureRegion`, `ScreenCapture`, `AppDelegate` et la logique `resolve()` ne sont pas touchés.

## Vérification

- `xcodegen generate` + `xcodebuild -scheme Pinpoint -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED** (0 erreur, 0 warning sur les fichiers modifiés).
- À valider manuellement sur un vrai setup multi-écran : les deux écrans s'assombrissent, la sélection est possible sur chacun, et une sélection à cheval est clampée sur l'écran d'ancrage.

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)