### PR TITLE
Release v0.4.0

### DIFF
--- a/Pinpoint/AppDelegate.swift
+++ b/Pinpoint/AppDelegate.swift
@@ -1,6 +1,7 @@
 import AppKit
 import SwiftUI
 import KeyboardShortcuts
+import Sparkle
 
 extension Notification.Name {
     /// Posted by the shelf to open Pinpoint's unified settings window.
@@ -18,6 +19,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var settingsController: SettingsWindowController?
     private var shelfController: ShelfWindowController?
     private let recentMenu = NSMenu()
+    /// Sparkle updater. Created (and started) at launch so scheduled background
+    /// checks run; the menu item below also triggers a manual check.
+    private let updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         setupStatusItem()
@@ -93,6 +97,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         recentItem.submenu = recentMenu
         menu.addItem(recentItem)
         menu.addItem(.separator())
+
+        let updatesItem = NSMenuItem(title: String(localized: "Check for updates…"),
+                                     action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)),
+                                     keyEquivalent: "")
+        updatesItem.target = updaterController
+        menu.addItem(updatesItem)
 
         let settingsItem = NSMenuItem(title: String(localized: "Settings…"), action: #selector(openSettings), keyEquivalent: ",")
         settingsItem.target = self

--- a/Pinpoint/EditorView.swift
+++ b/Pinpoint/EditorView.swift
@@ -1,4 +1,6 @@
 import SwiftUI
+import AppKit
+import UniformTypeIdentifiers
 
 /// Annotation tools the user can switch between in the editor.
 enum EditorTool: String, CaseIterable, Identifiable {
@@ -238,6 +240,13 @@ struct EditorView: View {
             .buttonStyle(.borderedProminent)
             .tint(.pinpointVermillon)
             .keyboardShortcut("c", modifiers: [.command])
+
+            Button(action: save) {
+                Label(String(localized: "Save image…"), systemImage: "square.and.arrow.down")
+                    .frame(maxWidth: .infinity)
+            }
+            .controlSize(.large)
+            .keyboardShortcut("s", modifiers: [.command])
         }
         .padding(14)
     }
@@ -385,6 +394,21 @@ struct EditorView: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) {
             withAnimation { didCopy = false }
         }
+    }
+
+    private func save() {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.png]
+        panel.nameFieldStringValue = "Pinpoint.png"
+        panel.canCreateDirectories = true
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        // Full resolution here (no cap): the file is meant to be attached/kept,
+        // unlike the pasteboard image which is downscaled to stay pasteable.
+        guard let png = Exporter.pngData(base: image, pins: pins, shapes: shapes, context: context,
+                                         style: pinStyle, includeLegend: includeLegend, maxDimension: nil) else { return }
+        try? png.write(to: url)
+        onPersist(pins, shapes, context)
     }
 
     // MARK: - Geometry

--- a/Pinpoint/Exporter.swift
+++ b/Pinpoint/Exporter.swift
@@ -268,8 +268,49 @@ enum Exporter {
         return result
     }
 
