### PR TITLE
Tier 0 — Export : texte agent-ready enrichi (pixels, formes, IDs stables)

### DIFF
--- a/Pinpoint/Exporter.swift
+++ b/Pinpoint/Exporter.swift
@@ -176,32 +176,70 @@ enum Exporter {
         label.draw(in: textRect, withAttributes: attrs)
     }
 
-    /// Builds the agent-ready text block referencing each numbered pin.
+    /// Builds the agent-ready text block referencing each annotation.
     ///
-    /// Markdown-structured so an AI agent can parse it: image dimensions, each
-    /// marker with its description and approximate position (percentage of the
-    /// image, top-left origin) so the agent can locate it even without reading
-    /// the pixels, then the user's instructions in their own section.
-    static func buildText(pins: [Pin], context: String, imageSize: CGSize) -> String {
+    /// Markdown-structured so an AI agent can parse it: image dimensions, then
+    /// one line per numbered marker and one per shape (arrow/rectangle), each
+    /// with a stable ID and its position both in pixels and in percent of the
+    /// image (top-left origin), so the agent can locate every annotation
+    /// without reading the pixels — then the user's instructions in their own
+    /// section.
+    static func buildText(pins: [Pin], shapes: [Markup] = [], context: String, imageSize: CGSize) -> String {
         let width = Int(imageSize.width.rounded())
         let height = Int(imageSize.height.rounded())
+        let orderedPins = pins.sorted { $0.number < $1.number }
 
         var lines: [String] = []
-        lines.append(String(localized: "export.header", defaultValue: "# Annotated capture — \(width)×\(height) px"))
+        // POSIX locale so the dimensions stay raw digits: the user's locale would
+        // group them ("2 560×1 440"), which is noise for the agent reading this.
+        lines.append(String(localized: "export.header",
+                            defaultValue: "# Annotated capture — \(width)×\(height) px",
+                            locale: Locale(identifier: "en_US_POSIX")))
         lines.append("")
 
-        if pins.isEmpty {
+        if orderedPins.isEmpty {
             lines.append(String(localized: "An image is attached (no markers placed)."))
         } else {
             lines.append(String(localized: "An image is attached. Numbered (ringed) badges point to specific elements."))
-            lines.append(String(localized: "Markers (position in % of the image, top-left origin):"))
+        }
+        if !orderedPins.isEmpty || !shapes.isEmpty {
+            lines.append(String(localized: "export.coordinates", defaultValue: "Positions are given in pixels from the top-left corner (0, 0), then as a percentage of the image size."))
+        }
+
+        if !orderedPins.isEmpty {
             lines.append("")
-            for pin in pins.sorted(by: { $0.number < $1.number }) {
+            lines.append("## " + String(localized: "Markers"))
+            lines.append(String(localized: "export.markers.legend", defaultValue: "M1, M2… are the numbers drawn on the image; the code in brackets is a stable ID for that marker."))
+            lines.append("")
+            for pin in orderedPins {
                 let note = pin.note.trimmingCharacters(in: .whitespacesAndNewlines)
                 let description = note.isEmpty ? String(localized: "(no description)") : note
-                let xPct = Int((pin.position.x * 100).rounded())
-                let yPct = Int((pin.position.y * 100).rounded())
-                lines.append("\(pin.number). \(description) · ~\(xPct) % × \(yPct) %")
+                lines.append("- M\(pin.number) [\(pin.id.shortToken)] · \(description) — "
+                             + "\(pixels(pin.position, in: imageSize)) px · \(percent(pin.position))")
+            }
+        }
+
+        if !shapes.isEmpty {
+            lines.append("")
+            lines.append("## " + String(localized: "export.shapes.heading", defaultValue: "Shapes"))
+            lines.append(String(localized: "export.shapes.legend", defaultValue: "Unnumbered outlines drawn on the image: rectangles are listed top-left → bottom-right, arrows tail → tip, followed by the size of their bounding box."))
+            lines.append("")
+            for (index, shape) in shapes.enumerated() {
+                let box = shape.rect
+                let from: CGPoint, to: CGPoint
+                switch shape.kind {
+                case .rectangle:
+                    from = CGPoint(x: box.minX, y: box.minY)
+                    to = CGPoint(x: box.maxX, y: box.maxY)
+                case .arrow:
+                    from = shape.start
+                    to = shape.end
+                }
+                let boxWidth = Int((box.width * imageSize.width).rounded())
+                let boxHeight = Int((box.height * imageSize.height).rounded())
+                lines.append("- S\(index + 1) [\(shape.id.shortToken)] · \(shape.label) — "
+                             + "\(pixels(from, in: imageSize)) → \(pixels(to, in: imageSize)) px · "
+                             + "\(percent(from)) → \(percent(to)) · \(boxWidth)×\(boxHeight) px")
             }
         }
 
@@ -212,6 +250,16 @@ enum Exporter {
             lines.append(ctx)
         }
         return lines.joined(separator: "\n")
+    }
+
+    /// `(1075, 259)` — a normalized point in the image's pixel grid, top-left origin.
+    private static func pixels(_ point: CGPoint, in size: CGSize) -> String {
+        "(\(Int((point.x * size.width).rounded())), \(Int((point.y * size.height).rounded())))"
+    }
+
+    /// `(42 %, 18 %)` — the same point as a share of the image's width and height.
+    private static func percent(_ point: CGPoint) -> String {
+        "(\(Int((point.x * 100).rounded())) %, \(Int((point.y * 100).rounded())) %)"
     }
 
     /// The image to share with an agent: the annotated capture, optionally with
@@ -352,7 +400,8 @@ enum Exporter {
         }
 
         if !includeLegend {
-            pasteboard.setString(buildText(pins: pins, context: context, imageSize: base.size), forType: .string)
+            pasteboard.setString(buildText(pins: pins, shapes: shapes, context: context, imageSize: base.size),
+                                 forType: .string)
         }
     }
 }

--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -320,10 +320,34 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Inclure la légende dans l’image" } }
       }
     },
