### PR TITLE
Auto-update in-app via Sparkle

### DIFF
--- a/Pinpoint/AppDelegate.swift
+++ b/Pinpoint/AppDelegate.swift
@@ -1,6 +1,7 @@
 import AppKit
 import SwiftUI
 import KeyboardShortcuts
+import Sparkle
 
 extension Notification.Name {
     /// Posted by the shelf to open Pinpoint's unified settings window.
@@ -18,6 +19,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var settingsController: SettingsWindowController?
     private var shelfController: ShelfWindowController?
     private let recentMenu = NSMenu()
+    /// Sparkle updater. Created (and started) at launch so scheduled background
+    /// checks run; the menu item below also triggers a manual check.
+    private let updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         setupStatusItem()
@@ -93,6 +97,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         recentItem.submenu = recentMenu
         menu.addItem(recentItem)
         menu.addItem(.separator())
+
+        let updatesItem = NSMenuItem(title: String(localized: "Check for updates…"),
+                                     action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)),
+                                     keyEquivalent: "")
+        updatesItem.target = updaterController
+        menu.addItem(updatesItem)
 
         let settingsItem = NSMenuItem(title: String(localized: "Settings…"), action: #selector(openSettings), keyEquivalent: ",")
         settingsItem.target = self

--- a/Pinpoint/Info.plist
+++ b/Pinpoint/Info.plist
@@ -24,5 +24,11 @@
 	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2026 Baptiste Bouillot</string>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+	<key>SUFeedURL</key>
+	<string>https://pinpoint-ashy.vercel.app/appcast.xml</string>
+	<key>SUPublicEDKey</key>
+	<string>+9BFwjsyhynA3QpwOytwA3h1E7yy0OJH+R26Xbzkrsw=</string>
 </dict>
 </plist>

--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -119,6 +119,11 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Capturée le" } }
       }
     },
+    "Check for updates…" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Rechercher les mises à jour…" } }
+      }
+    },
     "Choose a folder…" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Choisir un dossier…" } }

--- a/README.md
+++ b/README.md
@@ -180,13 +180,19 @@ then:
 scripts/release.sh   # → build/dist/Pinpoint.dmg (signed, notarized, stapled)
 ```
 
-Then publish the release and bump the Homebrew cask:
+Then publish the release, bump the Homebrew cask, and update the Sparkle appcast:
 
 ```bash
 git tag vX.Y.Z && git push origin vX.Y.Z
 gh release create vX.Y.Z --latest build/dist/Pinpoint.dmg#Pinpoint.dmg