+    /// Longest-edge cap (pixels) for the image placed on the pasteboard. Captures
+    /// are stored at native Retina resolution, which makes the full-size PNG too
+    /// large to paste into some targets (Claude, GitHub). The agent doesn't need
+    /// that detail — the text carries each marker's position — so the clipboard
+    /// image is downscaled to fit, while "Save image…" keeps full resolution.
+    static let clipboardMaxDimension: CGFloat = 2000
+
+    /// PNG data for the annotated image (with legend when `includeLegend`),
+    /// optionally downscaled so its longest edge is at most `maxDimension` pixels.
+    /// Pass `nil` for full native resolution.
+    static func pngData(base: NSImage, pins: [Pin], shapes: [Markup], context: String,
+                        style: PinStyle, includeLegend: Bool, maxDimension: CGFloat?) -> Data? {
+        let image = exportImage(base: base, pins: pins, shapes: shapes, context: context,
+                                style: style, includeLegend: includeLegend)
+        guard let tiff = image.tiffRepresentation, let rep = NSBitmapImageRep(data: tiff) else { return nil }
+        let output = maxDimension.flatMap { downscaled(rep, maxDimension: $0) } ?? rep
+        return output.representation(using: .png, properties: [:])
+    }
+
+    /// Returns `rep` shrunk so its longest pixel edge is `maxDimension`, or `rep`
+    /// itself when it already fits. Works in pixels so the cap is exact regardless
+    /// of the drawing context's scale.
+    private static func downscaled(_ rep: NSBitmapImageRep, maxDimension: CGFloat) -> NSBitmapImageRep? {
+        let longest = CGFloat(max(rep.pixelsWide, rep.pixelsHigh))
+        guard longest > maxDimension else { return rep }
+        let factor = maxDimension / longest
+        let width = Int((CGFloat(rep.pixelsWide) * factor).rounded())
+        let height = Int((CGFloat(rep.pixelsHigh) * factor).rounded())
+        guard let dst = NSBitmapImageRep(
+            bitmapDataPlanes: nil, pixelsWide: width, pixelsHigh: height,
+            bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+            colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0) else { return rep }
+        dst.size = NSSize(width: width, height: height)
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: dst)
+        NSGraphicsContext.current?.imageInterpolation = .high
+        rep.draw(in: NSRect(x: 0, y: 0, width: width, height: height))
+        NSGraphicsContext.restoreGraphicsState()
+        return dst
+    }
+
     /// Puts the (optionally legend-bearing) annotated PNG on the general
-    /// pasteboard.
+    /// pasteboard, downscaled to `clipboardMaxDimension` so it stays pasteable.
     ///
     /// When the legend is baked into the image the PNG is self-contained, so we
     /// deliberately leave the plain instruction text off the pasteboard: a
@@ -279,14 +320,11 @@ enum Exporter {
     /// is the sole carrier of the marker descriptions and instructions.
     static func copyToPasteboard(base: NSImage, pins: [Pin], shapes: [Markup], context: String,
                                  style: PinStyle, includeLegend: Bool) {
-        let image = exportImage(base: base, pins: pins, shapes: shapes, context: context,
-                                style: style, includeLegend: includeLegend)
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
 
-        if let tiff = image.tiffRepresentation,
-           let rep = NSBitmapImageRep(data: tiff),
-           let png = rep.representation(using: .png, properties: [:]) {
+        if let png = pngData(base: base, pins: pins, shapes: shapes, context: context,
+                             style: style, includeLegend: includeLegend, maxDimension: clipboardMaxDimension) {
             pasteboard.setData(png, forType: .png)
         }
 

--- a/Pinpoint/Info.plist
+++ b/Pinpoint/Info.plist
@@ -24,5 +24,11 @@
 	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2026 Baptiste Bouillot</string>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+	<key>SUFeedURL</key>
+	<string>https://pinpoint-ashy.vercel.app/appcast.xml</string>
+	<key>SUPublicEDKey</key>
+	<string>+9BFwjsyhynA3QpwOytwA3h1E7yy0OJH+R26Xbzkrsw=</string>
 </dict>
 </plist>

--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -119,6 +119,11 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Capturée le" } }
       }
     },
+    "Check for updates…" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Rechercher les mises à jour…" } }
+      }
+    },
     "Choose a folder…" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Choisir un dossier…" } }

--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -169,6 +169,11 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Copier pour l’agent" } }
       }
     },
+    "Save image…" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Enregistrer l’image…" } }
+      }
+    },
     "Copy image" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Copier l’image" } }

