### PR TITLE
Repères : pastille entière près des bords

### DIFF
--- a/Pinpoint/EditorView.swift
+++ b/Pinpoint/EditorView.swift
@@ -149,7 +149,7 @@ struct EditorView: View {
 
                 // Numbered pins.
                 ForEach($pins) { $pin in
-                    let anchor = absolutePoint(pin.position, in: fitted)
+                    let anchor = clampedMarkerAnchor(absolutePoint(pin.position, in: fitted), in: fitted)
                     PinMarker(number: pin.number, style: pinStyle, selected: pin.id == selectedPinID)
                         .position(x: anchor.x, y: anchor.y + PinMarker.anchorYOffset(pinStyle))
                         .gesture(pinDrag($pin, in: fitted))
@@ -437,6 +437,25 @@ struct EditorView: View {
 
     private func absolutePoint(_ p: CGPoint, in fitted: CGRect) -> CGPoint {
         CGPoint(x: fitted.minX + p.x * fitted.width, y: fitted.minY + p.y * fitted.height)
+    }
+
+    /// Nudges a marker's anchor so its badge stays fully within the fitted image
+    /// even when the point is near an edge. Only affects where the badge is
+    /// drawn — `pin.position` is untouched — and mirrors `Exporter`'s clamping so
+    /// the editor and the exported image agree.
+    private func clampedMarkerAnchor(_ anchor: CGPoint, in fitted: CGRect) -> CGPoint {
+        let side = PinMarker.headDiameter / 2 + 2  // circle half-width incl. ring
+        let x = min(max(anchor.x, fitted.minX + side), max(fitted.minX + side, fitted.maxX - side))
+        switch pinStyle {
+        case .disc, .outline:
+            let y = min(max(anchor.y, fitted.minY + side), max(fitted.minY + side, fitted.maxY - side))
+            return CGPoint(x: x, y: y)
+        case .pointer:
+            // The 28×42 marker sits with its tip at the anchor, extending upward.
+            let top = fitted.minY + PinMarker.pointerHeight
+            let y = min(max(anchor.y, top), max(top, fitted.maxY))
+            return CGPoint(x: x, y: y)
+        }
     }
 
     private func absoluteRect(_ r: CGRect, in fitted: CGRect) -> CGRect {

--- a/Pinpoint/Exporter.swift
+++ b/Pinpoint/Exporter.swift
@@ -25,7 +25,10 @@ enum Exporter {
                 x: pin.position.x * size.width,
                 y: (1 - pin.position.y) * size.height
             )
-            drawMarker(number: pin.number, anchor: anchor, radius: radius, style: style)
+            // Keep the badge fully inside the image when the point is near an
+            // edge; the exact point is still carried by the % in the text.
+            let drawAnchor = clampedMarkerAnchor(anchor, radius: radius, style: style, in: size)
+            drawMarker(number: pin.number, anchor: drawAnchor, radius: radius, style: style)
         }
 
         result.unlockFocus()
@@ -79,6 +82,26 @@ enum Exporter {
             path.line(to: right)
             path.stroke()
         }
+    }
+
+    /// Shifts `anchor` so the marker's badge stays fully within `size` (image
+    /// space, y up). For the pointer the tip is at the anchor and the head sits
+    /// above it (+y); disc/outline are centred on the anchor. Mirrors the
+    /// clamping done on screen in `EditorView` so export and editor agree.
+    private static func clampedMarkerAnchor(_ anchor: CGPoint, radius: CGFloat, style: PinStyle, in size: CGSize) -> CGPoint {
+        let side = radius + max(2, radius * 0.16)  // half-width incl. ring
+        let x = clamp(anchor.x, side, size.width - side)
+        switch style {
+        case .disc, .outline:
+            return CGPoint(x: x, y: clamp(anchor.y, side, size.height - side))
+        case .pointer:
+            // The head reaches anchor.y + 3·radius upward; the tip is the low point.
+            return CGPoint(x: x, y: clamp(anchor.y, 0, size.height - radius * 3))
+        }
+    }
+
+    private static func clamp(_ v: CGFloat, _ lo: CGFloat, _ hi: CGFloat) -> CGFloat {
+        max(lo, min(v, max(lo, hi)))
     }
 
     /// Draws a numbered marker at `anchor` (image space) in the chosen style.


### PR DESCRIPTION
Corrige les pastilles rognées/flottantes quand un repère est posé près d'un bord. Closes #34.

## Cause
La pastille était dessinée centrée sur le point cliqué → près d'un bord, elle débordait : au-dessus de l'image dans l'éditeur, et **rognée dans le PNG exporté** (numéro coupé pour l'agent).

## Fix
Clamp de l'ancre de **dessin** pour garder la pastille entièrement dans l'image, **sans changer la position stockée** (le point exact reste dans le texte en %). Même logique dans l'éditeur (`PinMarker`) et l'export (`Exporter`) :
- disc/outline : centrés, ramenés à l'intérieur (rayon + anneau).
- pointer : la pointe reste sur le point (haut/bas), la tête est ramenée sous le bord.

## Vérification
- `xcodebuild … build` → **BUILD SUCCEEDED**.
- Harnais autonome sur `Exporter.annotatedImage` : repères aux 4 coins/bords extrêmes → **toutes les pastilles entières**, aucune rognée (disc + pointer), vérifié visuellement sur les PNG exportés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)