+    "export.coordinates" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Positions are given in pixels from the top-left corner (0, 0), then as a percentage of the image size." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Les positions sont données en pixels depuis le coin haut-gauche (0, 0), puis en pourcentage de la taille de l’image." } }
+      }
+    },
     "export.header" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "# Annotated capture — %lld×%lld px" } },
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "# Capture annotée — %lld×%lld px" } }
+      }
+    },
+    "export.markers.legend" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "M1, M2… are the numbers drawn on the image; the code in brackets is a stable ID for that marker." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "M1, M2… correspondent aux numéros dessinés sur l’image ; le code entre crochets est un identifiant stable de ce repère." } }
+      }
+    },
+    "export.shapes.heading" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Shapes" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Formes" } }
+      }
+    },
+    "export.shapes.legend" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Unnumbered outlines drawn on the image: rectangles are listed top-left → bottom-right, arrows tail → tip, followed by the size of their bounding box." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Tracés non numérotés dessinés sur l’image : les rectangles sont donnés haut-gauche → bas-droite, les flèches base → pointe, suivis de la taille de leur boîte englobante." } }
       }
     },
     "Favorites" : {

--- a/Pinpoint/Markup.swift
+++ b/Pinpoint/Markup.swift
@@ -3,10 +3,11 @@ import Foundation
 
 /// A non-numbered visual annotation (arrow or rectangle) drawn on the capture.
 ///
-/// Unlike `Pin`, markups are not numbered and are not referenced in the
-/// agent-ready text — they're purely visual emphasis. Coordinates are
-/// normalized (0...1) in image space, top-left origin (same convention as
-/// `Pin`), so they scale with the canvas and export correctly.
+/// Unlike `Pin`, markups carry no number and no user description: they're
+/// visual emphasis. The agent-ready text still describes each of them (kind,
+/// endpoints and bounding box) so an agent can situate them without the image.
+/// Coordinates are normalized (0...1) in image space, top-left origin (same
+/// convention as `Pin`), so they scale with the canvas and export correctly.
 struct Markup: Identifiable, Equatable, Codable {
     enum Kind: String, Equatable, Codable {
         case arrow

--- a/Pinpoint/Pin.swift
+++ b/Pinpoint/Pin.swift
@@ -9,3 +9,13 @@ struct Pin: Identifiable, Equatable, Codable {
     var position: CGPoint
     var note: String = ""
 }
+
+extension UUID {
+    /// Short, readable form of the identifier (first 6 hex characters), used to
+    /// give every annotation a stable ID in the agent-ready text: it survives
+    /// the renumbering that follows a deletion, so two exports of the same
+    /// session refer to the same marker by the same code.
+    var shortToken: String {
+        String(uuidString.prefix(6)).lowercased()
+    }
+}


### PR DESCRIPTION
## Lot D — Tier 0 : export agent-ready (roadmap #59)

### [Export] Enrichir le texte agent-ready — Closes #41

`Exporter.buildText` produit désormais un bloc Markdown qui suffit à situer chaque
repère sans voir l'image :

- **Pixels + pourcentages** — chaque position est donnée en pixels depuis le coin
  haut-gauche (calculés depuis `imageSize`, déjà connu de `buildText`) puis en % de
  la taille de l'image.
- **Formes décrites** — nouvelle section « Formes » : les rectangles sont listés
  haut-gauche → bas-droite, les flèches base → pointe, suivis de la taille de leur
  boîte englobante (`Markup.rect`). Jusqu'ici elles n'apparaissaient nulle part dans
  le texte, ce que `Markup.swift` notait explicitement (commentaire mis à jour).
- **IDs stables** — chaque annotation porte un identifiant : `M<numéro>` pour les
  repères (le numéro dessiné sur l'image, donc directement corrélable au badge) et
  `S<n>` pour les formes, chacun suivi d'un code court dérivé de l'UUID
  (`UUID.shortToken`, nouveau dans `Pin.swift`). Ce code survit à la renumérotation
  qui suit une suppression : deux exports de la même session désignent le même
  repère par le même code.
- **Bonus** — l'en-tête donnait les dimensions via l'interpolation localisée, ce qui
  produisait « 2 560×1 440 px » en français (espace insécable de groupage) et
  « 2,560×1,440 px » en anglais. Le formatage passe en locale POSIX : chiffres bruts,
  stables d'une locale à l'autre. La langue du texte, elle, reste celle du bundle
  (vérifié : le paramètre `locale:` ne pilote que le formatage des arguments).

### Rendu (exemple réel, 3 repères + 2 formes)

```
# Annotated capture — 2560×1440 px

An image is attached. Numbered (ringed) badges point to specific elements.
Positions are given in pixels from the top-left corner (0, 0), then as a percentage of the image size.

## Markers
M1, M2… are the numbers drawn on the image; the code in brackets is a stable ID for that marker.

- M1 [9e245e] · Bouton « Se connecter » mal aligné — (1075, 259) px · (42 %, 18 %)
- M2 [c26f31] · (no description) — (512, 900) px · (20 %, 63 %)
- M3 [06ccd6] · Le total ne se met pas à jour — (2235, 1345) px · (87 %, 93 %)

## Shapes
Unnumbered outlines drawn on the image: rectangles are listed top-left → bottom-right, arrows tail → tip, followed by the size of their bounding box.

- S1 [60f63a] · Rectangle — (256, 144) → (768, 432) px · (10 %, 10 %) → (30 %, 30 %) · 512×288 px
- S2 [62f7b6] · Arrow — (102, 101) → (410, 504) px · (4 %, 7 %) → (16 %, 35 %) · 307×403 px

## Instructions
Corrige l'alignement du bouton et le calcul du total.
```

### Compatibilité et périmètre

- `buildText(pins:shapes:context:imageSize:)` — `shapes` a une **valeur par défaut**
  (`[]`), donc l'appel existant reste valide. `EditorView.swift` n'est pas touché
  (un autre lot y travaille) : le seul appelant est `Exporter.copyToPasteboard`, qui
  dispose déjà de `shapes`.
- i18n : 4 nouvelles clés (`export.coordinates`, `export.markers.legend`,
  `export.shapes.heading`, `export.shapes.legend`) avec `en` + `fr`, insérées dans
  l'ordre alphabétique du JSON. La clé
  `"Markers (position in % of the image, top-left origin):"` n'est plus utilisée ;
  elle est laissée en place pour ne pas gêner les autres branches en cours.

### Vérifications

- `xcodegen generate` + `xcodebuild -scheme Pinpoint -destination 'platform=macOS'
  CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED**.
- Rendu du texte vérifié en exécutant le code réel (`Exporter.buildText` compilé avec
  les sources du repo) sur 4 cas : repères + formes + instructions, formes seules,
  export vide, et repères renumérotés après suppression (les codes stables suivent
  bien le bon repère).
- Traductions `en`/`fr` vérifiées dans le `Localizable.strings` compilé du `.app`.

### À noter pour la suite (hors périmètre)

`includeLegend` vaut `true` par défaut, et dans ce cas `copyToPasteboard` ne met
**que** l'image (légende gravée) sur le presse-papier — ce texte enrichi n'est donc
transmis que lorsque la légende embarquée est désactivée. La légende gravée, elle,
ne porte ni pixels, ni formes, ni IDs. Une issue de suivi serait utile pour aligner
les deux canaux.
