### PR TITLE
Aligner main sur develop : fix canonical astro.config (#63)

### DIFF
--- a/landing/astro.config.mjs
+++ b/landing/astro.config.mjs
@@ -5,7 +5,7 @@ import { defineConfig } from 'astro/config';
 // rolldown-based Vite.
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://pinpoint.app',
+  site: 'https://pinpoint-ashy.vercel.app',
   i18n: {
     defaultLocale: 'en',
     locales: ['en', 'fr'],


### PR DESCRIPTION
Reporte dans `main` le seul commit qui manquait après la release v0.6.0 : le correctif du `site` canonical Astro (#63), mergé dans `develop` juste après la PR de release #62.

- `landing/astro.config.mjs` : `site` `pinpoint.app` → `pinpoint-ashy.vercel.app` (le domaine parké ne doit pas servir de canonical/sitemap).
- Aucun changement de code applicatif — n'affecte que la landing.

Après merge, `main` == `develop`, et le redeploy Vercel de la landing v0.6.0 aura le bon canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)