### PR TITLE
Éditeur : suppression au clavier, échecs d'export remontés, découvrabilité (#37, #38, #43)

### DIFF
--- a/Pinpoint/AppDelegate.swift
+++ b/Pinpoint/AppDelegate.swift
@@ -89,7 +89,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         menu.addItem(fullScreenItem)
         menu.addItem(.separator())
 
-        let shelfItem = NSMenuItem(title: String(localized: "Shelf…"), action: #selector(openShelf), keyEquivalent: "")
+        // Mirrors the global ⌘⇧2 shortcut (see `KeyboardShortcuts.Name.openShelf`),
+        // the same way the capture items advertise ⌘⇧1 / ⌘⇧3.
+        let shelfItem = NSMenuItem(title: String(localized: "Shelf…"), action: #selector(openShelf), keyEquivalent: "2")
+        shelfItem.keyEquivalentModifierMask = [.command, .shift]
         shelfItem.target = self
         menu.addItem(shelfItem)
 

--- a/Pinpoint/EditorView.swift
+++ b/Pinpoint/EditorView.swift
@@ -66,6 +66,9 @@ struct EditorView: View {
     @State private var draft: Markup?
     @State private var dragStartPosition: CGPoint?
     @State private var didCopy = false
+    /// Non-nil while an export failure is being shown. Copy and save used to
+    /// swallow their errors and still report success.
+    @State private var exportError: String?
     /// Which text field is being edited, if any. Only used to step aside: the
     /// Delete key equivalent is disabled while typing so ⌫ keeps editing text.
     @FocusState private var focusedField: EditorField?
@@ -108,6 +111,14 @@ struct EditorView: View {
         }
         .frame(minWidth: 680, minHeight: 440)
         .onDisappear { onPersist(pins, shapes, context, image) }
+        .alert(
+            String(localized: "Export failed"),
+            isPresented: Binding(get: { exportError != nil }, set: { if !$0 { exportError = nil } })
+        ) {
+            Button(String(localized: "OK"), role: .cancel) { exportError = nil }
+        } message: {
+            Text(exportError ?? "")
+        }
     }
 
     // MARK: - Toolbar
@@ -521,8 +532,11 @@ struct EditorView: View {
     }
 
     private func copy() {
-        Exporter.copyToPasteboard(base: image, pins: pins, shapes: shapes, context: context,
-                                  style: pinStyle, includeLegend: includeLegend)
+        guard Exporter.copyToPasteboard(base: image, pins: pins, shapes: shapes, context: context,
+                                        style: pinStyle, includeLegend: includeLegend) else {
+            exportError = String(localized: "Nothing was written to the clipboard. The annotated image couldn’t be rendered.")
+            return
+        }
         onPersist(pins, shapes, context, image)
         withAnimation { didCopy = true }
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) {
@@ -540,8 +554,16 @@ struct EditorView: View {
         // Full resolution here (no cap): the file is meant to be attached/kept,
         // unlike the pasteboard image which is downscaled to stay pasteable.
         guard let png = Exporter.pngData(base: image, pins: pins, shapes: shapes, context: context,
-                                         style: pinStyle, includeLegend: includeLegend, maxDimension: nil) else { return }
-        try? png.write(to: url)
+                                         style: pinStyle, includeLegend: includeLegend, maxDimension: nil) else {
+            exportError = String(localized: "The annotated image couldn’t be rendered.")
+            return
+        }
+        do {
+            try png.write(to: url)
+        } catch {
+            exportError = error.localizedDescription
+            return
+        }
         onPersist(pins, shapes, context, image)
     }
 

--- a/Pinpoint/EditorView.swift
+++ b/Pinpoint/EditorView.swift
@@ -23,6 +23,16 @@ enum EditorTool: String, CaseIterable, Identifiable {
         case .rectangle: return "rectangle"
         }
     }
+
+    /// Used with ⌘. A bare digit or letter would be swallowed by the marker
+    /// note fields and the instructions editor while typing.
+    var shortcut: KeyEquivalent {
+        switch self {
+        case .pin: return "1"
+        case .arrow: return "2"
+        case .rectangle: return "3"
+        }
+    }
 }
 
 struct EditorView: View {
@@ -121,6 +131,8 @@ struct EditorView: View {
                 .pickerStyle(.segmented)
                 .labelsHidden()
                 .fixedSize()
+                .help(toolPickerHelp)
+                .background(hiddenShortcuts)
 
                 Button {
                     enterCropMode()
@@ -144,6 +156,31 @@ struct EditorView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
+    }
+
+    /// One tooltip for the whole picker: a segmented control's segments carry no
+    /// tooltip of their own on macOS, so the picker advertises every tool and
+    /// its key equivalent at once. Built from the localized labels, so it can't
+    /// drift from what the segments show.
+    private var toolPickerHelp: String {
+        EditorTool.allCases
+            .map { "\($0.label) ⌘\($0.shortcut.character)" }
+            .joined(separator: " · ")
+    }
+
+    /// Invisible buttons that exist only to own key equivalents: a segmented
+    /// `Picker` can't carry one per segment. Rendered inside the picker's
+    /// background with hit-testing off.
+    private var hiddenShortcuts: some View {
+        ZStack {
+            ForEach(EditorTool.allCases) { item in
+                Button("") { tool = item }
+                    .keyboardShortcut(item.shortcut, modifiers: .command)
+            }
+        }
+        .opacity(0)
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
     }
 
     private var toolHint: String {

--- a/Pinpoint/EditorView.swift
+++ b/Pinpoint/EditorView.swift
@@ -35,6 +35,13 @@ enum EditorTool: String, CaseIterable, Identifiable {
     }
 }
 
+/// The editor's text inputs, tracked so keyboard shortcuts can stand down
+/// while the user is typing.
+private enum EditorField: Hashable {
+    case note(Pin.ID)
+    case context
+}
+
 struct EditorView: View {
     /// The editor's base image. Mutable: a crop replaces it in place. Kept at
     /// native pixel size (`.size` == pixels) so export renders at full res.
@@ -59,6 +66,9 @@ struct EditorView: View {
     @State private var draft: Markup?
     @State private var dragStartPosition: CGPoint?
     @State private var didCopy = false
+    /// Which text field is being edited, if any. Only used to step aside: the
+    /// Delete key equivalent is disabled while typing so ⌫ keeps editing text.
+    @FocusState private var focusedField: EditorField?
 
     // Crop mode state. `cropRect` is normalized (0...1, top-left origin), same
     // convention as pins/markups.
@@ -169,7 +179,8 @@ struct EditorView: View {
     }
 
     /// Invisible buttons that exist only to own key equivalents: a segmented
-    /// `Picker` can't carry one per segment. Rendered inside the picker's
+    /// `Picker` can't carry one per segment, and the canvas can't reliably hold
+    /// keyboard focus for an `.onKeyPress`. Rendered inside the picker's
     /// background with hit-testing off.
     private var hiddenShortcuts: some View {
         ZStack {
@@ -177,6 +188,17 @@ struct EditorView: View {
                 Button("") { tool = item }
                     .keyboardShortcut(item.shortcut, modifiers: .command)
             }
+
+            // ⌫ / ⌦ remove the selected marker or annotation. Disabled while a
+            // text field has focus — a disabled button doesn't claim its key
+            // equivalent, so ⌫ keeps deleting characters while typing.
+            Button("") { deleteSelection() }
+                .keyboardShortcut(.delete, modifiers: [])
+                .disabled(focusedField != nil || !hasSelection)
+
+            Button("") { deleteSelection() }
+                .keyboardShortcut(.deleteForward, modifiers: [])
+                .disabled(focusedField != nil || !hasSelection)
         }
         .opacity(0)
         .allowsHitTesting(false)
@@ -321,6 +343,7 @@ struct EditorView: View {
             Text("Instructions for the agent")
                 .font(.headline)
             TextEditor(text: $context)
+                .focused($focusedField, equals: .context)
                 .font(.body)
                 .frame(minHeight: 70, maxHeight: 120)
                 .overlay(RoundedRectangle(cornerRadius: 6).stroke(.quaternary))
@@ -383,6 +406,7 @@ struct EditorView: View {
 
             TextField("Describe this marker…", text: pin.note)
                 .textFieldStyle(.roundedBorder)
+                .focused($focusedField, equals: .note(pin.wrappedValue.id))
 
             Button {
                 removePin(pin.wrappedValue)
@@ -466,6 +490,22 @@ struct EditorView: View {
     private func selectShape(_ id: Markup.ID) {
         selectedShapeID = id
         selectedPinID = nil
+    }
+
+    private var hasSelection: Bool {
+        selectedPinID != nil || selectedShapeID != nil
+    }
+
+    /// Removes whatever is currently selected, from wherever it was selected —
+    /// canvas or side panel. `removePin` already renumbers the remaining
+    /// markers, and both removers clear the selection they consumed.
+    private func deleteSelection() {
+        guard !isCropping else { return }
+        if let id = selectedPinID, let pin = pins.first(where: { $0.id == id }) {
+            removePin(pin)
+        } else if let id = selectedShapeID, let shape = shapes.first(where: { $0.id == id }) {
+            removeShape(shape)
+        }
     }
 
     private func removePin(_ pin: Pin) {

--- a/Pinpoint/Exporter.swift
+++ b/Pinpoint/Exporter.swift
@@ -341,18 +341,26 @@ enum Exporter {
     /// both share a pasteboard item, so the bare string would hide the capture.
     /// Only when the legend is *not* embedded do we add the text, since then it
     /// is the sole carrier of the marker descriptions and instructions.
+    /// Returns `false` when nothing reached the pasteboard — rendering failed or
+    /// every write was rejected — so callers don't report a copy that never
+    /// happened.
+    @discardableResult
     static func copyToPasteboard(base: NSImage, pins: [Pin], shapes: [Markup], context: String,
-                                 style: PinStyle, includeLegend: Bool) {
+                                 style: PinStyle, includeLegend: Bool) -> Bool {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
 
+        var wrote = false
         if let png = pngData(base: base, pins: pins, shapes: shapes, context: context,
                              style: style, includeLegend: includeLegend, maxDimension: clipboardMaxDimension) {
-            pasteboard.setData(png, forType: .png)
+            wrote = pasteboard.setData(png, forType: .png)
         }
 
         if !includeLegend {
-            pasteboard.setString(buildText(pins: pins, context: context, imageSize: base.size), forType: .string)
+            let text = buildText(pins: pins, context: context, imageSize: base.size)
+            wrote = pasteboard.setString(text, forType: .string) || wrote
         }
+
+        return wrote
     }
 }

--- a/Pinpoint/Exporter.swift
+++ b/Pinpoint/Exporter.swift
@@ -176,32 +176,70 @@ enum Exporter {
         label.draw(in: textRect, withAttributes: attrs)
     }
 
-    /// Builds the agent-ready text block referencing each numbered pin.
+    /// Builds the agent-ready text block referencing each annotation.
     ///
-    /// Markdown-structured so an AI agent can parse it: image dimensions, each
-    /// marker with its description and approximate position (percentage of the
-    /// image, top-left origin) so the agent can locate it even without reading
-    /// the pixels, then the user's instructions in their own section.
-    static func buildText(pins: [Pin], context: String, imageSize: CGSize) -> String {
+    /// Markdown-structured so an AI agent can parse it: image dimensions, then
+    /// one line per numbered marker and one per shape (arrow/rectangle), each
+    /// with a stable ID and its position both in pixels and in percent of the
+    /// image (top-left origin), so the agent can locate every annotation
+    /// without reading the pixels — then the user's instructions in their own
+    /// section.
+    static func buildText(pins: [Pin], shapes: [Markup] = [], context: String, imageSize: CGSize) -> String {
         let width = Int(imageSize.width.rounded())
         let height = Int(imageSize.height.rounded())
+        let orderedPins = pins.sorted { $0.number < $1.number }
 
         var lines: [String] = []
-        lines.append(String(localized: "export.header", defaultValue: "# Annotated capture — \(width)×\(height) px"))
+        // POSIX locale so the dimensions stay raw digits: the user's locale would
+        // group them ("2 560×1 440"), which is noise for the agent reading this.
+        lines.append(String(localized: "export.header",
+                            defaultValue: "# Annotated capture — \(width)×\(height) px",
+                            locale: Locale(identifier: "en_US_POSIX")))
         lines.append("")
 
-        if pins.isEmpty {
+        if orderedPins.isEmpty {
             lines.append(String(localized: "An image is attached (no markers placed)."))
         } else {
             lines.append(String(localized: "An image is attached. Numbered (ringed) badges point to specific elements."))
-            lines.append(String(localized: "Markers (position in % of the image, top-left origin):"))
+        }
+        if !orderedPins.isEmpty || !shapes.isEmpty {
+            lines.append(String(localized: "export.coordinates", defaultValue: "Positions are given in pixels from the top-left corner (0, 0), then as a percentage of the image size."))
+        }
+
+        if !orderedPins.isEmpty {
             lines.append("")
-            for pin in pins.sorted(by: { $0.number < $1.number }) {
+            lines.append("## " + String(localized: "Markers"))
+            lines.append(String(localized: "export.markers.legend", defaultValue: "M1, M2… are the numbers drawn on the image; the code in brackets is a stable ID for that marker."))
+            lines.append("")
+            for pin in orderedPins {
                 let note = pin.note.trimmingCharacters(in: .whitespacesAndNewlines)
                 let description = note.isEmpty ? String(localized: "(no description)") : note
-                let xPct = Int((pin.position.x * 100).rounded())
-                let yPct = Int((pin.position.y * 100).rounded())
-                lines.append("\(pin.number). \(description) · ~\(xPct) % × \(yPct) %")
+                lines.append("- M\(pin.number) [\(pin.id.shortToken)] · \(description) — "
+                             + "\(pixels(pin.position, in: imageSize)) px · \(percent(pin.position))")
+            }
+        }
+
+        if !shapes.isEmpty {
+            lines.append("")
+            lines.append("## " + String(localized: "export.shapes.heading", defaultValue: "Shapes"))
+            lines.append(String(localized: "export.shapes.legend", defaultValue: "Unnumbered outlines drawn on the image: rectangles are listed top-left → bottom-right, arrows tail → tip, followed by the size of their bounding box."))
+            lines.append("")
+            for (index, shape) in shapes.enumerated() {
+                let box = shape.rect
+                let from: CGPoint, to: CGPoint
+                switch shape.kind {
+                case .rectangle:
+                    from = CGPoint(x: box.minX, y: box.minY)
+                    to = CGPoint(x: box.maxX, y: box.maxY)
+                case .arrow:
+                    from = shape.start
+                    to = shape.end
+                }
+                let boxWidth = Int((box.width * imageSize.width).rounded())
+                let boxHeight = Int((box.height * imageSize.height).rounded())
+                lines.append("- S\(index + 1) [\(shape.id.shortToken)] · \(shape.label) — "
+                             + "\(pixels(from, in: imageSize)) → \(pixels(to, in: imageSize)) px · "
+                             + "\(percent(from)) → \(percent(to)) · \(boxWidth)×\(boxHeight) px")
             }
         }
 
@@ -212,6 +250,16 @@ enum Exporter {
             lines.append(ctx)
         }
         return lines.joined(separator: "\n")
+    }
+
+    /// `(1075, 259)` — a normalized point in the image's pixel grid, top-left origin.
+    private static func pixels(_ point: CGPoint, in size: CGSize) -> String {
+        "(\(Int((point.x * size.width).rounded())), \(Int((point.y * size.height).rounded())))"
+    }
+
+    /// `(42 %, 18 %)` — the same point as a share of the image's width and height.
+    private static func percent(_ point: CGPoint) -> String {
+        "(\(Int((point.x * 100).rounded())) %, \(Int((point.y * 100).rounded())) %)"
     }
 
     /// The image to share with an agent: the annotated capture, optionally with
@@ -352,7 +400,8 @@ enum Exporter {
         }
 
         if !includeLegend {
-            pasteboard.setString(buildText(pins: pins, context: context, imageSize: base.size), forType: .string)
+            pasteboard.setString(buildText(pins: pins, shapes: shapes, context: context, imageSize: base.size),
+                                 forType: .string)
         }
     }
 }

--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -320,10 +320,34 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Inclure la légende dans l’image" } }
       }
     },
+    "export.coordinates" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Positions are given in pixels from the top-left corner (0, 0), then as a percentage of the image size." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Les positions sont données en pixels depuis le coin haut-gauche (0, 0), puis en pourcentage de la taille de l’image." } }
+      }
+    },
     "export.header" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "# Annotated capture — %lld×%lld px" } },
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "# Capture annotée — %lld×%lld px" } }
+      }
+    },
+    "export.markers.legend" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "M1, M2… are the numbers drawn on the image; the code in brackets is a stable ID for that marker." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "M1, M2… correspondent aux numéros dessinés sur l’image ; le code entre crochets est un identifiant stable de ce repère." } }
+      }
+    },
+    "export.shapes.heading" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Shapes" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Formes" } }
+      }
+    },
+    "export.shapes.legend" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Unnumbered outlines drawn on the image: rectangles are listed top-left → bottom-right, arrows tail → tip, followed by the size of their bounding box." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Tracés non numérotés dessinés sur l’image : les rectangles sont donnés haut-gauche → bas-droite, les flèches base → pointe, suivis de la taille de leur boîte englobante." } }
       }
     },
     "Favorites" : {

--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -224,6 +224,11 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Impossible de copier les fichiers sélectionnés." } }
       }
     },
