### PR TITLE
Capture : préflight de la permission Enregistrement de l'écran + ouverture des Réglages

### DIFF
--- a/Pinpoint/AppDelegate.swift
+++ b/Pinpoint/AppDelegate.swift
@@ -329,6 +329,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     @MainActor
     private func presentCaptureError(_ error: Error) {
+        // Missing screen-recording permission: the preflight already presented the
+        // dedicated alert (with the System Settings link), so don't stack a second.
+        guard !ScreenCapture.isPermissionError(error) else { return }
+
         let alert = NSAlert()
         alert.messageText = String(localized: "Capture failed")
         alert.informativeText = String(

--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -487,6 +487,30 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Pause avant la capture pour disposer les éléments ou ouvrir un menu." } }
       }
     },
+    "permission.screenRecording.body" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Captures stay blocked until Pinpoint is allowed to record the screen. Open System Settings ▸ Privacy & Security ▸ Screen Recording, turn Pinpoint on, then relaunch the app." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Les captures resteront impossibles tant que Pinpoint n’est pas autorisé à enregistrer l’écran. Ouvrez Réglages Système ▸ Confidentialité et sécurité ▸ Enregistrement de l’écran, activez Pinpoint, puis relancez l’application." } }
+      }
+    },
+    "permission.screenRecording.error" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Pinpoint isn’t allowed to record the screen." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Pinpoint n’est pas autorisé à enregistrer l’écran." } }
+      }
+    },
+    "permission.screenRecording.openSettings" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Open System Settings" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Ouvrir les Réglages Système" } }
+      }
+    },
+    "permission.screenRecording.title" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Pinpoint can’t record the screen" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Pinpoint ne peut pas enregistrer l’écran" } }
+      }
+    },
     "Pinpoint Settings" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Réglages Pinpoint" } }

