### PR TITLE
Capture : rectangle de sélection ajustable avant validation

### DIFF
--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -300,6 +300,11 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Glisser %lld fichiers" } }
       }
     },
+    "Drag or nudge with arrows · ↵ to capture · Esc to cancel" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Déplace ou décale aux flèches · ↵ pour capturer · Échap pour annuler" } }
+      }
+    },
     "Drag the selected screenshots" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Glisser les captures sélectionnées" } }

--- a/Pinpoint/RegionSelectionController.swift
+++ b/Pinpoint/RegionSelectionController.swift
@@ -1,7 +1,7 @@
 import AppKit
 
 /// Presents a full-screen dimming overlay (one borderless window per screen)
-/// and lets the user drag a rectangle to pick a capture region.
+/// and lets the user drag, then adjust, a rectangle to pick a capture region.
 ///
 /// One window per `NSScreen` is required because, with "Displays have separate
 /// Spaces" (the macOS default), a single window spanning the union of all
@@ -37,9 +37,10 @@ final class RegionSelectionController {
         let screens = NSScreen.screens
         guard !screens.isEmpty else { finish(nil); return }
 
-        // The window under the pointer becomes key so Esc works immediately and
-        // owns the hint; the others just dim their screen (AppKit routes a drag
-        // to the window that got the mouseDown, so the anchor screen owns it).
+        // The window under the pointer starts out key so Esc works immediately
+        // and owns the hint; the others just dim their screen (AppKit routes a
+        // drag to the window that got the mouseDown, so the anchor screen owns
+        // it). `focus(_:)` hands both over as soon as a drag starts elsewhere.
         let cursor = NSEvent.mouseLocation
         let keyScreen = screens.first { NSMouseInRect(cursor, $0.frame, false) } ?? NSScreen.main
 
@@ -65,6 +66,10 @@ final class RegionSelectionController {
                 self?.finish(Self.resolve(globalRect: globalRect, anchor: anchor))
             }
             view.onCancel = { [weak self] in self?.finish(nil) }
+            view.onBeginSelection = { [weak self, weak view] in
+                guard let view else { return }
+                self?.focus(view)
+            }
             window.contentView = view
 
             windows.append(window)
@@ -78,6 +83,23 @@ final class RegionSelectionController {
         }
 
         NSCursor.crosshair.push()
+    }
+
+    /// Hands the hint, the keyboard focus and the sole selection to the screen
+    /// the user is actually selecting on. The adjustable stage is driven by the keyboard (Return,
+    /// Esc, arrows), so the window owning the selection has to be the key one —
+    /// otherwise a selection started on a secondary display would have its keys
+    /// swallowed by whichever window was key at first.
+    private func focus(_ view: RegionSelectionView) {
+        for window in windows {
+            guard let other = window.contentView as? RegionSelectionView else { continue }
+            let isActive = (other === view)
+            other.showsHint = isActive
+            if !isActive { other.clearSelection() }
+        }
+        guard let window = view.window, !window.isKeyWindow else { return }
+        window.makeKeyAndOrderFront(nil)
+        window.makeFirstResponder(view)
     }
 
     private func finish(_ region: CaptureRegion?) {

--- a/Pinpoint/RegionSelectionView.swift
+++ b/Pinpoint/RegionSelectionView.swift
@@ -2,27 +2,70 @@ import AppKit
 
 /// The dimming + rubber-band drawing surface for region selection.
 ///
-/// Tracks the drag in view-local coordinates and reports the finished selection
-/// back to `RegionSelectionController` in global (screen) coordinates.
+/// The first drag rubber-bands a rectangle, but releasing the mouse doesn't
+/// capture yet: the rectangle enters an *adjustable* stage where it can be
+/// dragged around, resized from its eight handles and nudged with the arrow
+/// keys (1 pt, 10 pt with ⇧). Return — or a click inside the rectangle —
+/// captures, Esc cancels the whole selection, and a drag starting outside it
+/// rubber-bands a fresh one.
+///
+/// Everything is tracked in view-local coordinates and handed back to
+/// `RegionSelectionController` in global (screen) coordinates.
 final class RegionSelectionView: NSView {
-    /// Called on a finished drag with the selection rect in global AppKit
-    /// coordinates (bottom-left origin) and the drag's anchor point.
+    /// Called when the user validates the selection, with the rect in global
+    /// AppKit coordinates (bottom-left origin) and the drag's anchor point.
     var onComplete: ((CGRect, CGPoint) -> Void)?
     /// Called when the user cancels (Esc, or a click without a real drag).
     var onCancel: (() -> Void)?
-    /// Whether to draw the "drag a rectangle" hint. With one view per screen,
-    /// only the view under the pointer sets this, so the hint shows just once.
-    var showsHint: Bool = true
+    /// Called on every mouse-down, before anything else. The controller uses it
+    /// to hand keyboard focus (and the hint) to the screen the user is actually
+    /// selecting on — otherwise a selection started on a secondary display would
+    /// leave Esc/Return/arrows going to another window.
+    var onBeginSelection: (() -> Void)?
+    /// Whether to draw the hint. With one view per screen, only the view the
+    /// user is working on sets this, so the hint shows just once.
+    var showsHint: Bool = true { didSet { needsDisplay = true } }
 
-    private var anchor: CGPoint?  // view-local
-    private var current: CGPoint? // view-local
+    /// Smallest drag that counts as a selection, and smallest side a resize can
+    /// leave behind.
+    private static let minSide: CGFloat = 3
+    /// A press that travels less than this is a click, not a drag.
+    private static let clickSlop: CGFloat = 3
+    /// Half-size of a handle's hit area — generous, the dots are small.
+    private static let handleTolerance: CGFloat = 10
+    private static let handleRadius: CGFloat = 4
+
+    /// What the pointer is currently doing.
+    private enum Gesture {
+        case none
+        case drawing                     // rubber-banding a new rect
+        case moving                      // dragging the selection around
+        case resizing(SelectionHandle)   // dragging one of its handles
+    }
+
+    private var gesture: Gesture = .none
+    /// The settled selection (view-local), non-nil once a drag produced one.
+    /// Always clamped to `bounds`, so it stays reachable and maps cleanly onto
+    /// this view's screen.
+    private var selection: CGRect?
+    private var anchor: CGPoint?   // rubber-band start, view-local
+    private var current: CGPoint?  // rubber-band end, view-local
+    /// Anchor of the drag that produced `selection`, in global coordinates. It
+    /// picks the target display downstream, so adjusting must not disturb it.
+    private var globalAnchor: CGPoint?
+    /// Pointer position at the previous drag event; gestures apply the delta
+    /// since then rather than a cumulative translation.
+    private var lastDragPoint: CGPoint?
+    /// Where the current press started, to tell a click from a drag.
+    private var pressPoint: CGPoint?
+    private var trackingArea: NSTrackingArea?
 
     override var isFlipped: Bool { false }
     override var acceptsFirstResponder: Bool { true }
     override var mouseDownCanMoveWindow: Bool { false }
 
-    /// Current selection in view-local coordinates, or `nil` before a drag.
-    private var selectionRect: CGRect? {
+    /// Rubber-band rect in view-local coordinates, or `nil` outside a drag.
+    private var rubberBandRect: CGRect? {
         guard let anchor, let current else { return nil }
         return CGRect(
             x: min(anchor.x, current.x),
@@ -32,41 +75,186 @@ final class RegionSelectionView: NSView {
         )
     }
 
+    /// The rect to draw: the live rubber band while drawing, the settled
+    /// selection otherwise.
+    private var displayRect: CGRect? {
+        if case .drawing = gesture { return rubberBandRect }
+        return selection
+    }
+
+    /// Whether a settled selection is up and waiting to be adjusted.
+    private var isAdjusting: Bool {
+        if case .drawing = gesture { return false }
+        return selection != nil
+    }
+
+    /// Drops whatever is selected here. The controller calls this on the other
+    /// screens' views when a selection starts, so only one rectangle is ever on
+    /// screen across displays.
+    func clearSelection() {
+        guard selection != nil || anchor != nil else { return }
+        selection = nil
+        anchor = nil
+        current = nil
+        globalAnchor = nil
+        gesture = .none
+        needsDisplay = true
+    }
+
     // MARK: - Mouse
 
     override func mouseDown(with event: NSEvent) {
-        anchor = convert(event.locationInWindow, from: nil)
-        current = anchor
+        onBeginSelection?()
+        let point = convert(event.locationInWindow, from: nil)
+        pressPoint = point
+        lastDragPoint = point
+
+        if let selection {
+            if let handle = SelectionHandle.hit(point, in: selection, tolerance: Self.handleTolerance) {
+                gesture = .resizing(handle)
+                return
+            }
+            if selection.contains(point) {
+                gesture = .moving
+                NSCursor.closedHand.set()
+                return
+            }
+        }
+
+        // Outside any selection: rubber-band a new one. The previous selection
+        // is kept until this drag proves itself, so a stray click doesn't throw
+        // the work away (it is restored in `mouseUp`).
+        anchor = point
+        current = point
+        gesture = .drawing
         needsDisplay = true
     }
 
     override func mouseDragged(with event: NSEvent) {
-        current = convert(event.locationInWindow, from: nil)
-        needsDisplay = true
+        let point = convert(event.locationInWindow, from: nil)
+        defer { lastDragPoint = point; needsDisplay = true }
+
+        switch gesture {
+        case .drawing:
+            current = point
+        case .moving:
+            guard let selection, let last = lastDragPoint else { return }
+            self.selection = SelectionHandle.moved(
+                selection, dx: point.x - last.x, dy: point.y - last.y, in: bounds
+            )
+        case .resizing(let handle):
+            guard let selection, let last = lastDragPoint else { return }
+            self.selection = handle.resize(
+                selection, dx: point.x - last.x, dy: point.y - last.y,
+                minSide: Self.minSide, in: bounds
+            )
+        case .none:
+            break
+        }
     }
 
     override func mouseUp(with event: NSEvent) {
-        defer { anchor = nil; current = nil; needsDisplay = true }
-        guard let rect = selectionRect, rect.width >= 3, rect.height >= 3,
-              let anchor, let window else {
-            onCancel?()
-            return
+        let finished = gesture
+        let point = convert(event.locationInWindow, from: nil)
+        let travel = pressPoint.map { hypot(point.x - $0.x, point.y - $0.y) } ?? 0
+        gesture = .none
+        pressPoint = nil
+        lastDragPoint = nil
+
+        switch finished {
+        case .drawing:
+            defer { anchor = nil; current = nil; needsDisplay = true }
+            let drawn = rubberBandRect?.intersection(bounds) ?? .null
+            guard drawn.width >= Self.minSide, drawn.height >= Self.minSide,
+                  let anchor, let window else {
+                // A click without a real drag: cancel outright when nothing is
+                // selected yet, otherwise keep the selection that was there.
+                if selection == nil { onCancel?() }
+                return
+            }
+            selection = drawn
+            globalAnchor = window.convertPoint(toScreen: anchor)
+        case .moving:
+            // A press inside the selection that never moved is a click, and a
+            // click validates.
+            if travel < Self.clickSlop {
+                commit()
+            } else {
+                cursor(at: point).set()  // back from the closed hand
+            }
+        case .resizing, .none:
+            break
         }
-        let globalRect = window.convertToScreen(rect)
-        let globalAnchor = window.convertPoint(toScreen: anchor)
-        onComplete?(globalRect, globalAnchor)
     }
 
-    // MARK: - Keyboard (Esc cancels)
+    // MARK: - Keyboard
 
     override func cancelOperation(_ sender: Any?) { onCancel?() }
 
     override func keyDown(with event: NSEvent) {
-        if event.keyCode == 53 { // Esc
-            onCancel?()
-        } else {
-            super.keyDown(with: event)
+        let step: CGFloat = event.modifierFlags.contains(.shift) ? 10 : 1
+        switch event.keyCode {
+        case 53:            onCancel?()                 // Esc — cancels everything
+        case 36, 76:        commit()                    // Return / keypad Enter
+        case 123:           nudge(dx: -step, dy: 0)     // ←
+        case 124:           nudge(dx: step, dy: 0)      // →
+        case 125:           nudge(dx: 0, dy: -step)     // ↓ (unflipped view)
+        case 126:           nudge(dx: 0, dy: step)      // ↑
+        default:            super.keyDown(with: event)
         }
+    }
+
+    /// Slides the selection by a keyboard step. No-op while a mouse gesture is
+    /// in flight, or before there is anything to nudge.
+    private func nudge(dx: CGFloat, dy: CGFloat) {
+        guard isAdjusting, case .none = gesture, let selection else { return }
+        self.selection = SelectionHandle.moved(selection, dx: dx, dy: dy, in: bounds)
+        needsDisplay = true
+    }
+
+    /// Hands the settled selection over in global coordinates. Silent when
+    /// there is nothing to capture yet (Return before the first drag).
+    private func commit() {
+        guard isAdjusting, let selection, let window,
+              selection.width >= Self.minSide, selection.height >= Self.minSide else { return }
+        let globalRect = window.convertToScreen(selection)
+        let anchor = globalAnchor
+            ?? window.convertPoint(toScreen: CGPoint(x: selection.midX, y: selection.midY))
+        onComplete?(globalRect, anchor)
+    }
+
+    // MARK: - Cursor
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingArea { removeTrackingArea(trackingArea) }
+        let area = NSTrackingArea(
+            rect: .zero,  // ignored with `.inVisibleRect`
+            options: [.activeAlways, .inVisibleRect, .mouseMoved, .cursorUpdate],
+            owner: self
+        )
+        addTrackingArea(area)
+        trackingArea = area
+    }
+
+    override func cursorUpdate(with event: NSEvent) {
+        cursor(at: convert(event.locationInWindow, from: nil)).set()
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        cursor(at: convert(event.locationInWindow, from: nil)).set()
+    }
+
+    /// Crosshair everywhere, except over an adjustable selection: its handles
+    /// get the matching resize cursor and its interior an open hand, so the rect
+    /// reads as draggable. The controller pushes the crosshair; setting a cursor
+    /// here only changes what's displayed, so its `pop()` still restores.
+    private func cursor(at point: CGPoint) -> NSCursor {
+        guard isAdjusting, let selection else { return .crosshair }
+        if let handle = SelectionHandle.hit(point, in: selection, tolerance: Self.handleTolerance) {
+            return handle.cursor
+        }
+        return selection.contains(point) ? .openHand : .crosshair
     }
 
     // MARK: - Drawing
@@ -75,9 +263,9 @@ final class RegionSelectionView: NSView {
         let dim = NSColor.black.withAlphaComponent(0.45)
         dim.setFill()
 
-        guard let sel = selectionRect?.intersection(bounds), sel.width > 0, sel.height > 0 else {
+        guard let sel = displayRect?.intersection(bounds), sel.width > 0, sel.height > 0 else {
             bounds.fill()
-            if showsHint { drawHint() }
+            if showsHint { drawHint(String(localized: "Drag a rectangle · Esc to cancel"), at: bounds.center) }
             return
         }
 
@@ -96,15 +284,27 @@ final class RegionSelectionView: NSView {
 
         drawHandles(sel)
         drawDimensions(sel)
+        if showsHint, isAdjusting {
+            // Below the selection by default, above it when the rect reaches
+            // that low — the hint must not sit on top of what's being framed.
+            let low = CGPoint(x: bounds.midX, y: bounds.minY + 56)
+            let high = CGPoint(x: bounds.midX, y: bounds.maxY - 56)
+            drawHint(
+                String(localized: "Drag or nudge with arrows · ↵ to capture · Esc to cancel"),
+                at: sel.minY < low.y + 24 ? high : low
+            )
+        }
     }
 
+    /// Four corner dots while rubber-banding; all eight once the selection is
+    /// adjustable, since that's when they actually do something.
     private func drawHandles(_ sel: CGRect) {
-        let r: CGFloat = 4
-        let corners = [
-            CGPoint(x: sel.minX, y: sel.minY), CGPoint(x: sel.maxX, y: sel.minY),
-            CGPoint(x: sel.minX, y: sel.maxY), CGPoint(x: sel.maxX, y: sel.maxY)
-        ]
-        for c in corners {
+        let handles: [SelectionHandle] = isAdjusting
+            ? SelectionHandle.allCases
+            : [.topLeft, .topRight, .bottomLeft, .bottomRight]
+        let r = Self.handleRadius
+        for handle in handles {
+            let c = handle.point(in: sel)
             let dot = NSBezierPath(ovalIn: NSRect(x: c.x - r, y: c.y - r, width: r * 2, height: r * 2))
             NSColor.white.setFill()
             dot.fill()
@@ -133,8 +333,8 @@ final class RegionSelectionView: NSView {
         text.draw(at: CGPoint(x: rect.minX + padX, y: rect.minY + padY), withAttributes: attrs)
     }
 
-    private func drawHint() {
-        let text = String(localized: "Drag a rectangle · Esc to cancel") as NSString
+    private func drawHint(_ string: String, at center: CGPoint) {
+        let text = string as NSString
         let attrs: [NSAttributedString.Key: Any] = [
             .font: NSFont.systemFont(ofSize: 13, weight: .medium),
             .foregroundColor: NSColor.white.withAlphaComponent(0.9)
@@ -143,8 +343,8 @@ final class RegionSelectionView: NSView {
         let padX: CGFloat = 14, padY: CGFloat = 8
         let badge = CGSize(width: textSize.width + padX * 2, height: textSize.height + padY * 2)
         let rect = CGRect(
-            x: bounds.midX - badge.width / 2,
-            y: bounds.midY - badge.height / 2,
+            x: center.x - badge.width / 2,
+            y: center.y - badge.height / 2,
             width: badge.width,
             height: badge.height
         )
@@ -152,4 +352,8 @@ final class RegionSelectionView: NSView {
         NSBezierPath(roundedRect: rect, xRadius: 10, yRadius: 10).fill()
         text.draw(at: CGPoint(x: rect.minX + padX, y: rect.minY + padY), withAttributes: attrs)
     }
+}
+
+private extension CGRect {
+    var center: CGPoint { CGPoint(x: midX, y: midY) }
 }

--- a/Pinpoint/SelectionHandle.swift
+++ b/Pinpoint/SelectionHandle.swift
@@ -1,0 +1,106 @@
+import AppKit
+
+/// The eight resize handles of an adjustable rectangle: four corners plus four
+/// edge midpoints.
+///
+/// This mirrors `CropOverlay`'s handle semantics in the editor so both surfaces
+/// behave the same way — a corner moves two edges, an edge handle moves one,
+/// free aspect ratio, a minimum side is enforced. The two can't share a type as
+/// is: the crop overlay works on a normalized SwiftUI rect (top-left origin),
+/// this one on view-local AppKit points. Geometry here is therefore expressed
+/// in AppKit's default bottom-left origin space (`RegionSelectionView` isn't
+/// flipped), so `top` means the *larger* `y`.
+enum SelectionHandle: CaseIterable {
+    case topLeft, top, topRight, right, bottomRight, bottom, bottomLeft, left
+
+    /// Where the handle sits on `rect`.
+    func point(in rect: CGRect) -> CGPoint {
+        switch self {
+        case .topLeft:     return CGPoint(x: rect.minX, y: rect.maxY)
+        case .top:         return CGPoint(x: rect.midX, y: rect.maxY)
+        case .topRight:    return CGPoint(x: rect.maxX, y: rect.maxY)
+        case .right:       return CGPoint(x: rect.maxX, y: rect.midY)
+        case .bottomRight: return CGPoint(x: rect.maxX, y: rect.minY)
+        case .bottom:      return CGPoint(x: rect.midX, y: rect.minY)
+        case .bottomLeft:  return CGPoint(x: rect.minX, y: rect.minY)
+        case .left:        return CGPoint(x: rect.minX, y: rect.midY)
+        }
+    }
+
+    /// The handle whose hit area contains `point`, or `nil` if none does.
+    ///
+    /// Corners are tested before edges: on a small rect their hit areas overlap,
+    /// and a corner (two edges at once) is the more useful of the two.
+    static func hit(_ point: CGPoint, in rect: CGRect, tolerance: CGFloat) -> SelectionHandle? {
+        let ordered: [SelectionHandle] = [
+            .topLeft, .topRight, .bottomRight, .bottomLeft,  // corners first
+            .top, .right, .bottom, .left
+        ]
+        return ordered.first { handle in
+            let p = handle.point(in: rect)
+            return abs(point.x - p.x) <= tolerance && abs(point.y - p.y) <= tolerance
+        }
+    }
+
+    /// Applies `dx`/`dy` to the edges this handle owns and returns the new rect,
+    /// never thinner than `minSide` on either axis and never leaving `bounds`.
+    ///
+    /// Built from explicit x/y/width/height because `CGRect`'s `minX`/`maxX` are
+    /// read-only, same as the editor's crop overlay.
+    func resize(_ rect: CGRect, dx: CGFloat, dy: CGFloat, minSide: CGFloat, in bounds: CGRect) -> CGRect {
+        var x = rect.minX
+        var y = rect.minY
+        var w = rect.width
+        var h = rect.height
+
+        switch self {
+        case .topLeft, .left, .bottomLeft:            // left edge
+            let nx = min(max(bounds.minX, x + dx), x + w - minSide)
+            w += x - nx
+            x = nx
+        default: break
+        }
+        switch self {
+        case .topRight, .right, .bottomRight:         // right edge
+            w = max(minSide, min(x + w + dx, bounds.maxX) - x)
+        default: break
+        }
+        switch self {
+        case .bottomLeft, .bottom, .bottomRight:      // bottom edge (smaller y)
+            let ny = min(max(bounds.minY, y + dy), y + h - minSide)
+            h += y - ny
+            y = ny
+        default: break
+        }
+        switch self {
+        case .topLeft, .top, .topRight:               // top edge (larger y)
+            h = max(minSide, min(y + h + dy, bounds.maxY) - y)
+        default: break
+        }
+
+        return CGRect(x: x, y: y, width: w, height: h)
+    }
+
+    /// Translates `rect` by `dx`/`dy`, keeping it fully inside `bounds` (the
+    /// rect keeps its size and slides along the edge it runs into).
+    static func moved(_ rect: CGRect, dx: CGFloat, dy: CGFloat, in bounds: CGRect) -> CGRect {
+        var moved = rect
+        moved.origin.x = min(max(bounds.minX, rect.minX + dx), max(bounds.minX, bounds.maxX - rect.width))
+        moved.origin.y = min(max(bounds.minY, rect.minY + dy), max(bounds.minY, bounds.maxY - rect.height))
+        return moved
+    }
+
+    /// The matching system frame-resize cursor, so a handle looks like one.
+    var cursor: NSCursor {
+        switch self {
+        case .topLeft:     return .frameResize(position: .topLeft, directions: .all)
+        case .top:         return .frameResize(position: .top, directions: .all)
+        case .topRight:    return .frameResize(position: .topRight, directions: .all)
+        case .right:       return .frameResize(position: .right, directions: .all)
+        case .bottomRight: return .frameResize(position: .bottomRight, directions: .all)
+        case .bottom:      return .frameResize(position: .bottom, directions: .all)
+        case .bottomLeft:  return .frameResize(position: .bottomLeft, directions: .all)
+        case .left:        return .frameResize(position: .left, directions: .all)
+        }
+    }
+}


### PR DESCRIPTION
Closes #47

## Le problème

`RegionSelectionView` dessinait des poignées qui promettaient un redimensionnement, mais `mouseUp` validait immédiatement : impossible de déplacer, d'ajuster ou de décaler le rectangle. Un cadrage à quelques pixels près obligeait à refaire tout le glisser.

## Ce que fait la PR

Le glisser initial ne capture plus. Il ouvre un **mode ajustable** :

- **Déplacer** — glisser à l'intérieur du rectangle (curseur main, contraint à l'écran).
- **Redimensionner** — huit poignées (4 coins + 4 milieux de bord), avec les curseurs de redimensionnement système. Un coin déplace deux bords, un bord un seul ; ratio libre.
- **Décaler au clavier** — flèches = 1 pt, ⇧ + flèches = 10 pt (convention macOS).
- **Valider** — Entrée (ou Entrée du pavé numérique), ou un clic sans déplacement dans le rectangle.
- **Annuler** — Échap annule **toute** la sélection, pas seulement l'ajustement.
- **Recommencer** — un glisser démarré hors du rectangle en trace un nouveau. Un clic isolé hors du rectangle ne jette pas le travail en cours : l'ancienne sélection est restaurée.

L'infobulle bascule de « Trace un rectangle » à « Déplace ou décale aux flèches · ↵ pour capturer · Échap pour annuler », et se place au-dessus du rectangle quand celui-ci descend dans le bas de l'écran.

## Implémentation

- Nouveau `Pinpoint/SelectionHandle.swift` : la géométrie des huit poignées (placement, hit-test, redimensionnement contraint, déplacement clampé). Il reprend la sémantique de `CropOverlay` de l'éditeur — un coin déplace deux bords, un bord un seul, ratio libre, côté minimal — pour que les deux surfaces se ressemblent. Les deux types ne peuvent pas fusionner en l'état : le recadrage travaille sur un rect SwiftUI normalisé (origine en haut à gauche), celui-ci sur des points AppKit locaux à la vue (origine en bas à gauche). `EditorView.swift` n'est pas touché (undo/redo #44 y est en cours en parallèle).
- `RegionSelectionView` porte désormais une petite machine à états (`none` / `drawing` / `moving` / `resizing`). Les gestes appliquent le delta depuis l'événement précédent, jamais une translation cumulée.
- La sélection est clampée aux `bounds` de la vue dès sa création, donc à l'écran d'ancrage — le même écran que celui que `resolve(globalRect:anchor:)` choisissait déjà, avec les poignées toujours atteignables.

### Multi-écran (cf. #26)

Le mode ajustable est piloté au clavier, donc la fenêtre qui porte la sélection doit être la fenêtre clé. Le contrôleur transfère maintenant, au premier clic, la fenêtre clé, l'infobulle et l'unique sélection à l'écran sur lequel l'utilisateur travaille — sinon une sélection démarrée sur un écran secondaire aurait vu Entrée / Échap / flèches partir dans la fenêtre restée clé. Les autres écrans effacent leur sélection, donc un seul rectangle est visible à la fois.

Le préflight de permission d'enregistrement de l'écran (`ScreenCapture.ensurePermission`, Tier 0) reste en tête de `selectRegion()`, avant tout affichage d'overlay.

## Vérifications

- `xcodegen generate` puis `xcodebuild -scheme Pinpoint -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` : **BUILD SUCCEEDED**, sans warning (c'est exactement ce que fait la CI).
- La géométrie de `SelectionHandle` a été vérifiée par un harnais `swiftc` hors projet (24 assertions : placement des poignées, priorité coin > bord au hit-test, chaque poignée déplace bien les bons bords, plancher de côté minimal, clamps aux quatre bords, déplacement clampé y compris pour un rect plus grand que la vue). Toutes passent. Le harnais n'est pas commité, faute de cible de test dans `project.yml`.
- **Non testé à la main** : lancer l'overlay demande de réinstaller l'app localement et de re-accorder la permission d'enregistrement de l'écran, ce qui aurait écrasé l'installation de la machine pendant que d'autres branches sont en cours. Le parcours souris/clavier reste donc à valider visuellement, en particulier sur un écran secondaire.

## i18n

Une seule clé ajoutée à `Localizable.xcstrings` (`en` par la clé, `fr` traduit), insérée à sa place alphabétique pour limiter les conflits avec les branches parallèles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)