+    "Export failed" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Échec de l’export" } }
+      }
+    },
     "Couldn’t save the watched folder." : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Impossible d’enregistrer le dossier surveillé." } }
@@ -457,9 +462,19 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Aucune capture d’écran" } }
       }
     },
+    "Nothing was written to the clipboard. The annotated image couldn’t be rendered." : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Rien n’a été écrit dans le presse-papiers. L’image annotée n’a pas pu être générée." } }
+      }
+    },
     "Off" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Désactivé" } }
+      }
+    },
+    "OK" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "OK" } }
       }
     },
     "Older" : {
@@ -615,6 +630,11 @@
     "The tip marks the exact pixel." : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "La pointe désigne le pixel exact." } }
+      }
+    },
+    "The annotated image couldn’t be rendered." : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "L’image annotée n’a pas pu être générée." } }
       }
     },
     "This month" : {

--- a/Pinpoint/Markup.swift
+++ b/Pinpoint/Markup.swift
@@ -3,10 +3,11 @@ import Foundation
 
 /// A non-numbered visual annotation (arrow or rectangle) drawn on the capture.
 ///
-/// Unlike `Pin`, markups are not numbered and are not referenced in the
-/// agent-ready text — they're purely visual emphasis. Coordinates are
-/// normalized (0...1) in image space, top-left origin (same convention as
-/// `Pin`), so they scale with the canvas and export correctly.
+/// Unlike `Pin`, markups carry no number and no user description: they're
+/// visual emphasis. The agent-ready text still describes each of them (kind,
+/// endpoints and bounding box) so an agent can situate them without the image.
+/// Coordinates are normalized (0...1) in image space, top-left origin (same
+/// convention as `Pin`), so they scale with the canvas and export correctly.
 struct Markup: Identifiable, Equatable, Codable {
     enum Kind: String, Equatable, Codable {
         case arrow

--- a/Pinpoint/Pin.swift
+++ b/Pinpoint/Pin.swift
@@ -9,3 +9,13 @@ struct Pin: Identifiable, Equatable, Codable {
     var position: CGPoint
     var note: String = ""
 }
+
+extension UUID {
+    /// Short, readable form of the identifier (first 6 hex characters), used to
+    /// give every annotation a stable ID in the agent-ready text: it survives
+    /// the renumbering that follows a deletion, so two exports of the same
+    /// session refer to the same marker by the same code.
+    var shortToken: String {
+        String(uuidString.prefix(6)).lowercased()
+    }
+}

--- a/Pinpoint/ScreenshotDetailWindowController.swift
+++ b/Pinpoint/ScreenshotDetailWindowController.swift
@@ -17,15 +17,18 @@ final class ScreenshotDetailWindowController: NSWindowController, NSWindowDelega
             backing: .buffered,
             defer: false
         )
-        window.title = item.filename
+        window.title = store.displayTitle(for: item)
         window.isReleasedWhenClosed = false
 
         super.init(window: window)
         window.delegate = self
 
-        let root = ScreenshotDetailContainer(item: item, store: store) { [weak window] in
-            window?.close()
-        }
+        let root = ScreenshotDetailContainer(
+            item: item,
+            store: store,
+            onTitleChange: { [weak window] title in window?.title = title },
+            onClose: { [weak window] in window?.close() }
+        )
         .environmentObject(store)
         window.contentView = NSHostingView(rootView: root)
         window.center()
@@ -44,11 +47,20 @@ final class ScreenshotDetailWindowController: NSWindowController, NSWindowDelega
 private struct ScreenshotDetailContainer: View {
     @ObservedObject var store: ScreenshotStore
     let item: ScreenshotItem
+    /// Keeps the window title in sync when the display title is edited from the
+    /// shelf while this window is open.
+    let onTitleChange: (String) -> Void
     let onClose: () -> Void
 
-    init(item: ScreenshotItem, store: ScreenshotStore, onClose: @escaping () -> Void) {
+    init(
+        item: ScreenshotItem,
+        store: ScreenshotStore,
+        onTitleChange: @escaping (String) -> Void,
+        onClose: @escaping () -> Void
+    ) {
         self.item = item
         self.store = store
+        self.onTitleChange = onTitleChange
         self.onClose = onClose
     }
 
@@ -68,5 +80,8 @@ private struct ScreenshotDetailContainer: View {
             },
             onClose: onClose
         )
+        .onChange(of: store.displayTitle(for: item)) { _, newTitle in
+            onTitleChange(newTitle)
+        }
     }
 }

--- a/Pinpoint/Shelf/Views/Screens/ScreenshotDetailView.swift
+++ b/Pinpoint/Shelf/Views/Screens/ScreenshotDetailView.swift
@@ -59,13 +59,14 @@ struct ScreenshotDetailView: View {
     private var header: some View {
         HStack(spacing: 12) {
             VStack(alignment: .leading, spacing: 4) {
-                Text(item.filename)
+                Text(store.displayTitle(for: item))
                     .font(.title3.weight(.semibold))
                     .lineLimit(1)
 
-                Text(item.url.deletingLastPathComponent().lastPathComponent)
+                Text(headerSubtitle)
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                    .lineLimit(1)
             }
 
             Spacer()
@@ -84,6 +85,14 @@ struct ScreenshotDetailView: View {
             .help("Close")
         }
         .padding(16)
+    }
+
+    /// The containing folder, prefixed with the file name whenever a custom
+    /// title took its place in the heading so it stays visible somewhere.
+    private var headerSubtitle: String {
+        let folder = item.url.deletingLastPathComponent().lastPathComponent
+        guard store.displayTitle(for: item) != item.filename else { return folder }
+        return "\(item.filename) · \(folder)"
     }
 
     private func close() {


### PR DESCRIPTION
Lot A du Tier 0 de la roadmap #59 : trois quick wins sur l'éditeur.

## #37 — Supprimer le marqueur ou la forme sélectionnée au clavier

`⌫` et `⌦` suppriment l'élément sélectionné, qu'il ait été sélectionné sur le canvas ou dans le panneau latéral. `removePin` renumérote déjà les marqueurs restants, et les deux suppressions vident la sélection consommée (un second `⌫` ne supprime donc rien).

Le raccourci est porté par un bouton invisible plutôt que par `.onDeleteCommand` sur le canvas : **testé, ni `.onDeleteCommand` ni `.onKeyPress` ne se déclenchent** — le canvas ne conserve pas le focus clavier de façon fiable (`@FocusState` sur une vue `.focusable()` ne prend pas). Le bouton est désactivé tant qu'un champ de texte est en cours d'édition : un bouton désactivé ne réclame pas son équivalent clavier, donc `⌫` continue d'effacer des caractères dans les notes et les instructions.

Closes #37

## #38 — Ne plus annoncer un succès sur un échec silencieux

- `Exporter.copyToPasteboard` renvoie désormais un `Bool` (`@discardableResult`, seul appelant : `EditorView.copy()`) indiquant si au moins une écriture sur le presse-papiers a réussi.
- « Copié ! » ne s'affiche que dans ce cas ; sinon une alerte remonte l'échec.
- `save()` ne fait plus disparaître l'erreur d'écriture (`try?` → `do/catch`) ni un `pngData` à `nil` : les deux passent par la même alerte.

Closes #38

## #43 — Polissage de la découvrabilité

- Le sélecteur d'outil expose une infobulle listant les trois outils et leurs raccourcis, `⌘1` / `⌘2` / `⌘3`. **Vérifié via l'accessibilité** : un contrôle segmenté macOS n'expose pas d'infobulle par segment (`AXHelp` absent sur chaque segment), d'où une infobulle unique sur le picker, composée à partir des libellés localisés. Les raccourcis prennent `⌘` plutôt que `P`/`A`/`R` ou `1`/`2`/`3` nus, qui seraient volés aux champs de note et à l'éditeur d'instructions pendant la saisie.
- L'entrée de menu « Étagère… » affiche `⌘⇧2`, comme les entrées de capture affichent déjà `⌘⇧1` / `⌘⇧3`.
- La fenêtre de détail utilise `displayTitle` dans son en-tête et son titre de fenêtre, et le garde à jour s'il change pendant que la fenêtre est ouverte. Le nom de fichier reste visible en sous-titre quand un titre personnalisé l'a remplacé.

Closes #43

## Vérification

`xcodegen generate` + `xcodebuild -scheme Pinpoint -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` : **succès, sans warning**.

Testé à la main dans l'app (build Debug) :
- `⌫` supprime le marqueur sélectionné (3 → 2 marqueurs), renumérotation correcte, un second `⌫` ne supprime rien ;
- `⌫` avec le focus dans un champ de note édite le texte et ne supprime aucun marqueur ;
- `⌘1` / `⌘2` / `⌘3` changent bien d'outil ;
- l'infobulle du picker expose « Repère ⌘1 · Flèche ⌘2 · Rectangle ⌘3 » ;
- le menu de la barre affiche le raccourci sur « Étagère… » (rendu `⇧⌘é` sur AZERTY, comme `⇧⌘&` / `⇧⌘"` pour les captures) ;
- « Copier pour l'agent » place bien un PNG dans le presse-papiers.

## Notes

- `Pinpoint/Exporter.swift` est hors du périmètre annoncé de ce lot : la modification s'y limite au type de retour de `copyToPasteboard` et au suivi des écritures réussies, sans toucher au reste du fichier.
- `Pinpoint/Localizable.xcstrings` : 4 clés ajoutées (`Export failed`, `OK`, et les deux messages d'échec d'export), insérées à leur place alphabétique, avec traductions `fr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)