### PR TITLE
Corrige l'URL du menu « What's New » (domaine pinpoint.app parké)

### DIFF
--- a/Pinpoint/AppDelegate.swift
+++ b/Pinpoint/AppDelegate.swift
@@ -187,7 +187,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     /// release added. Kept as a plain URL rather than an in-app window — the
     /// changelog lives on the site next to the download/appcast.
     @objc private func openChangelog() {
-        guard let url = URL(string: "https://pinpoint.app/changelog") else { return }
+        guard let url = URL(string: "https://pinpoint-ashy.vercel.app/changelog") else { return }
         NSWorkspace.shared.open(url)
     }
 


### PR DESCRIPTION
Correctif rapide avant la release v0.6.0.

`pinpoint.app` (utilisé dans le nouvel item de menu « What's New… » ajouté en #60) **n'est pas notre domaine** : il redirige vers une page GoDaddy « for sale ». Le site de prod est **`pinpoint-ashy.vercel.app`** — le même hôte que le `SUFeedURL` Sparkle (dont l'auto-update fonctionne déjà).

- `AppDelegate.swift` : le lien du menu ouvre désormais `https://pinpoint-ashy.vercel.app/changelog`.
- Build vérifié : **BUILD SUCCEEDED**.

> À part : `landing/astro.config.mjs` a aussi `site: 'https://pinpoint.app'` (canonical/sitemap) — incohérent, mais non bloquant pour la release. À revoir séparément selon que tu comptes acquérir `pinpoint.app` ou non.

🤖 Generated with [Claude Code](https://claude.com/claude-code)