### PR TITLE
Shelf : recherche texte et états vides contextuels

### DIFF
--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -351,6 +351,11 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Disque plein" } }
       }
     },
+    "Folder unavailable" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Dossier introuvable" } }
+      }
+    },
     "Follow the macOS screenshot location" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Suivre l’emplacement des captures de macOS" } }
@@ -437,14 +442,29 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Déplacer la sélection" } }
       }
     },
+    "Move this screenshot to the Trash?" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Placer cette capture dans la corbeille ?" } }
+      }
+    },
     "Move to folder" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Déplacer vers un dossier" } }
       }
     },
+    "Move to Trash" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Placer dans la corbeille" } }
+      }
+    },
     "Newest" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Plus récent" } }
+      }
+    },
+    "No matching screenshots" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Aucune capture correspondante" } }
       }
     },
     "No recent captures" : {
@@ -455,6 +475,11 @@
     "No screen available for capture." : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Aucun écran disponible pour la capture." } }
+      }
+    },
+    "No screenshot matches the current search and filters." : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Aucune capture ne correspond à la recherche et aux filtres actuels." } }
       }
     },
     "No screenshots" : {
@@ -532,6 +557,11 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Renommer la capture" } }
       }
     },
+    "Reset filters" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Réinitialiser les filtres" } }
+      }
+    },
     "Reveal" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Afficher" } }
@@ -571,6 +601,24 @@
     "Shelf" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Étagère" } }
+      }
+    },
+    "shelf.delete.confirm.message" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Nothing is erased until you empty the Trash." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Rien n’est effacé tant que la corbeille n’est pas vidée." } }
+      }
+    },
+    "shelf.delete.confirm.title" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Move %lld screenshots to the Trash?" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Placer %lld captures dans la corbeille ?" } }
+      }
+    },
+    "shelf.empty.missingFolder.description" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Pinpoint can’t read %@ anymore. It may have been moved, renamed, or unmounted." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Pinpoint n’arrive plus à lire %@. Le dossier a peut-être été déplacé, renommé ou démonté." } }
       }
     },
     "Shelf…" : {

--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -154,6 +154,11 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Vider l’historique" } }
       }
     },
+    "Clear search" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Effacer la recherche" } }
+      }
+    },
     "Clear selection" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Effacer la sélection" } }
@@ -540,6 +545,11 @@
     "Save" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Enregistrer" } }
