### PR TITLE
landing : site canonical → domaine de prod (pinpoint.app parké)

### DIFF
--- a/landing/astro.config.mjs
+++ b/landing/astro.config.mjs
@@ -5,7 +5,7 @@ import { defineConfig } from 'astro/config';
 // rolldown-based Vite.
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://pinpoint.app',
+  site: 'https://pinpoint-ashy.vercel.app',
   i18n: {
     defaultLocale: 'en',
     locales: ['en', 'fr'],


### PR DESCRIPTION
Corrige `landing/astro.config.mjs` : `site` pointait vers `https://pinpoint.app`, un domaine parké (page GoDaddy « for sale »), ce qui produisait des URLs canoniques et un sitemap erronés.

Aligné sur le domaine de prod réel **`https://pinpoint-ashy.vercel.app`** — cohérent avec le `SUFeedURL` Sparkle et le lien du menu « What's New » (#61).

Vérifié : `node --check` OK.

> Baptiste ne compte pas acquérir `pinpoint.app` pour l'instant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)