### PR TITLE
Release v0.6.0 : changelog, crédit @ganuong11, menu « What's New »

### DIFF
--- a/Pinpoint/AppDelegate.swift
+++ b/Pinpoint/AppDelegate.swift
@@ -105,6 +105,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         updatesItem.target = updaterController
         menu.addItem(updatesItem)
 
+        let changelogItem = NSMenuItem(title: String(localized: "What’s New…"), action: #selector(openChangelog), keyEquivalent: "")
+        changelogItem.target = self
+        menu.addItem(changelogItem)
+
         let settingsItem = NSMenuItem(title: String(localized: "Settings…"), action: #selector(openSettings), keyEquivalent: ",")
         settingsItem.target = self
         menu.addItem(settingsItem)
@@ -177,6 +181,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
                 presentCaptureError(error)
             }
         }
+    }
+
+    /// Opens the public changelog (landing page) so users can see what each
+    /// release added. Kept as a plain URL rather than an in-app window — the
+    /// changelog lives on the site next to the download/appcast.
+    @objc private func openChangelog() {
+        guard let url = URL(string: "https://pinpoint.app/changelog") else { return }
+        NSWorkspace.shared.open(url)
     }
 
     @objc private func openSettings() {

--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -652,6 +652,11 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Dossier surveillé" } }
       }
     },
+    "What’s New…" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Nouveautés…" } }
+      }
+    },
     "White ring + drop shadow." : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Anneau blanc + ombre portée." } }

--- a/landing/src/changelog.ts
+++ b/landing/src/changelog.ts
@@ -10,13 +10,28 @@ export interface ChangelogEntry {
   date: string;
   latest?: boolean;
   changes: { type: ChangeType; text: string }[];
+  /** Optional credit line (e.g. an external contributor), linked to `href`. */
+  credit?: { text: string; href: string };
 }
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.6.0',
+    date: '2026-07-14',
+    latest: true,
+    changes: [
+      { type: 'added', text: 'Crop tool in the editor — trim a capture with eight handles and a rule-of-thirds grid; existing markers and arrows are remapped into the cropped frame.' },
+      { type: 'added', text: 'Optional capture timer — a 3, 5, or 10-second countdown before the shot so you can arrange your UI or open a menu; press Esc to cancel.' },
+      { type: 'added', text: 'A “What’s New…” item in the menu bar opens this changelog, so you can always see what each release added.' },
+    ],
+    credit: {
+      text: 'Crop tool and capture timer contributed by @ganuong11 — thank you! 🙏',
+      href: 'https://github.com/ganuong11',
+    },
+  },
+  {
     version: '0.5.0',
     date: '2026-07-09',
-    latest: true,
     changes: [
       { type: 'fixed', text: 'Markers placed near an edge are no longer clipped in the exported image — the badge is kept fully inside the picture.' },
       { type: 'added', text: 'Shelf: ⌘A selects all screenshots and Esc exits selection mode.' },

--- a/landing/src/pages/changelog.astro
+++ b/landing/src/pages/changelog.astro
@@ -81,6 +81,18 @@ const fmt = (iso: string) =>
                 </li>
               ))}
             </ul>
+            {entry.credit && (
+              <p class="mt-4 text-sm text-zinc-400">
+                <a
+                  href={entry.credit.href}
+                  target="_blank"
+                  rel="noopener"
+                  class="text-brand transition hover:underline"
+                >
+                  {entry.credit.text}
+                </a>
+              </p>
+            )}
           </section>
         ))
       }

--- a/project.yml
+++ b/project.yml
@@ -45,8 +45,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: app.croustibat.Pinpoint
-        MARKETING_VERSION: "0.5.0"
-        CURRENT_PROJECT_VERSION: "5"
+        MARKETING_VERSION: "0.6.0"
+        CURRENT_PROJECT_VERSION: "6"
         GENERATE_INFOPLIST_FILE: NO
         SWIFT_VERSION: "5.0"
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
Prépare la sortie **v0.6.0** : bump de version, entrée changelog, crédit du contributeur externe, et nouvel accès au changelog depuis le menu.

## Contenu
- **Bump** `project.yml` : `MARKETING_VERSION` 0.5.0 → **0.6.0**, `CURRENT_PROJECT_VERSION` 5 → **6**.
- **Changelog** (`landing/src/changelog.ts`) : entrée v0.6.0 en tête (`latest`), 3 lignes — outil de recadrage, minuteur de capture, item de menu « What's New… ». `latest` retiré de 0.5.0.
- **Crédit contributeur** : page `/changelog` affiche, sous les changes de la v0.6.0, un remerciement à **@ganuong11** (outil crop + minuteur), lié à son profil GitHub. Nouveau champ optionnel `credit` sur `ChangelogEntry`.
- **Menu** (`AppDelegate.swift`) : nouvel item **« What's New… »** / **« Nouveautés… »** sous « Check for updates… », ouvre `https://pinpoint.app/changelog`.
- **i18n** (`Localizable.xcstrings`) : clé `What's New…` + FR `Nouveautés…` (insertion chirurgicale, +5 lignes).

## Vérifications
- `xcodegen generate && xcodebuild -scheme Pinpoint -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED**, zéro warning.
- `changelog.ts` importé sans erreur : une seule entrée `latest`, crédit bien formé.
- Catalogue : apostrophe U+2019 identique entre le code Swift et la clé, JSON valide.

## Suite
Une fois cette PR mergée dans `develop`, ouvrir la PR `develop` → `main` (« Release v0.6.0 »), qui embarque aussi le crop (#21) et le minuteur (#22). Sa fusion, après build/notarisation + `release.sh`/`update-appcast`/`update-cask` + redeploy Vercel, constitue la release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