+      }
+    },
+    "Search screenshots" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Rechercher des captures" } }
       }
     },
     "Select" : {

--- a/Pinpoint/Shelf/Stores/ScreenshotStore.swift
+++ b/Pinpoint/Shelf/Stores/ScreenshotStore.swift
@@ -14,6 +14,7 @@ final class ScreenshotStore: ObservableObject {
     @Published var selectedDateFilter: ScreenshotDateFilter = .all
     @Published var selectedSortOrder: ScreenshotSortOrder = .newestFirst
     @Published var showsFavoritesOnly = false
+    @Published var searchQuery = ""
     @Published private(set) var watchedFolderURL: URL
     @Published private(set) var isLoading = false
     @Published private(set) var launchAtLoginEnabled = false
@@ -42,12 +43,38 @@ final class ScreenshotStore: ObservableObject {
     }
 
     var filteredScreenshots: [ScreenshotItem] {
+        let needle = normalizedSearchQuery
         let filtered = screenshots.filter { item in
             let matchesDate = selectedDateFilter.matches(item)
             let matchesFavorites = showsFavoritesOnly == false || isFavorite(item)
-            return matchesDate && matchesFavorites
+            let matchesSearch = needle.map { matches($0, in: item) } ?? true
+            return matchesDate && matchesFavorites && matchesSearch
         }
         return selectedSortOrder.sort(filtered)
+    }
+
+    /// The search query folded once per filtering pass, or `nil` when the field
+    /// is empty (every item matches).
+    private var normalizedSearchQuery: String? {
+        let trimmed = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.isEmpty == false else {
+            return nil
+        }
+
+        return Self.foldedForSearch(trimmed)
+    }
+
+    /// Matches an already folded needle against the display title (custom title
+    /// or file name) and the file name on disk.
+    private func matches(_ needle: String, in item: ScreenshotItem) -> Bool {
+        [displayTitle(for: item), item.filename].contains { haystack in
+            Self.foldedForSearch(haystack).contains(needle)
+        }
+    }
+
+    /// Case- and diacritic-insensitive folding so `resume` matches `Résumé`.
+    private static func foldedForSearch(_ value: String) -> String {
+        value.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
     }
 
     var groupedScreenshots: [(section: ScreenshotSection, items: [ScreenshotItem])] {

--- a/Pinpoint/Shelf/Stores/ScreenshotStore.swift
+++ b/Pinpoint/Shelf/Stores/ScreenshotStore.swift
@@ -17,6 +17,8 @@ final class ScreenshotStore: ObservableObject {
     @Published var searchQuery = ""
     @Published private(set) var watchedFolderURL: URL
     @Published private(set) var isLoading = false
+    /// `false` once a scan failed — folder deleted, unmounted, or unreadable.
+    @Published private(set) var watchedFolderIsReadable = true
     @Published private(set) var launchAtLoginEnabled = false
     @Published private(set) var followsSystemScreenshotLocation: Bool
     @Published private(set) var favoritePaths: Set<String>
@@ -77,6 +79,19 @@ final class ScreenshotStore: ObservableObject {
         value.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
     }
 
+    /// True when at least one filter — date, favorites, or search — is narrowing
+    /// the library, so an empty shelf can point at the filters rather than at
+    /// the folder.
+    var hasActiveFilters: Bool {
+        selectedDateFilter != .all || showsFavoritesOnly || normalizedSearchQuery != nil
+    }
+
+    func resetFilters() {
+        selectedDateFilter = .all
+        showsFavoritesOnly = false
+        searchQuery = ""
+    }
+
     var groupedScreenshots: [(section: ScreenshotSection, items: [ScreenshotItem])] {
         ScreenshotSection.allCases.compactMap { section in
             let items = filteredScreenshots.filter { ScreenshotSection.section(for: $0.createdAt) == section }
@@ -100,9 +115,11 @@ final class ScreenshotStore: ObservableObject {
             screenshots = try await service.scanFolder(at: watchedFolderURL)
             pruneMissingFavorites()
             pruneMissingCustomTitles()
+            watchedFolderIsReadable = true
             lastErrorMessage = nil
         } catch {
             screenshots = []
+            watchedFolderIsReadable = false
             lastErrorMessage = String(localized: "store.error.read", defaultValue: "Couldn’t read \(watchedFolderURL.lastPathComponent).")
         }
     }

--- a/Pinpoint/Shelf/Views/Screens/ShelfView.swift
+++ b/Pinpoint/Shelf/Views/Screens/ShelfView.swift
@@ -13,6 +13,8 @@ struct ShelfView: View {
     @State private var activeItemID: URL?
     @State private var keyMonitor: Any?
     @FocusState private var isSearchFieldFocused: Bool
+    @State private var itemsPendingDeletion: [ScreenshotItem] = []
+    @State private var isDeleteConfirmationPresented = false
     private let gridSpacing: CGFloat = 14
     private let gridPadding: CGFloat = 16
     private let gridColumnCount = 2
@@ -35,6 +37,16 @@ struct ShelfView: View {
                     renameTarget = nil
                 }
             )
+        }
+        .confirmationDialog(
+            deleteConfirmationTitle,
+            isPresented: $isDeleteConfirmationPresented,
+            titleVisibility: .visible
+        ) {
+            Button(String(localized: "Move to Trash"), role: .destructive, action: confirmPendingDeletion)
+            Button(String(localized: "Cancel"), role: .cancel) {}
+        } message: {
+            Text(String(localized: "shelf.delete.confirm.message", defaultValue: "Nothing is erased until you empty the Trash."))
         }
         .onAppear(perform: installKeyboardMonitor)
         .onDisappear(perform: removeKeyboardMonitor)
@@ -179,21 +191,7 @@ struct ShelfView: View {
             ProgressView("Loading screenshots…")
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if store.groupedScreenshots.isEmpty {
-            VStack(spacing: 12) {
-                ContentUnavailableView(
-                    "No screenshots",
-                    systemImage: "photo.on.rectangle.angled",
-                    description: Text("Drop screenshots into \(store.watchedFolderURL.lastPathComponent) or change the watched folder in Settings.")
-                )
-
-                if let error = store.lastErrorMessage {
-                    Text(error)
-                        .font(.caption)
-                        .foregroundStyle(.red)
-                }
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .padding()
+            emptyState
         } else {
             GeometryReader { proxy in
                 let cardWidth = gridCardWidth(for: proxy.size.width)
@@ -225,6 +223,55 @@ struct ShelfView: View {
                 }
             }
         }
+    }
+
+    /// An empty shelf means one of three different things — an unreachable
+    /// folder, a folder with nothing in it, or filters that hide everything —
+    /// and each one gets its own way out.
+    @ViewBuilder
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            if store.watchedFolderIsReadable == false {
+                ContentUnavailableView {
+                    Label("Folder unavailable", systemImage: "folder.badge.questionmark")
+                } description: {
+                    Text(String(localized: "shelf.empty.missingFolder.description", defaultValue: "Pinpoint can’t read \(store.watchedFolderURL.lastPathComponent) anymore. It may have been moved, renamed, or unmounted."))
+                } actions: {
+                    Button("Choose a folder…") {
+                        store.chooseWatchedFolder()
+                    }
+                }
+            } else if store.hasActiveFilters {
+                ContentUnavailableView {
+                    Label("No matching screenshots", systemImage: "line.3.horizontal.decrease.circle")
+                } description: {
+                    Text("No screenshot matches the current search and filters.")
+                } actions: {
+                    Button("Reset filters") {
+                        store.resetFilters()
+                    }
+                }
+            } else {
+                ContentUnavailableView {
+                    Label("No screenshots", systemImage: "photo.on.rectangle.angled")
+                } description: {
+                    Text("Drop screenshots into \(store.watchedFolderURL.lastPathComponent) or change the watched folder in Settings.")
+                } actions: {
+                    Button("Choose a folder…") {
+                        store.chooseWatchedFolder()
+                    }
+                }
+            }
+
+            // The unreachable-folder state already says what went wrong.
+            if let error = store.lastErrorMessage, store.watchedFolderIsReadable {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
     }
 
     private var selectedItems: [ScreenshotItem] {
@@ -300,10 +347,7 @@ struct ShelfView: View {
                 .help("More actions")
 
                 Button(role: .destructive) {
-                    let items = selectedItems
-                    selectedIDs.removeAll()
-                    selectionMode = false
-                    store.delete(items)
+                    requestDeletion(of: selectedItems)
                 } label: {
                     Image(systemName: "trash")
                 }
@@ -426,7 +470,7 @@ struct ShelfView: View {
     }
 
     private var shouldHandleKeyEvent: Bool {
-        if isSearchFieldFocused || renameTarget != nil {
+        if isSearchFieldFocused || isDeleteConfirmationPresented || renameTarget != nil {
             return false
         }
 
@@ -491,7 +535,7 @@ struct ShelfView: View {
                     onCopyImage: { store.copyImage(item) },
                     onCopyPath: { store.copyPaths([item]) },
                     onOpenDetails: { openDetailWindow(for: item) },
-                    onDelete: { store.delete(item) },
+                    onDelete: { requestDeletion(of: [item]) },
                     onQuickLook: { store.quickLook(item) },
                     onMove: { store.move(item) },
                     onRename: {
@@ -552,10 +596,7 @@ struct ShelfView: View {
 
     private func deleteFocusedItems() {
         if selectionMode, selectedItems.isEmpty == false {
-            let items = selectedItems
-            selectedIDs.removeAll()
-            selectionMode = false
-            store.delete(items)
+            requestDeletion(of: selectedItems)
             return
         }
 
@@ -563,8 +604,43 @@ struct ShelfView: View {
             return
         }
 
-        activeItemID = nil
-        store.delete(focusedItem)
+        requestDeletion(of: [focusedItem])
+    }
+
+    /// Every deletion path funnels through here: moving files to the Trash is
+    /// destructive enough to be worth one confirmation.
+    private func requestDeletion(of items: [ScreenshotItem]) {
+        guard items.isEmpty == false else {
+            return
+        }
+
+        itemsPendingDeletion = items
+        isDeleteConfirmationPresented = true
+    }
+
+    private func confirmPendingDeletion() {
+        let items = itemsPendingDeletion
+
+        guard items.isEmpty == false else {
+            return
+        }
+
+        if selectionMode {
+            selectionMode = false
+            selectedIDs.removeAll()
+        }
+
+        if let activeItemID, items.contains(where: { $0.id == activeItemID }) {
+            self.activeItemID = nil
+        }
+
+        store.delete(items)
+    }
+
+    private var deleteConfirmationTitle: String {
+        itemsPendingDeletion.count == 1
+            ? String(localized: "Move this screenshot to the Trash?")
+            : String(localized: "shelf.delete.confirm.title", defaultValue: "Move \(itemsPendingDeletion.count) screenshots to the Trash?")
     }
 
     private func toggleFavoriteFocusedItems() {

--- a/Pinpoint/Shelf/Views/Screens/ShelfView.swift
+++ b/Pinpoint/Shelf/Views/Screens/ShelfView.swift
@@ -12,6 +12,7 @@ struct ShelfView: View {
     @State private var selectedIDs = Set<URL>()
     @State private var activeItemID: URL?
     @State private var keyMonitor: Any?
+    @FocusState private var isSearchFieldFocused: Bool
     private let gridSpacing: CGFloat = 14
     private let gridPadding: CGFloat = 16
     private let gridColumnCount = 2
@@ -84,6 +85,8 @@ struct ShelfView: View {
                 .buttonStyle(.borderless)
             }
 
+            searchField
+
             HStack {
                 Menu {
                     ForEach(ScreenshotDateFilter.allCases) { filter in
@@ -137,6 +140,37 @@ struct ShelfView: View {
             }
         }
         .padding(16)
+    }
+
+    /// Free-text filter over the shelf. The shelf lives in a plain window with no
+    /// navigation container, so `.searchable()` has nothing to attach to — a
+    /// styled text field in the header plays the same role.
+    private var searchField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+
+            TextField("Search screenshots", text: $store.searchQuery)
+                .textFieldStyle(.plain)
+                .focused($isSearchFieldFocused)
+                .onSubmit { isSearchFieldFocused = false }
+
+            if store.searchQuery.isEmpty == false {
+                Button {
+                    store.searchQuery = ""
+                    isSearchFieldFocused = true
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.borderless)
+                .help("Clear search")
+            }
+        }
+        .font(.subheadline)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: 8))
     }
 
     @ViewBuilder
@@ -328,11 +362,18 @@ struct ShelfView: View {
     }
 
     private func handleKeyEvent(_ event: NSEvent) -> NSEvent? {
+        let commandPressed = event.modifierFlags.intersection(.deviceIndependentFlagsMask).contains(.command)
+
+        // Handled before the guard below: the search field must stay reachable
+        // even when the current filters leave nothing visible.
+        if commandPressed, isSearchFieldFocused == false, event.charactersIgnoringModifiers?.lowercased() == "f" {
+            isSearchFieldFocused = true
+            return nil
+        }
+
         guard shouldHandleKeyEvent else {
             return event
         }
-
-        let commandPressed = event.modifierFlags.intersection(.deviceIndependentFlagsMask).contains(.command)
 
         if commandPressed, event.charactersIgnoringModifiers?.lowercased() == "c" {
             copyFocusedItems()
@@ -385,11 +426,7 @@ struct ShelfView: View {
     }
 
     private var shouldHandleKeyEvent: Bool {
-        guard visibleItems.isEmpty == false else {
-            return false
-        }
-
-        if renameTarget != nil {
+        if isSearchFieldFocused || renameTarget != nil {
             return false
         }
 
@@ -397,7 +434,7 @@ struct ShelfView: View {
             return false
         }
 
-        return true
+        return visibleItems.isEmpty == false
     }
 
     private func syncActiveItem() {


### PR DESCRIPTION
Lot B de la roadmap Tier 0 (#59) : la Shelf gagne une recherche, des états vides qui disent quoi faire, et une confirmation avant d'envoyer des captures à la corbeille.

## #40 — Recherche dans la Shelf

Un champ de recherche dans l'en-tête filtre sur le **titre affiché** (titre personnalisé ou nom de fichier) et sur le **nom de fichier**, insensible à la casse et aux accents (`resume` trouve `Résumé`). Il se combine aux filtres date et favoris existants dans `ScreenshotStore.filteredScreenshots`.

`.searchable()` n'était pas utilisable ici : la Shelf vit dans une `NSWindow` sans conteneur de navigation, donc le modificateur n'a rien où s'accrocher. Un `TextField` stylisé dans l'en-tête joue le même rôle, avec un bouton d'effacement et **⌘F** pour y placer le focus — y compris quand les filtres ne laissent rien d'affiché. Le moniteur clavier de la Shelf ne capte plus les touches pendant la saisie (sinon `f` aurait basculé un favori en pleine frappe).

Closes #40

## #42 — États vides contextuels + confirmation de suppression

Une étagère vide voulait dire trois choses différentes sous un seul « No screenshots ». Chaque cas a maintenant son propre message et sa propre sortie :

| Situation | Message | Action |
|---|---|---|
| Dossier illisible (déplacé, renommé, démonté) | « Dossier introuvable » | Choisir un dossier… |
| Dossier vide | « Aucune capture d'écran » | Choisir un dossier… |
| Filtres actifs (date, favoris ou recherche) | « Aucune capture correspondante » | Réinitialiser les filtres |

`ScreenshotStore` expose `watchedFolderIsReadable` (mis à jour par le scan), `hasActiveFilters` et `resetFilters()`.

Côté suppression, ⌫, le bouton corbeille de la barre de sélection et le menu contextuel d'une carte passent tous par un `confirmationDialog` unique qui rappelle le nombre de captures concernées et précise que rien n'est effacé tant que la corbeille n'est pas vidée. Le moniteur clavier se tait tant que le dialogue est affiché.

Closes #42

## i18n

10 nouvelles clés dans `Localizable.xcstrings`, `en` + `fr`, insérées en respectant l'ordre alphabétique du fichier pour limiter les conflits avec les branches parallèles.

## Vérification

`xcodegen generate` + `xcodebuild -scheme Pinpoint -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED**. La sémantique de recherche (casse, accents, requête vide) a été vérifiée séparément. Pas de test manuel dans l'app : deux instances de Pinpoint tournaient déjà sur la machine et partagent le même bundle ID (donc les mêmes `UserDefaults`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)