--- a/Pinpoint/PinpointApp.swift
+++ b/Pinpoint/PinpointApp.swift
@@ -25,15 +25,33 @@ struct PinpointApp: App {
 /// onglets pilotent le même `ScreenshotStore` partagé que la fenêtre Étagère.
 struct SettingsView: View {
     var body: some View {
-        TabView {
-            CaptureSettingsView()
-                .tabItem { Label("Capture", systemImage: "camera.viewfinder") }
+        VStack(spacing: 0) {
+            TabView {
+                CaptureSettingsView()
+                    .tabItem { Label("Capture", systemImage: "camera.viewfinder") }
 
-            ShelfSettingsView()
-                .environmentObject(ScreenshotStore.shared)
-                .tabItem { Label("Shelf", systemImage: "tray.full") }
+                ShelfSettingsView()
+                    .environmentObject(ScreenshotStore.shared)
+                    .tabItem { Label("Shelf", systemImage: "tray.full") }
+            }
+
+            Divider()
+            Text(Self.versionString)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+                .padding(.vertical, 6)
         }
-        .frame(width: 460, height: 340)
+        .frame(width: 460, height: 366)
+    }
+
+    /// Marketing version + build read from the bundle, e.g. "Pinpoint 0.3.0 (3)".
+    /// Selectable so it can be copied into a bug report.
+    private static var versionString: String {
+        let info = Bundle.main.infoDictionary
+        let short = info?["CFBundleShortVersionString"] as? String ?? "—"
+        let build = info?["CFBundleVersion"] as? String ?? "—"
+        return "Pinpoint \(short) (\(build))"
     }
 }
 

--- a/Pinpoint/RegionSelectionController.swift
+++ b/Pinpoint/RegionSelectionController.swift
@@ -1,13 +1,17 @@
 import AppKit
 
-/// Presents a full-screen dimming overlay (one borderless window spanning all
-/// screens) and lets the user drag a rectangle to pick a capture region.
+/// Presents a full-screen dimming overlay (one borderless window per screen)
+/// and lets the user drag a rectangle to pick a capture region.
 ///
-/// Mirrors `EditorWindowController`: this file owns presentation and the window;
-/// `RegionSelectionView` owns drawing and event handling.
+/// One window per `NSScreen` is required because, with "Displays have separate
+/// Spaces" (the macOS default), a single window spanning the union of all
+/// screens only renders reliably on the primary display.
+///
+/// Mirrors `EditorWindowController`: this file owns presentation and the
+/// windows; `RegionSelectionView` owns drawing and event handling.
 @MainActor
 final class RegionSelectionController {
-    private var window: OverlayWindow?
+    private var windows: [OverlayWindow] = []
     private var continuation: CheckedContinuation<CaptureRegion?, Never>?
 
     /// Shows the overlay and resolves with the chosen region, or `nil` if the
@@ -22,33 +26,49 @@ final class RegionSelectionController {
     // MARK: - Presentation
 
     private func present() {
-        let unionFrame = NSScreen.screens.reduce(CGRect.null) { $0.union($1.frame) }
-        guard !unionFrame.isNull else { finish(nil); return }
+        let screens = NSScreen.screens
+        guard !screens.isEmpty else { finish(nil); return }
 
-        let window = OverlayWindow(
-            contentRect: unionFrame,
-            styleMask: .borderless,
-            backing: .buffered,
-            defer: false
-        )
-        window.level = .screenSaver
-        window.isOpaque = false
-        window.backgroundColor = .clear
-        window.hasShadow = false
-        window.ignoresMouseEvents = false
-        window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+        // The window under the pointer becomes key so Esc works immediately and
+        // owns the hint; the others just dim their screen (AppKit routes a drag
+        // to the window that got the mouseDown, so the anchor screen owns it).
+        let cursor = NSEvent.mouseLocation
+        let keyScreen = screens.first { NSMouseInRect(cursor, $0.frame, false) } ?? NSScreen.main
 
-        let view = RegionSelectionView(frame: NSRect(origin: .zero, size: unionFrame.size))
-        view.onComplete = { [weak self] globalRect, anchor in
-            self?.finish(Self.resolve(globalRect: globalRect, anchor: anchor))
-        }
-        view.onCancel = { [weak self] in self?.finish(nil) }
-        window.contentView = view
-
-        self.window = window
         NSApp.activate(ignoringOtherApps: true)
-        window.makeKeyAndOrderFront(nil)
-        window.makeFirstResponder(view)
+
+        for screen in screens {
+            let window = OverlayWindow(
+                contentRect: screen.frame,
+                styleMask: .borderless,
+                backing: .buffered,
+                defer: false
+            )
+            window.level = .screenSaver
+            window.isOpaque = false
+            window.backgroundColor = .clear
+            window.hasShadow = false
+            window.ignoresMouseEvents = false
+            window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+
+            let view = RegionSelectionView(frame: NSRect(origin: .zero, size: screen.frame.size))
+            view.showsHint = (screen == keyScreen)
+            view.onComplete = { [weak self] globalRect, anchor in
+                self?.finish(Self.resolve(globalRect: globalRect, anchor: anchor))
+            }
+            view.onCancel = { [weak self] in self?.finish(nil) }
+            window.contentView = view
+
+            windows.append(window)
+
+            if screen == keyScreen {
+                window.makeKeyAndOrderFront(nil)
+                window.makeFirstResponder(view)
+            } else {
+                window.orderFront(nil)
+            }
+        }
+
         NSCursor.crosshair.push()
     }
 
@@ -56,8 +76,8 @@ final class RegionSelectionController {
         guard let continuation else { return }
         self.continuation = nil
         NSCursor.pop()
-        window?.orderOut(nil)
-        window = nil
+        for window in windows { window.orderOut(nil) }
+        windows.removeAll()
         continuation.resume(returning: region)
     }
 

--- a/Pinpoint/RegionSelectionView.swift
+++ b/Pinpoint/RegionSelectionView.swift
@@ -10,6 +10,9 @@ final class RegionSelectionView: NSView {
     var onComplete: ((CGRect, CGPoint) -> Void)?
     /// Called when the user cancels (Esc, or a click without a real drag).
     var onCancel: (() -> Void)?
+    /// Whether to draw the "drag a rectangle" hint. With one view per screen,
+    /// only the view under the pointer sets this, so the hint shows just once.
+    var showsHint: Bool = true
 
     private var anchor: CGPoint?  // view-local
     private var current: CGPoint? // view-local
@@ -74,7 +77,7 @@ final class RegionSelectionView: NSView {
 
         guard let sel = selectionRect?.intersection(bounds), sel.width > 0, sel.height > 0 else {
             bounds.fill()
-            drawHint()
+            if showsHint { drawHint() }
             return
         }
 

--- a/README.md
+++ b/README.md
@@ -180,13 +180,19 @@ then:
 scripts/release.sh   # → build/dist/Pinpoint.dmg (signed, notarized, stapled)
 ```
 
-Then publish the release and bump the Homebrew cask:
+Then publish the release, bump the Homebrew cask, and update the Sparkle appcast:
 
 ```bash
 git tag vX.Y.Z && git push origin vX.Y.Z
 gh release create vX.Y.Z --latest build/dist/Pinpoint.dmg#Pinpoint.dmg
-scripts/update-cask.sh   # → pushes the version + sha256 to croustibat/homebrew-tap
+scripts/update-cask.sh      # → pushes the version + sha256 to croustibat/homebrew-tap
+scripts/update-appcast.sh   # → signs the DMG (EdDSA) and adds it to landing/public/appcast.xml
 ```
+
+Then commit `landing/public/appcast.xml` and redeploy the landing (`vercel deploy --prod`)
+so in-app auto-update (Sparkle) sees the new version. The EdDSA private key lives in
+the release machine's keychain (paired with `SUPublicEDKey` in `project.yml`); create it
+once with Sparkle's `generate_keys`.
 
 ## License
 

--- a/landing/public/appcast.xml
+++ b/landing/public/appcast.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Pinpoint</title>
+    <link>https://pinpoint-ashy.vercel.app/appcast.xml</link>
+    <description>Most recent updates to Pinpoint.</description>
+    <language>en</language>
+    <!-- NEWEST-ITEM-ANCHOR — scripts/update-appcast.sh inserts each release below this line. -->
+  </channel>
+</rss>

--- a/project.yml
+++ b/project.yml
@@ -45,8 +45,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: app.croustibat.Pinpoint
-        MARKETING_VERSION: "0.3.0"
-        CURRENT_PROJECT_VERSION: "3"
+        MARKETING_VERSION: "0.4.0"
+        CURRENT_PROJECT_VERSION: "4"
         GENERATE_INFOPLIST_FILE: NO
         SWIFT_VERSION: "5.0"
         CODE_SIGN_STYLE: Automatic

--- a/project.yml
+++ b/project.yml
@@ -10,6 +10,9 @@ packages:
   KeyboardShortcuts:
     url: https://github.com/sindresorhus/KeyboardShortcuts
     from: "2.2.0"
+  Sparkle:
+    url: https://github.com/sparkle-project/Sparkle
+    from: "2.9.0"
 
 targets:
   Pinpoint:
@@ -19,6 +22,7 @@ targets:
       - Pinpoint
     dependencies:
       - package: KeyboardShortcuts
+      - package: Sparkle
     info:
       path: Pinpoint/Info.plist
       properties:
@@ -32,6 +36,12 @@ targets:
         # Menu-bar only app: no Dock icon, no main window.
         LSUIElement: true
         NSHumanReadableCopyright: "© 2026 Baptiste Bouillot"
+        # Sparkle auto-update. The appcast is hosted on the landing site; the
+        # public EdDSA key pairs with the private key held in the release
+        # machine's keychain (used by scripts/update-appcast.sh to sign updates).
+        SUFeedURL: https://pinpoint-ashy.vercel.app/appcast.xml
+        SUPublicEDKey: "+9BFwjsyhynA3QpwOytwA3h1E7yy0OJH+R26Xbzkrsw="
+        SUEnableAutomaticChecks: true
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: app.croustibat.Pinpoint

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -36,8 +36,18 @@ xcodebuild -scheme Pinpoint -configuration Release \
   clean build >/dev/null
 
 echo "▸ Signing with Developer ID + hardened runtime"
-# Sign nested code (frameworks/dylibs) first, then the app bundle.
+# Sign nested code deepest-first, then the app bundle. Sparkle ships a helper
+# app (Updater.app), XPC services and a bare Autoupdate tool that each need
+# their own signature under the hardened runtime, before the framework and app.
 if [ -d "$APP/Contents/Frameworks" ]; then
+  find "$APP/Contents/Frameworks" -depth \( -name "*.xpc" -o -name "*.app" \) -print0 \
+    | while IFS= read -r -d '' item; do
+        codesign --force --options runtime --timestamp --sign "$IDENTITY" "$item"
+      done
+  find "$APP/Contents/Frameworks" -name "Autoupdate" -type f -print0 \
+    | while IFS= read -r -d '' item; do
+        codesign --force --options runtime --timestamp --sign "$IDENTITY" "$item"
+      done
   find "$APP/Contents/Frameworks" -depth \( -name "*.framework" -o -name "*.dylib" \) -print0 \
     | while IFS= read -r -d '' item; do
         codesign --force --options runtime --timestamp --sign "$IDENTITY" "$item"

--- a/scripts/update-appcast.sh
+++ b/scripts/update-appcast.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# Appends the freshly built release to the Sparkle appcast
+# (landing/public/appcast.xml), signing the notarized DMG with the EdDSA key
+# held in the release machine's keychain.
+#
+# Run AFTER scripts/release.sh (which resolves Sparkle's tools under build/) and
+# AFTER the GitHub release DMG is uploaded, so the enclosure URL resolves. Then
+# commit landing/public/appcast.xml and redeploy the landing so Sparkle sees it.
+#
+# Usage: scripts/update-appcast.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DMG="$ROOT/build/dist/Pinpoint.dmg"
+APPCAST="$ROOT/landing/public/appcast.xml"
+FEED_BASE="https://github.com/croustibat/Pinpoint/releases/download"
+
+VERSION="$(grep -m1 'MARKETING_VERSION:' "$ROOT/project.yml" | sed -E 's/.*"([^"]+)".*/\1/')"
+BUILD="$(grep -m1 'CURRENT_PROJECT_VERSION:' "$ROOT/project.yml" | sed -E 's/.*"([^"]+)".*/\1/')"
+MIN_OS="$(grep -m1 'MACOSX_DEPLOYMENT_TARGET:' "$ROOT/project.yml" | sed -E 's/.*"([^"]+)".*/\1/')"
+
+[ -n "$VERSION" ] || { echo "✗ MARKETING_VERSION introuvable dans project.yml"; exit 1; }
+[ -f "$DMG" ] || { echo "✗ DMG introuvable: $DMG — lance d'abord scripts/release.sh"; exit 1; }
+[ -f "$APPCAST" ] || { echo "✗ appcast introuvable: $APPCAST"; exit 1; }
+
+# Locate Sparkle's sign_update (resolved SPM artifact under build/, or override).
+SIGN_UPDATE="${SIGN_UPDATE:-$(find "$ROOT/build" -name sign_update -type f 2>/dev/null | head -1)}"
+[ -x "$SIGN_UPDATE" ] || { echo "✗ sign_update introuvable — définis SIGN_UPDATE=/chemin/vers/sign_update"; exit 1; }
+
+if grep -q "shortVersionString>$VERSION<" "$APPCAST"; then
+  echo "✓ L'appcast contient déjà la version $VERSION"
+  exit 0
+fi
+
+# sign_update prints: sparkle:edSignature="…" length="…"
+SIG_ATTRS="$("$SIGN_UPDATE" "$DMG")"
+PUBDATE="$(date "+%a, %d %b %Y %H:%M:%S %z")"
+
+ITEM="$(mktemp)"
+cat > "$ITEM" <<EOF
+    <item>
+      <title>Version $VERSION</title>
+      <pubDate>$PUBDATE</pubDate>
+      <sparkle:version>$BUILD</sparkle:version>
+      <sparkle:shortVersionString>$VERSION</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>${MIN_OS:-15.0}</sparkle:minimumSystemVersion>
+      <enclosure url="$FEED_BASE/v$VERSION/Pinpoint.dmg" $SIG_ATTRS type="application/octet-stream" />
+    </item>
+EOF
+
+# Insert the new item right after the anchor comment (newest first).
+sed -i '' -e "/NEWEST-ITEM-ANCHOR/r $ITEM" "$APPCAST"
+rm -f "$ITEM"
+
+echo "✓ appcast mis à jour : Pinpoint $VERSION"
+echo "  → commit landing/public/appcast.xml puis redéploie la landing (vercel deploy --prod)."


### PR DESCRIPTION
Release **v0.4.0** — regroupe tout ce qui a atterri sur `develop` depuis v0.3.0.

## Inclus
- **Fix multi-écran** (#26) : overlay de sélection sur tous les écrans (une fenêtre par `NSScreen`). *Vérifié visuellement sur 2 moniteurs.*
- **Image copiée plafonnée + « Enregistrer l'image… »** (#28) : le collage passe partout (≤ 2000 px), export PNG pleine réso via ⌘S.
- **Auto-update Sparkle** : mise à jour in-app + menu « Rechercher les mises à jour… » + appcast.
- **Version affichée dans les réglages**.
- Bump `MARKETING_VERSION` → 0.4.0 (build 4).

⚠️ 1er build embarquant Sparkle : la signature du code imbriqué (Updater.app, XPCServices, Autoupdate) sera validée à la notarisation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)