-scripts/update-cask.sh   # → pushes the version + sha256 to croustibat/homebrew-tap
+scripts/update-cask.sh      # → pushes the version + sha256 to croustibat/homebrew-tap
+scripts/update-appcast.sh   # → signs the DMG (EdDSA) and adds it to landing/public/appcast.xml
 ```
+
+Then commit `landing/public/appcast.xml` and redeploy the landing (`vercel deploy --prod`)
+so in-app auto-update (Sparkle) sees the new version. The EdDSA private key lives in
+the release machine's keychain (paired with `SUPublicEDKey` in `project.yml`); create it
+once with Sparkle's `generate_keys`.
 
 ## License
 

--- a/landing/public/appcast.xml
+++ b/landing/public/appcast.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Pinpoint</title>
+    <link>https://pinpoint-ashy.vercel.app/appcast.xml</link>
+    <description>Most recent updates to Pinpoint.</description>
+    <language>en</language>
+    <!-- NEWEST-ITEM-ANCHOR — scripts/update-appcast.sh inserts each release below this line. -->
+  </channel>
+</rss>

--- a/project.yml
+++ b/project.yml
@@ -10,6 +10,9 @@ packages:
   KeyboardShortcuts:
     url: https://github.com/sindresorhus/KeyboardShortcuts
     from: "2.2.0"
+  Sparkle:
+    url: https://github.com/sparkle-project/Sparkle
+    from: "2.9.0"
 
 targets:
   Pinpoint:
@@ -19,6 +22,7 @@ targets:
       - Pinpoint
     dependencies:
       - package: KeyboardShortcuts
+      - package: Sparkle
     info:
       path: Pinpoint/Info.plist
       properties:
@@ -32,6 +36,12 @@ targets:
         # Menu-bar only app: no Dock icon, no main window.
         LSUIElement: true
         NSHumanReadableCopyright: "© 2026 Baptiste Bouillot"
+        # Sparkle auto-update. The appcast is hosted on the landing site; the
+        # public EdDSA key pairs with the private key held in the release
+        # machine's keychain (used by scripts/update-appcast.sh to sign updates).
+        SUFeedURL: https://pinpoint-ashy.vercel.app/appcast.xml
+        SUPublicEDKey: "+9BFwjsyhynA3QpwOytwA3h1E7yy0OJH+R26Xbzkrsw="
+        SUEnableAutomaticChecks: true
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: app.croustibat.Pinpoint

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -36,8 +36,18 @@ xcodebuild -scheme Pinpoint -configuration Release \
   clean build >/dev/null
 
 echo "▸ Signing with Developer ID + hardened runtime"
-# Sign nested code (frameworks/dylibs) first, then the app bundle.
+# Sign nested code deepest-first, then the app bundle. Sparkle ships a helper
+# app (Updater.app), XPC services and a bare Autoupdate tool that each need
+# their own signature under the hardened runtime, before the framework and app.
 if [ -d "$APP/Contents/Frameworks" ]; then
+  find "$APP/Contents/Frameworks" -depth \( -name "*.xpc" -o -name "*.app" \) -print0 \
+    | while IFS= read -r -d '' item; do
+        codesign --force --options runtime --timestamp --sign "$IDENTITY" "$item"
+      done
+  find "$APP/Contents/Frameworks" -name "Autoupdate" -type f -print0 \
+    | while IFS= read -r -d '' item; do
+        codesign --force --options runtime --timestamp --sign "$IDENTITY" "$item"
+      done
   find "$APP/Contents/Frameworks" -depth \( -name "*.framework" -o -name "*.dylib" \) -print0 \
     | while IFS= read -r -d '' item; do
         codesign --force --options runtime --timestamp --sign "$IDENTITY" "$item"

--- a/scripts/update-appcast.sh
+++ b/scripts/update-appcast.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# Appends the freshly built release to the Sparkle appcast
+# (landing/public/appcast.xml), signing the notarized DMG with the EdDSA key
+# held in the release machine's keychain.
+#
+# Run AFTER scripts/release.sh (which resolves Sparkle's tools under build/) and
+# AFTER the GitHub release DMG is uploaded, so the enclosure URL resolves. Then
+# commit landing/public/appcast.xml and redeploy the landing so Sparkle sees it.
+#
+# Usage: scripts/update-appcast.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DMG="$ROOT/build/dist/Pinpoint.dmg"
+APPCAST="$ROOT/landing/public/appcast.xml"
+FEED_BASE="https://github.com/croustibat/Pinpoint/releases/download"
+
+VERSION="$(grep -m1 'MARKETING_VERSION:' "$ROOT/project.yml" | sed -E 's/.*"([^"]+)".*/\1/')"
+BUILD="$(grep -m1 'CURRENT_PROJECT_VERSION:' "$ROOT/project.yml" | sed -E 's/.*"([^"]+)".*/\1/')"
+MIN_OS="$(grep -m1 'MACOSX_DEPLOYMENT_TARGET:' "$ROOT/project.yml" | sed -E 's/.*"([^"]+)".*/\1/')"
+
+[ -n "$VERSION" ] || { echo "✗ MARKETING_VERSION introuvable dans project.yml"; exit 1; }
+[ -f "$DMG" ] || { echo "✗ DMG introuvable: $DMG — lance d'abord scripts/release.sh"; exit 1; }
+[ -f "$APPCAST" ] || { echo "✗ appcast introuvable: $APPCAST"; exit 1; }
+
+# Locate Sparkle's sign_update (resolved SPM artifact under build/, or override).
+SIGN_UPDATE="${SIGN_UPDATE:-$(find "$ROOT/build" -name sign_update -type f 2>/dev/null | head -1)}"
+[ -x "$SIGN_UPDATE" ] || { echo "✗ sign_update introuvable — définis SIGN_UPDATE=/chemin/vers/sign_update"; exit 1; }
+
+if grep -q "shortVersionString>$VERSION<" "$APPCAST"; then
+  echo "✓ L'appcast contient déjà la version $VERSION"
+  exit 0
+fi
+
+# sign_update prints: sparkle:edSignature="…" length="…"
+SIG_ATTRS="$("$SIGN_UPDATE" "$DMG")"
+PUBDATE="$(date "+%a, %d %b %Y %H:%M:%S %z")"
+
+ITEM="$(mktemp)"
+cat > "$ITEM" <<EOF
+    <item>
+      <title>Version $VERSION</title>
+      <pubDate>$PUBDATE</pubDate>
+      <sparkle:version>$BUILD</sparkle:version>
+      <sparkle:shortVersionString>$VERSION</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>${MIN_OS:-15.0}</sparkle:minimumSystemVersion>
+      <enclosure url="$FEED_BASE/v$VERSION/Pinpoint.dmg" $SIG_ATTRS type="application/octet-stream" />
+    </item>
+EOF
+
+# Insert the new item right after the anchor comment (newest first).
+sed -i '' -e "/NEWEST-ITEM-ANCHOR/r $ITEM" "$APPCAST"
+rm -f "$ITEM"
+
+echo "✓ appcast mis à jour : Pinpoint $VERSION"
+echo "  → commit landing/public/appcast.xml puis redéploie la landing (vercel deploy --prod)."


### PR DESCRIPTION
Ajoute la mise à jour automatique **in-app** (1 clic) via [Sparkle](https://sparkle-project.org) 2.9, pour les builds distribués hors App Store (DMG notarisé sur GitHub Releases).

## Contenu
- **App** : package SPM Sparkle + `SPUStandardUpdaterController` démarré au lancement (checks auto) + item de menu **« Rechercher les mises à jour… »**. Clés Info.plist : `SUFeedURL` (appcast sur la landing), `SUPublicEDKey`, `SUEnableAutomaticChecks`.
- **Appcast** : `landing/public/appcast.xml` servi sur `pinpoint-ashy.vercel.app/appcast.xml`.
- **Release** : `scripts/update-appcast.sh` signe le DMG (EdDSA, clé du Trousseau) et ajoute l'entrée à l'appcast ; `release.sh` signe désormais le code imbriqué de Sparkle (Updater.app, XPCServices, Autoupdate) requis par le hardened runtime.
- README + i18n FR.

## Vérification
- `xcodebuild … build` → **BUILD SUCCEEDED** (Sparkle résolu).
- App buildée : `Sparkle.framework` embarqué (Updater.app, Downloader/Installer.xpc, Autoupdate) + clés Info.plist présentes (`SUFeedURL`, `SUPublicEDKey`, checks auto).
- `appcast.xml` validé (`xmllint`).

## À faire pour activer
1. Merger + inclure dans la prochaine release (ex. v0.4.0) : `release.sh` → `gh release create` → `update-appcast.sh`.
2. Committer `appcast.xml` + **redéployer la landing** (`vercel deploy --prod`) pour servir le flux.

## Rollout
Les utilisateurs actuels (v0.3.0, sans Sparkle) devront installer **manuellement** la 1re version qui embarque Sparkle ; ensuite les mises à jour sont automatiques.

## Notes de sécurité / infra
- La **clé privée EdDSA** reste dans le Trousseau de la machine de release (publique dans `project.yml`).
- ⚠️ La signature du code imbriqué Sparkle en release notarisée est à **confirmer au 1er vrai build notarisé** (impossible à vérifier sans cutter une release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)