### PR TITLE
Éditeur : plafonner l'image copiée + « Enregistrer l'image… »

### DIFF
--- a/Pinpoint/EditorView.swift
+++ b/Pinpoint/EditorView.swift
@@ -1,4 +1,6 @@
 import SwiftUI
+import AppKit
+import UniformTypeIdentifiers
 
 /// Annotation tools the user can switch between in the editor.
 enum EditorTool: String, CaseIterable, Identifiable {
@@ -238,6 +240,13 @@ struct EditorView: View {
             .buttonStyle(.borderedProminent)
             .tint(.pinpointVermillon)
             .keyboardShortcut("c", modifiers: [.command])
+
+            Button(action: save) {
+                Label(String(localized: "Save image…"), systemImage: "square.and.arrow.down")
+                    .frame(maxWidth: .infinity)
+            }
+            .controlSize(.large)
+            .keyboardShortcut("s", modifiers: [.command])
         }
         .padding(14)
     }
@@ -385,6 +394,21 @@ struct EditorView: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) {
             withAnimation { didCopy = false }
         }
+    }
+
+    private func save() {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.png]
+        panel.nameFieldStringValue = "Pinpoint.png"
+        panel.canCreateDirectories = true
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        // Full resolution here (no cap): the file is meant to be attached/kept,
+        // unlike the pasteboard image which is downscaled to stay pasteable.
+        guard let png = Exporter.pngData(base: image, pins: pins, shapes: shapes, context: context,
+                                         style: pinStyle, includeLegend: includeLegend, maxDimension: nil) else { return }
+        try? png.write(to: url)
+        onPersist(pins, shapes, context)
     }
 
     // MARK: - Geometry

--- a/Pinpoint/Exporter.swift
+++ b/Pinpoint/Exporter.swift
@@ -268,8 +268,49 @@ enum Exporter {
         return result
     }
 
+    /// Longest-edge cap (pixels) for the image placed on the pasteboard. Captures
+    /// are stored at native Retina resolution, which makes the full-size PNG too
+    /// large to paste into some targets (Claude, GitHub). The agent doesn't need
+    /// that detail — the text carries each marker's position — so the clipboard
+    /// image is downscaled to fit, while "Save image…" keeps full resolution.
+    static let clipboardMaxDimension: CGFloat = 2000
+
+    /// PNG data for the annotated image (with legend when `includeLegend`),
+    /// optionally downscaled so its longest edge is at most `maxDimension` pixels.
+    /// Pass `nil` for full native resolution.
+    static func pngData(base: NSImage, pins: [Pin], shapes: [Markup], context: String,
+                        style: PinStyle, includeLegend: Bool, maxDimension: CGFloat?) -> Data? {
+        let image = exportImage(base: base, pins: pins, shapes: shapes, context: context,
+                                style: style, includeLegend: includeLegend)
+        guard let tiff = image.tiffRepresentation, let rep = NSBitmapImageRep(data: tiff) else { return nil }
+        let output = maxDimension.flatMap { downscaled(rep, maxDimension: $0) } ?? rep
+        return output.representation(using: .png, properties: [:])
+    }
+
+    /// Returns `rep` shrunk so its longest pixel edge is `maxDimension`, or `rep`
+    /// itself when it already fits. Works in pixels so the cap is exact regardless
+    /// of the drawing context's scale.
+    private static func downscaled(_ rep: NSBitmapImageRep, maxDimension: CGFloat) -> NSBitmapImageRep? {
+        let longest = CGFloat(max(rep.pixelsWide, rep.pixelsHigh))
+        guard longest > maxDimension else { return rep }
+        let factor = maxDimension / longest
+        let width = Int((CGFloat(rep.pixelsWide) * factor).rounded())
+        let height = Int((CGFloat(rep.pixelsHigh) * factor).rounded())
+        guard let dst = NSBitmapImageRep(
+            bitmapDataPlanes: nil, pixelsWide: width, pixelsHigh: height,
+            bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+            colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0) else { return rep }
+        dst.size = NSSize(width: width, height: height)
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: dst)
+        NSGraphicsContext.current?.imageInterpolation = .high
+        rep.draw(in: NSRect(x: 0, y: 0, width: width, height: height))
+        NSGraphicsContext.restoreGraphicsState()
+        return dst
+    }
+
     /// Puts the (optionally legend-bearing) annotated PNG on the general
-    /// pasteboard.
+    /// pasteboard, downscaled to `clipboardMaxDimension` so it stays pasteable.
     ///
     /// When the legend is baked into the image the PNG is self-contained, so we
     /// deliberately leave the plain instruction text off the pasteboard: a
@@ -279,14 +320,11 @@ enum Exporter {
     /// is the sole carrier of the marker descriptions and instructions.
     static func copyToPasteboard(base: NSImage, pins: [Pin], shapes: [Markup], context: String,
                                  style: PinStyle, includeLegend: Bool) {
-        let image = exportImage(base: base, pins: pins, shapes: shapes, context: context,
-                                style: style, includeLegend: includeLegend)
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
 
-        if let tiff = image.tiffRepresentation,
-           let rep = NSBitmapImageRep(data: tiff),
-           let png = rep.representation(using: .png, properties: [:]) {
+        if let png = pngData(base: base, pins: pins, shapes: shapes, context: context,
+                             style: style, includeLegend: includeLegend, maxDimension: clipboardMaxDimension) {
             pasteboard.setData(png, forType: .png)
         }
 

--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -169,6 +169,11 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Copier pour l’agent" } }
       }
     },
+    "Save image…" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Enregistrer l’image…" } }
+      }
+    },
     "Copy image" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Copier l’image" } }


### PR DESCRIPTION
Corrige le collage impossible car l'image « Copier pour l'agent » est trop volumineuse (rejetée par Claude et GitHub). Fixes #28.

## Cause
La capture est un `NSImage` dont la taille en points = pixels natifs Retina ; `Exporter.copyToPasteboard` posait ce PNG **plein format, sans plafond**, sur le presse-papier. Mesuré : une image 4000×3000 pt sort en **8000×6000 px / 3,1 Mo** (2× du contexte de dessin).

## Fix
- **Presse-papier plafonné** : image redimensionnée à **2000 px** de grand côté (calcul en pixels via `NSBitmapImageRep` → cap exact quel que soit le scale). Vérifié : 4000×3000 → **2000×1500 / 54 Ko** (÷58). Le collage passe partout ; légende toujours incrustée.
- **« Enregistrer l'image… » (⌘S)** : `NSSavePanel` → PNG **pleine résolution** (8000×6000 conservé), pour joindre le fichier.
- i18n FR (`Enregistrer l'image…`).

## Vérification
- `xcodebuild … build` → **BUILD SUCCEEDED**.
- Harnais autonome sur `Exporter.pngData` confirmant les dimensions plafonnées vs pleine réso.

Fichiers : `Exporter.swift`, `EditorView.swift`, `Localizable.xcstrings`. Pipeline de capture non touché.

🤖 Generated with [Claude Code](https://claude.com/claude-code)