--- a/Pinpoint/RegionSelectionController.swift
+++ b/Pinpoint/RegionSelectionController.swift
@@ -15,9 +15,17 @@ final class RegionSelectionController {
     private var continuation: CheckedContinuation<CaptureRegion?, Never>?
 
     /// Shows the overlay and resolves with the chosen region, or `nil` if the
-    /// user cancelled (Esc, or a click without a meaningful drag).
+    /// user cancelled (Esc, or a click without a meaningful drag) — or if screen
+    /// recording isn't allowed.
+    ///
+    /// The permission is checked *before* anything is put on screen: otherwise the
+    /// user drags a region, waits out the countdown, and only then hits a failed
+    /// capture. A `nil` here unwinds the whole flow (no overlay, no timer) and the
+    /// explanatory alert has already been shown by `ScreenCapture`.
     func selectRegion() async -> CaptureRegion? {
-        await withCheckedContinuation { continuation in
+        guard await ScreenCapture.ensurePermission() else { return nil }
+
+        return await withCheckedContinuation { continuation in
             self.continuation = continuation
             present()
         }

--- a/Pinpoint/ScreenCapture.swift
+++ b/Pinpoint/ScreenCapture.swift
@@ -1,21 +1,102 @@
 import AppKit
+import CoreGraphics
 import ScreenCaptureKit
 
 enum ScreenCaptureError: LocalizedError {
     case noDisplay
+    /// Screen recording is not authorized. `ScreenCapture` has already shown the
+    /// dedicated alert (see `ensurePermission()`), so callers only have to abort.
+    case permissionDenied
 
     var errorDescription: String? {
         switch self {
         case .noDisplay: return String(localized: "No screen available for capture.")
+        case .permissionDenied:
+            return String(localized: "permission.screenRecording.error",
+                          defaultValue: "Pinpoint isn’t allowed to record the screen.")
         }
     }
 }
 
 enum ScreenCapture {
+
+    // MARK: - Screen recording permission
+
+    /// System Settings ▸ Privacy & Security ▸ Screen Recording.
+    private static let screenRecordingSettingsURL = URL(
+        string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+    )
+
+    /// Whether macOS currently grants Pinpoint screen-recording access.
+    /// Cheap and side-effect free — never prompts.
+    static var hasPermission: Bool { CGPreflightScreenCaptureAccess() }
+
+    /// Preflight to run *before* anything user-visible starts (selection overlay,
+    /// countdown, capture). Returns `true` when a capture may proceed.
+    ///
+    /// Without it, `SCShareableContent` is queried cold and fails after the user
+    /// has already dragged a region and waited out the timer.
+    ///
+    /// When access is missing it asks the system once — macOS shows its own
+    /// authorization sheet on first use, and silently returns `false` forever
+    /// after a denial — then falls back to an explicit alert that deep-links into
+    /// the right System Settings pane.
+    @MainActor
+    static func ensurePermission() async -> Bool {
+        if CGPreflightScreenCaptureAccess() { return true }
+
+        // Off the main actor: the call can block for as long as the system sheet
+        // is on screen, which would freeze the menu bar.
+        let granted = await Task.detached { CGRequestScreenCaptureAccess() }.value
+        if granted { return true }
+
+        presentPermissionAlert()
+        return false
+    }
+
+    /// Explains why the capture was abandoned and offers a one-click jump to the
+    /// Screen Recording pane — the previous message only told users to relaunch.
+    @MainActor
+    static func presentPermissionAlert() {
+        let alert = NSAlert()
+        alert.messageText = String(localized: "permission.screenRecording.title",
+                                   defaultValue: "Pinpoint can’t record the screen")
+        alert.informativeText = String(
+            localized: "permission.screenRecording.body",
+            defaultValue: "Captures stay blocked until Pinpoint is allowed to record the screen. Open System Settings ▸ Privacy & Security ▸ Screen Recording, turn Pinpoint on, then relaunch the app."
+        )
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: String(localized: "permission.screenRecording.openSettings",
+                                          defaultValue: "Open System Settings"))
+        alert.addButton(withTitle: String(localized: "Cancel"))
+        NSApp.activate(ignoringOtherApps: true)
+        if alert.runModal() == .alertFirstButtonReturn {
+            openScreenRecordingSettings()
+        }
+    }
+
+    /// Deep-links into System Settings ▸ Privacy & Security ▸ Screen Recording.
+    static func openScreenRecordingSettings() {
+        guard let screenRecordingSettingsURL else { return }
+        NSWorkspace.shared.open(screenRecordingSettingsURL)
+    }
+
+    /// `true` for the error thrown when the preflight failed — its alert has
+    /// already been shown, so the generic "Capture failed" one must be skipped.
+    static func isPermissionError(_ error: Error) -> Bool {
+        guard let error = error as? ScreenCaptureError else { return false }
+        if case .permissionDenied = error { return true }
+        return false
+    }
+
+    // MARK: - Capture
+
     /// Captures the full display that currently contains the mouse cursor,
     /// at native (Retina) resolution, using ScreenCaptureKit.
     @MainActor
     static func captureDisplayUnderCursor() async throws -> NSImage {
+        guard await ensurePermission() else { throw ScreenCaptureError.permissionDenied }
+
         let content = try await SCShareableContent.current
 
         let mouse = NSEvent.mouseLocation
@@ -51,6 +132,8 @@ enum ScreenCapture {
     /// the result keeps native resolution without any rescaling.
     @MainActor
     static func captureRegion(_ region: CaptureRegion) async throws -> NSImage {
+        guard await ensurePermission() else { throw ScreenCaptureError.permissionDenied }
+
         let content = try await SCShareableContent.current
 
         guard let display = content.displays.first(where: { $0.displayID == region.displayID })


### PR DESCRIPTION
## Contexte

`SCShareableContent.current` était appelé à froid. Sans la permission « Enregistrement de l'écran », l'utilisateur sélectionnait sa région, attendait le minuteur, et récupérait seulement un « Échec de la capture » lui demandant de relancer l'app — sans aucun moyen d'atteindre le bon panneau des Réglages Système.

## Ce que fait cette PR

- **Préflight** `CGPreflightScreenCaptureAccess()` dans un nouveau `ScreenCapture.ensurePermission()`, exécuté **avant** que quoi que ce soit n'apparaisse à l'écran.
- **Demande système** via `CGRequestScreenCaptureAccess()` quand l'accès manque (la fiche macOS n'apparaît qu'une fois dans la vie de l'app). L'appel est fait hors du main actor, car il peut bloquer tant que la fiche est affichée — sinon la barre des menus gèle. La demande est déclenchée à la première capture plutôt qu'au lancement, pour ne pas surprendre l'utilisateur avec une fiche TCC au démarrage.
- **Alerte explicite** avec un bouton « Ouvrir les Réglages Système » qui ouvre `x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture`, plus un bouton « Annuler ».
- **Aucun état incohérent** : `RegionSelectionController.selectRegion()` fait le préflight avant `present()` et rend `nil` — donc pas d'overlay posé, pas de minuteur lancé, pas de contrôleur qui traîne. Les deux fonctions de capture gardent aussi le préflight en tête et lèvent `ScreenCaptureError.permissionDenied`, que `AppDelegate.presentCaptureError` ignore pour ne pas empiler une seconde alerte générique.
- **i18n** : nouvelles clés `permission.screenRecording.{title,body,openSettings,error}` (en + fr), insérées dans l'ordre alphabétique du catalogue.

## Vérification

`xcodegen generate` + `xcodebuild -scheme Pinpoint -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED**, sans nouveau warning.

Test manuel de bout en bout sur un build local (refus de permission simulé par un hook temporaire non commité, pour ne pas toucher aux réglages TCC de la machine) :

1. Capture de région → l'alerte française s'affiche **avant** l'overlay ; aucun overlay ni minuteur n'apparaît.
2. Clic sur « Ouvrir les Réglages Système » → Réglages Système s'ouvre bien sur « Enregistrement de l'écran et des sons du système ».
3. Capture plein écran → même alerte ; à sa fermeture, `presentCaptureError` reçoit `permissionDenied` et n'affiche **aucune** seconde alerte.

## Note de périmètre

`AppDelegate.swift` (hors périmètre, travaillé en parallèle) a reçu une modification minimale : 1 ligne de code + 2 de commentaire en tête de `presentCaptureError`, indispensable pour éviter la double alerte sur le chemin plein écran.

Closes #39