### PR TITLE
Release v0.5.0

### DIFF
--- a/Pinpoint/EditorView.swift
+++ b/Pinpoint/EditorView.swift
@@ -149,7 +149,7 @@ struct EditorView: View {
 
                 // Numbered pins.
                 ForEach($pins) { $pin in
-                    let anchor = absolutePoint(pin.position, in: fitted)
+                    let anchor = clampedMarkerAnchor(absolutePoint(pin.position, in: fitted), in: fitted)
                     PinMarker(number: pin.number, style: pinStyle, selected: pin.id == selectedPinID)
                         .position(x: anchor.x, y: anchor.y + PinMarker.anchorYOffset(pinStyle))
                         .gesture(pinDrag($pin, in: fitted))
@@ -437,6 +437,25 @@ struct EditorView: View {
 
     private func absolutePoint(_ p: CGPoint, in fitted: CGRect) -> CGPoint {
         CGPoint(x: fitted.minX + p.x * fitted.width, y: fitted.minY + p.y * fitted.height)
+    }
+
+    /// Nudges a marker's anchor so its badge stays fully within the fitted image
+    /// even when the point is near an edge. Only affects where the badge is
+    /// drawn — `pin.position` is untouched — and mirrors `Exporter`'s clamping so
+    /// the editor and the exported image agree.
+    private func clampedMarkerAnchor(_ anchor: CGPoint, in fitted: CGRect) -> CGPoint {
+        let side = PinMarker.headDiameter / 2 + 2  // circle half-width incl. ring
+        let x = min(max(anchor.x, fitted.minX + side), max(fitted.minX + side, fitted.maxX - side))
+        switch pinStyle {
+        case .disc, .outline:
+            let y = min(max(anchor.y, fitted.minY + side), max(fitted.minY + side, fitted.maxY - side))
+            return CGPoint(x: x, y: y)
+        case .pointer:
+            // The 28×42 marker sits with its tip at the anchor, extending upward.
+            let top = fitted.minY + PinMarker.pointerHeight
+            let y = min(max(anchor.y, top), max(top, fitted.maxY))
+            return CGPoint(x: x, y: y)
+        }
     }
 
     private func absoluteRect(_ r: CGRect, in fitted: CGRect) -> CGRect {

--- a/Pinpoint/Exporter.swift
+++ b/Pinpoint/Exporter.swift
@@ -25,7 +25,10 @@ enum Exporter {
                 x: pin.position.x * size.width,
                 y: (1 - pin.position.y) * size.height
             )
-            drawMarker(number: pin.number, anchor: anchor, radius: radius, style: style)
+            // Keep the badge fully inside the image when the point is near an
+            // edge; the exact point is still carried by the % in the text.
+            let drawAnchor = clampedMarkerAnchor(anchor, radius: radius, style: style, in: size)
+            drawMarker(number: pin.number, anchor: drawAnchor, radius: radius, style: style)
         }
 
         result.unlockFocus()
@@ -79,6 +82,26 @@ enum Exporter {
             path.line(to: right)
             path.stroke()
         }
+    }
+
+    /// Shifts `anchor` so the marker's badge stays fully within `size` (image
+    /// space, y up). For the pointer the tip is at the anchor and the head sits
+    /// above it (+y); disc/outline are centred on the anchor. Mirrors the
+    /// clamping done on screen in `EditorView` so export and editor agree.
+    private static func clampedMarkerAnchor(_ anchor: CGPoint, radius: CGFloat, style: PinStyle, in size: CGSize) -> CGPoint {
+        let side = radius + max(2, radius * 0.16)  // half-width incl. ring
+        let x = clamp(anchor.x, side, size.width - side)
+        switch style {
+        case .disc, .outline:
+            return CGPoint(x: x, y: clamp(anchor.y, side, size.height - side))
+        case .pointer:
+            // The head reaches anchor.y + 3·radius upward; the tip is the low point.
+            return CGPoint(x: x, y: clamp(anchor.y, 0, size.height - radius * 3))
+        }
+    }
+
+    private static func clamp(_ v: CGFloat, _ lo: CGFloat, _ hi: CGFloat) -> CGFloat {
+        max(lo, min(v, max(lo, hi)))
     }
 
     /// Draws a numbered marker at `anchor` (image space) in the chosen style.

--- a/README.md
+++ b/README.md
@@ -189,10 +189,12 @@ scripts/update-cask.sh      # → pushes the version + sha256 to croustibat/home
 scripts/update-appcast.sh   # → signs the DMG (EdDSA) and adds it to landing/public/appcast.xml
 ```
 
-Then commit `landing/public/appcast.xml` and redeploy the landing (`vercel deploy --prod`)
-so in-app auto-update (Sparkle) sees the new version. The EdDSA private key lives in
-the release machine's keychain (paired with `SUPublicEDKey` in `project.yml`); create it
-once with Sparkle's `generate_keys`.
+Add the release to the changelog (`landing/src/changelog.ts` — new entry at the top,
+mark it `latest`), then commit it together with `landing/public/appcast.xml` and redeploy
+the landing (`vercel deploy --prod`) so in-app auto-update (Sparkle) sees the new version
+and [`/changelog`](https://pinpoint-ashy.vercel.app/changelog) shows it. The EdDSA private
+key lives in the release machine's keychain (paired with `SUPublicEDKey` in `project.yml`);
+create it once with Sparkle's `generate_keys`.
 
 ## License
 

--- a/landing/src/changelog.ts
+++ b/landing/src/changelog.ts
@@ -14,9 +14,18 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.5.0',
+    date: '2026-07-09',
+    latest: true,
+    changes: [
+      { type: 'fixed', text: 'Markers placed near an edge are no longer clipped in the exported image — the badge is kept fully inside the picture.' },
+      { type: 'added', text: 'Shelf: ⌘A selects all screenshots and Esc exits selection mode.' },
+      { type: 'fixed', text: 'The editor’s tool picker no longer shifts around in narrow windows.' },
+    ],
+  },
+  {
     version: '0.4.0',
     date: '2026-07-06',
-    latest: true,
     changes: [
       { type: 'added', text: 'Automatic updates — a new “Check for updates…” menu item plus background checks, so new releases install in one click.' },
       { type: 'fixed', text: 'Multi-monitor capture: the selection overlay now dims and works on every display, not just the primary one.' },

--- a/landing/src/changelog.ts
+++ b/landing/src/changelog.ts
@@ -1,0 +1,44 @@
+// Hand-maintained changelog shown on /changelog.
+// Add a new entry at the TOP for each release (mark it `latest: true` and drop
+// `latest` from the previous one). Keep it in sync with the GitHub release notes.
+
+export type ChangeType = 'added' | 'fixed' | 'changed';
+
+export interface ChangelogEntry {
+  version: string;
+  /** ISO date (YYYY-MM-DD) of the release. */
+  date: string;
+  latest?: boolean;
+  changes: { type: ChangeType; text: string }[];
+}
+
+export const changelog: ChangelogEntry[] = [
+  {
+    version: '0.4.0',
+    date: '2026-07-06',
+    latest: true,
+    changes: [
+      { type: 'added', text: 'Automatic updates — a new “Check for updates…” menu item plus background checks, so new releases install in one click.' },
+      { type: 'fixed', text: 'Multi-monitor capture: the selection overlay now dims and works on every display, not just the primary one.' },
+      { type: 'fixed', text: 'Copied images always paste — the “Copy for the agent” image is capped so it reliably pastes into Claude, GitHub, and other targets.' },
+      { type: 'added', text: '“Save image…” (⌘S) exports the full-resolution annotated PNG.' },
+      { type: 'added', text: 'The installed version is now shown in Settings.' },
+    ],
+  },
+  {
+    version: '0.3.0',
+    date: '2026-07-02',
+    changes: [
+      { type: 'added', text: 'Edit in Pinpoint from the Shelf — reopen any screenshot, including a native ⌘⇧4 capture, as an annotation session.' },
+      { type: 'added', text: 'Custom Shelf titles — rename a capture in the Shelf without touching the file on disk.' },
+      { type: 'fixed', text: 'Pasting a capture into a terminal now keeps the image instead of dropping it for the text.' },
+    ],
+  },
+  {
+    version: '0.2.0',
+    date: '2026-06-23',
+    changes: [
+      { type: 'added', text: 'First public release — capture a region, drop numbered markers, and copy a ready-to-paste prompt for your AI agent.' },
+    ],
+  },
+];

--- a/landing/src/components/Landing.astro
+++ b/landing/src/components/Landing.astro
@@ -30,6 +30,7 @@ const featureIcons = [
       <a href="#how" class="transition hover:text-white">{t.nav.how}</a>
       <a href="#features" class="transition hover:text-white">{t.nav.features}</a>
       <a href="#agents" class="transition hover:text-white">{t.nav.agents}</a>
+      <a href="/changelog" class="transition hover:text-white">{t.nav.changelog}</a>
       <a href={GITHUB_URL} class="transition hover:text-white">{t.nav.github}</a>
     </div>
 

--- a/landing/src/i18n.ts
+++ b/landing/src/i18n.ts
@@ -16,7 +16,7 @@ export const otherLang: Record<Lang, { code: Lang; href: string }> = {
 
 type Content = {
   meta: { title: string; description: string };
-  nav: { features: string; how: string; agents: string; github: string; download: string };
+  nav: { features: string; how: string; agents: string; changelog: string; github: string; download: string };
   hero: {
     eyebrow: string;
     titleA: string;
@@ -42,7 +42,7 @@ export const content: Record<Lang, Content> = {
       description:
         'A macOS menu-bar app that captures your screen, drops numbered markers on what matters, and copies a ready-to-paste prompt for your AI agent. Free & open source.',
     },
-    nav: { features: 'Features', how: 'How it works', agents: 'For agents', github: 'GitHub', download: 'Download' },
+    nav: { features: 'Features', how: 'How it works', agents: 'For agents', changelog: 'Changelog', github: 'GitHub', download: 'Download' },
     hero: {
       eyebrow: 'macOS menu-bar app — free & open source',
       titleA: 'Point at exactly',
@@ -115,7 +115,7 @@ Make the CTA full-width on mobile and fix the icon alignment.`,
       description:
         'Une app de barre de menus macOS qui capture ton écran, pose des repères numérotés sur ce qui compte, et copie un prompt prêt à coller pour ton agent IA. Gratuite & open source.',
     },
-    nav: { features: 'Fonctions', how: 'Comment ça marche', agents: 'Pour les agents', github: 'GitHub', download: 'Télécharger' },
+    nav: { features: 'Fonctions', how: 'Comment ça marche', agents: 'Pour les agents', changelog: 'Changelog', github: 'GitHub', download: 'Télécharger' },
     hero: {
       eyebrow: 'App de barre de menus macOS — gratuite & open source',
       titleA: 'Désigne exactement',

--- a/landing/src/pages/changelog.astro
+++ b/landing/src/pages/changelog.astro
@@ -1,0 +1,103 @@
+---
+import Base from '../layouts/Base.astro';
+import { changelog, type ChangeType } from '../changelog';
+import { GITHUB_URL, DOWNLOAD_URL } from '../i18n';
+
+const latest = changelog.find((e) => e.latest) ?? changelog[0];
+
+const badge: Record<ChangeType, { label: string; cls: string }> = {
+  added: { label: 'New', cls: 'bg-emerald-500/15 text-emerald-300 ring-1 ring-inset ring-emerald-500/20' },
+  fixed: { label: 'Fix', cls: 'bg-amber-500/15 text-amber-300 ring-1 ring-inset ring-amber-500/20' },
+  changed: { label: 'Changed', cls: 'bg-sky-500/15 text-sky-300 ring-1 ring-inset ring-sky-500/20' },
+};
+
+const fmt = (iso: string) =>
+  new Date(iso + 'T12:00:00Z').toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+---
+
+<Base
+  lang="en"
+  title="Pinpoint — Changelog"
+  description="What's new in Pinpoint, release by release."
+>
+  <header class="sticky top-0 z-50 border-b border-white/5 bg-ink/70 backdrop-blur-xl">
+    <nav class="mx-auto flex h-16 max-w-6xl items-center justify-between px-5">
+      <a href="/" class="flex items-center gap-2.5">
+        <img src="/icon.png" alt="Pinpoint" width="28" height="28" class="rounded-[7px]" />
+        <span class="text-[15px] font-semibold tracking-tight text-white">Pinpoint</span>
+      </a>
+
+      <div class="hidden items-center gap-8 text-sm text-zinc-400 md:flex">
+        <a href="/#how" class="transition hover:text-white">How it works</a>
+        <a href="/#features" class="transition hover:text-white">Features</a>
+        <a href="/changelog" class="text-white">Changelog</a>
+        <a href={GITHUB_URL} class="transition hover:text-white">GitHub</a>
+      </div>
+
+      <a
+        href={DOWNLOAD_URL}
+        class="rounded-lg bg-white px-3.5 py-1.5 text-sm font-semibold text-ink transition hover:bg-zinc-200"
+        >Download</a
+      >
+    </nav>
+  </header>
+
+  <main class="mx-auto max-w-3xl px-5 pt-16 pb-24">
+    <div class="mb-12 text-center">
+      <h1 class="text-4xl font-semibold tracking-tight text-white">Changelog</h1>
+      <p class="mx-auto mt-3 max-w-md text-zinc-400">
+        Every Pinpoint release. Current version
+        <a href={DOWNLOAD_URL} class="font-medium text-brand hover:underline">v{latest.version}</a>.
+      </p>
+    </div>
+
+    <div class="space-y-12">
+      {
+        changelog.map((entry) => (
+          <section class="relative border-l border-white/10 pl-6">
+            <div class="mb-4 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+              <h2 class="text-xl font-semibold text-white">v{entry.version}</h2>
+              <time datetime={entry.date} class="text-sm text-zinc-500">
+                {fmt(entry.date)}
+              </time>
+              {entry.latest && (
+                <span class="rounded-full bg-brand/15 px-2 py-0.5 text-xs font-medium text-brand ring-1 ring-inset ring-brand/25">
+                  Latest
+                </span>
+              )}
+            </div>
+            <ul class="space-y-2.5">
+              {entry.changes.map((c) => (
+                <li class="flex items-start gap-3 text-zinc-300">
+                  <span class={`mt-0.5 shrink-0 rounded-md px-1.5 py-0.5 text-[11px] font-semibold ${badge[c.type].cls}`}>
+                    {badge[c.type].label}
+                  </span>
+                  <span class="leading-relaxed">{c.text}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))
+      }
+    </div>
+  </main>
+
+  <footer class="border-t border-white/5">
+    <div class="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-5 py-10 sm:flex-row">
+      <div class="flex items-center gap-2.5">
+        <img src="/icon.png" alt="" width="22" height="22" class="rounded-md" />
+        <span class="text-sm text-zinc-400">Capture. Mark. Prompt.</span>
+      </div>
+      <div class="flex items-center gap-6 text-sm text-zinc-500">
+        <a href="/" class="transition hover:text-white">Home</a>
+        <a href={GITHUB_URL} class="transition hover:text-white">GitHub</a>
+        <span>© 2026 Baptiste Bouillot</span>
+      </div>
+    </div>
+  </footer>
+</Base>

--- a/project.yml
+++ b/project.yml
@@ -45,8 +45,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: app.croustibat.Pinpoint
-        MARKETING_VERSION: "0.4.0"
-        CURRENT_PROJECT_VERSION: "4"
+        MARKETING_VERSION: "0.5.0"
+        CURRENT_PROJECT_VERSION: "5"
         GENERATE_INFOPLIST_FILE: NO
         SWIFT_VERSION: "5.0"
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
Release **v0.5.0** — ce qui a atterri sur `develop` depuis v0.4.0.

## Inclus
- **Fix : pastilles rognées près des bords** (#35) — la pastille reste entière dans l'image exportée (vérifié visuellement).
- **Étagère : ⌘A tout sélectionner / Esc quitter la sélection** (#24).
- **Fix : layout du tool picker** dans les fenêtres étroites (#23).
- Page /changelog + entrée v0.5.0.
- Bump 0.4.0 → 0.5.0 (build 5).

_Note : crop (#21) et délai (#22) restent en attente de rebase — prévus pour une prochaine version._

🤖 Generated with [Claude Code](https://claude.com/claude-code)