### PR TITLE
Éditeur : formes sélectionnables, déplaçables et redimensionnables

### DIFF
--- a/Pinpoint/EditorView.swift
+++ b/Pinpoint/EditorView.swift
@@ -42,6 +42,16 @@ private enum EditorField: Hashable {
     case context
 }
 
+/// Which end of an arrow a handle drags. `tip` is the end carrying the
+/// arrowhead, so re-aiming an arrow is dragging its tip.
+private enum ArrowEnd: CaseIterable {
+    case tail, tip
+
+    func point(of shape: Markup) -> CGPoint {
+        self == .tail ? shape.start : shape.end
+    }
+}
+
 struct EditorView: View {
     /// The editor's base image. Mutable: a crop replaces it in place. Kept at
     /// native pixel size (`.size` == pixels) so export renders at full res.
@@ -80,13 +90,20 @@ struct EditorView: View {
 
     // MARK: Undo/redo state
     @State private var history = EditorHistory()
-    /// Pre-gesture state captured on a pin drag's first event, recorded once on
+    /// Pre-gesture state captured on a drag's first event, recorded once on
     /// release: a drag emits an event per frame, and each one must not become
-    /// its own undo entry.
+    /// its own undo entry. Shared by marker and shape gestures — only one of
+    /// them can be in flight at a time.
     @State private var dragUndoSnapshot: EditorSnapshot?
     /// Pre-edit state captured when a text field takes focus, recorded when it
     /// gives it up. See `flushTextEdit()` for why typing is coalesced this way.
     @State private var textEditSnapshot: EditorSnapshot?
+    /// The shape as it stood before the gesture in progress, captured on its
+    /// first event. Every frame applies the gesture's *cumulative* translation
+    /// to this copy rather than to the live shape — same rule as `pinDrag`, and
+    /// what keeps a drag from accelerating against its own output. Doubles as
+    /// the "a shape gesture is running" flag.
+    @State private var shapeDragOrigin: Markup?
 
     init(
         image: NSImage,
@@ -276,10 +293,19 @@ struct EditorView: View {
         if isCropping {
             return String(localized: "Drag handles to crop · Esc to cancel")
         }
+        // Once something of the active kind is on the canvas, the hint also
+        // advertises that it can be picked back up.
         switch tool {
-        case .pin: return String(localized: "Click to drop a marker")
-        case .arrow: return String(localized: "Drag to draw an arrow")
-        case .rectangle: return String(localized: "Drag to draw a rectangle")
+        case .pin:
+            return String(localized: "Click to drop a marker")
+        case .arrow:
+            return shapes.contains { $0.kind == .arrow }
+                ? String(localized: "Drag to draw an arrow · click one to move or re-aim it")
+                : String(localized: "Drag to draw an arrow")
+        case .rectangle:
+            return shapes.contains { $0.kind == .rectangle }
+                ? String(localized: "Drag to draw a rectangle · click one to move or resize it")
+                : String(localized: "Drag to draw a rectangle")
         }
     }
 
@@ -298,11 +324,25 @@ struct EditorView: View {
                     .position(x: fitted.midX, y: fitted.midY)
                     .shadow(radius: 8, y: 2)
 
-                // Committed markups (display-only; selection happens in the panel).
+                // Committed markups. Drawing and interaction are two layers:
+                // every shape draws first and takes no clicks, then the
+                // manipulable ones take them on top, so a handle is never
+                // buried under the outline of a shape drawn after it.
                 ForEach(shapes) { shape in
                     markupView(shape, in: fitted, selected: shape.id == selectedShapeID)
                 }
                 .allowsHitTesting(false)
+
+                // Grab bands along the outlines, then the selected shape's
+                // handles above every band. Non-manipulable shapes are left out
+                // of the layer entirely rather than hit-test-disabled inside it,
+                // so switching tools mid-hover takes their cursor with them.
+                ForEach(shapes.filter(isManipulable)) { shape in
+                    shapeGrabBand(shape, in: fitted)
+                }
+                if let shape = selectedShape, isManipulable(shape) {
+                    shapeHandles(shape, in: fitted)
+                }
 
                 // Live preview while drawing.
                 if let draft {
@@ -405,6 +445,225 @@ struct EditorView: View {
             .stroke(Color.pinpointVermillon, style: StrokeStyle(lineWidth: width, lineCap: .round, lineJoin: .round))
             .shadow(color: .black.opacity(0.25), radius: 1, y: 0.5)
         }
+    }
+
+    // MARK: - Shape manipulation
+
+    /// Width of the invisible band that makes a shape's outline clickable.
+    private static let shapeGrabBand: CGFloat = 14
+    /// Visible diameter of a manipulation handle, and the larger square that
+    /// actually takes the click — the dots are small, the grab area is not
+    /// (`RegionSelectionView` is equally generous with its 10pt tolerance).
+    private static let shapeHandleSize: CGFloat = 9
+    private static let shapeHandleHitSize: CGFloat = 20
+    /// Floor on a rectangle's on-screen sides while resizing. Small enough to
+    /// stay under anything `commitDraft` lets through, so touching a handle can
+    /// never inflate a shape that was already committed.
+    private static let shapeMinSide: CGFloat = 6
+
+    private var selectedShape: Markup? {
+        shapes.first { $0.id == selectedShapeID }
+    }
+
+    /// Whether a shape currently takes clicks on the canvas.
+    ///
+    /// The rule, chosen deliberately: a shape is manipulable exactly when the
+    /// tool that draws it is active — the same rule markers already follow, so
+    /// every tool owns its own objects and ⌘1/⌘2/⌘3 remain the single switch for
+    /// "what am I working on". A dedicated selection tool was the other option;
+    /// it would add a fourth segment and a mode to leave, to save one keystroke
+    /// in the only case where the rules differ (re-editing a shape whose tool
+    /// isn't the current one). Inert while cropping, like undo/redo: the crop
+    /// overlay is modal and owns interaction.
+    private func isManipulable(_ shape: Markup) -> Bool {
+        guard !isCropping else { return false }
+        switch shape.kind {
+        case .arrow: return tool == .arrow
+        case .rectangle: return tool == .rectangle
+        }
+    }
+
+    /// The clickable band along a shape's outline. Deliberately not its
+    /// interior: a rectangle annotation is mostly hole, and clicking through it
+    /// has to keep dropping markers and drawing new shapes.
+    @ViewBuilder
+    private func shapeGrabBand(_ shape: Markup, in fitted: CGRect) -> some View {
+        Group {
+            switch shape.kind {
+            case .rectangle:
+                let r = absoluteRect(shape.rect, in: fitted)
+                Color.clear
+                    .frame(width: r.width, height: r.height)
+                    .contentShape(OutlineHitShape(base: RoundedRectangle(cornerRadius: 4),
+                                                  width: Self.shapeGrabBand))
+                    .position(x: r.midX, y: r.midY)
+            case .arrow:
+                // Sized to the arrow's bounding box, band included, and the
+                // endpoints re-expressed inside it: `ArrowShape` draws in
+                // whatever space it is handed, and a view no larger than the
+                // shape keeps the hover cursor off the rest of the canvas.
+                let a = absolutePoint(shape.start, in: fitted)
+                let b = absolutePoint(shape.end, in: fitted)
+                let box = CGRect(x: min(a.x, b.x), y: min(a.y, b.y),
+                                 width: abs(b.x - a.x), height: abs(b.y - a.y))
+                    .insetBy(dx: -Self.shapeGrabBand, dy: -Self.shapeGrabBand)
+                Color.clear
+                    .frame(width: box.width, height: box.height)
+                    .contentShape(OutlineHitShape(
+                        base: ArrowShape(start: CGPoint(x: a.x - box.minX, y: a.y - box.minY),
+                                         end: CGPoint(x: b.x - box.minX, y: b.y - box.minY)),
+                        width: Self.shapeGrabBand
+                    ))
+                    .position(x: box.midX, y: box.midY)
+            }
+        }
+        .gesture(shapeMoveDrag(shape, in: fitted))
+        .hoverCursor(.openHand)
+    }
+
+    /// The handles of the selected shape: the two endpoints of an arrow (so a
+    /// mis-aimed one gets re-aimed instead of redrawn), the eight box handles of
+    /// a rectangle — `SelectionHandle`, the same geometry the capture overlay
+    /// uses, read in SwiftUI's top-left orientation.
+    @ViewBuilder
+    private func shapeHandles(_ shape: Markup, in fitted: CGRect) -> some View {
+        switch shape.kind {
+        case .arrow:
+            ForEach(ArrowEnd.allCases, id: \.self) { end in
+                handleDot(at: absolutePoint(end.point(of: shape), in: fitted), cursor: .crosshair)
+                    .gesture(arrowEndDrag(shape, end: end, in: fitted))
+            }
+        case .rectangle:
+            let r = absoluteRect(shape.rect, in: fitted)
+            ForEach(SelectionHandle.allCases, id: \.self) { handle in
+                handleDot(at: handle.point(in: r, orientation: .yDown), cursor: handle.cursor)
+                    .gesture(rectangleResizeDrag(shape, handle: handle, in: fitted))
+            }
+        }
+    }
+
+    /// One handle dot, styled like the crop overlay's so the two read as the
+    /// same control. The outer frame is the grab area, the inner one the dot.
+    private func handleDot(at point: CGPoint, cursor: NSCursor) -> some View {
+        ZStack {
+            Circle().fill(Color.white)
+            Circle().stroke(Color.pinpointVermillon, lineWidth: 2)
+        }
+        .frame(width: Self.shapeHandleSize, height: Self.shapeHandleSize)
+        .frame(width: Self.shapeHandleHitSize, height: Self.shapeHandleHitSize)
+        .contentShape(Rectangle())
+        .position(point)
+        .hoverCursor(cursor)
+    }
+
+    // MARK: Shape gestures
+
+    /// Shared prologue for every shape gesture: on the drag's first event it
+    /// closes any typing session, captures the pre-gesture state for undo and
+    /// the shape as it was, and selects it. Returns that pre-gesture copy, which
+    /// every mutation below applies the gesture's cumulative translation to.
+    private func beginShapeDrag(_ shape: Markup) -> Markup {
+        if shapeDragOrigin == nil {
+            flushTextEdit()
+            dragUndoSnapshot = snapshot()
+            shapeDragOrigin = shape
+        }
+        selectShape(shape.id)
+        return shapeDragOrigin ?? shape
+    }
+
+    /// Closes a shape gesture and records it as a single undo entry — nothing at
+    /// all when the drag was really a click, since selecting isn't an edit. Same
+    /// bookkeeping as `pinDrag`, which is why the two share `dragUndoSnapshot`:
+    /// only one gesture can be in flight at a time.
+    private func endShapeDrag() {
+        shapeDragOrigin = nil
+        guard let before = dragUndoSnapshot else { return }
+        dragUndoSnapshot = nil
+        if snapshot() != before { history.record(before) }
+    }
+
+    /// Writes a mutated shape back in place, if it is still there — an undo can
+    /// take it away mid-gesture.
+    private func replaceShape(_ shape: Markup) {
+        guard let index = shapes.firstIndex(where: { $0.id == shape.id }) else { return }
+        shapes[index] = shape
+    }
+
+    /// Drag anywhere on a shape's outline to move it.
+    private func shapeMoveDrag(_ shape: Markup, in fitted: CGRect) -> some Gesture {
+        DragGesture(minimumDistance: 0)
+            .onChanged { value in
+                let origin = beginShapeDrag(shape)
+                replaceShape(translated(origin, by: value.translation, in: fitted))
+            }
+            .onEnded { _ in endShapeDrag() }
+    }
+
+    /// Drag one of a rectangle's eight handles to resize it.
+    private func rectangleResizeDrag(_ shape: Markup, handle: SelectionHandle,
+                                     in fitted: CGRect) -> some Gesture {
+        DragGesture(minimumDistance: 0)
+            .onChanged { value in
+                let origin = beginShapeDrag(shape)
+                // Resized on screen, against the fitted image as bounds: that
+                // keeps the minimum side isotropic and the result inside 0...1
+                // without a second clamp fighting the first.
+                let resized = handle.resize(
+                    absoluteRect(origin.rect, in: fitted),
+                    dx: value.translation.width,
+                    dy: value.translation.height,
+                    minSide: Self.shapeMinSide,
+                    in: fitted,
+                    orientation: .yDown
+                )
+                var moved = origin
+                // Re-anchored to the box corners: `Markup.rect` is
+                // order-independent and the exporter reads rectangles through
+                // it, so which corner is `start` carries no meaning to lose.
+                moved.start = clamp01(normalize(CGPoint(x: resized.minX, y: resized.minY), in: fitted))
+                moved.end = clamp01(normalize(CGPoint(x: resized.maxX, y: resized.maxY), in: fitted))
+                replaceShape(moved)
+            }
+            .onEnded { _ in endShapeDrag() }
+    }
+
+    /// Drag an arrow's tail or tip to re-aim it. Same arithmetic as `pinDrag`:
+    /// one free point following the cursor, clamped to the image.
+    private func arrowEndDrag(_ shape: Markup, end: ArrowEnd, in fitted: CGRect) -> some Gesture {
+        DragGesture(minimumDistance: 0)
+            .onChanged { value in
+                let origin = beginShapeDrag(shape)
+                let base = end.point(of: origin)
+                let point = clamp01(CGPoint(
+                    x: base.x + value.translation.width / fitted.width,
+                    y: base.y + value.translation.height / fitted.height
+                ))
+                var moved = origin
+                switch end {
+                case .tail: moved.start = point
+                case .tip: moved.end = point
+                }
+                replaceShape(moved)
+            }
+            .onEnded { _ in endShapeDrag() }
+    }
+
+    /// Moves both defining points by the same on-screen translation, sliding the
+    /// shape back inside the image when it runs out. Clamping each point on its
+    /// own would squash the shape against the edge instead of stopping it, which
+    /// is exactly what `SelectionHandle.moved` already solves for the bounding
+    /// box — the effective delta it produces is then applied to both points.
+    private func translated(_ shape: Markup, by translation: CGSize, in fitted: CGRect) -> Markup {
+        guard fitted.width > 0, fitted.height > 0 else { return shape }
+        let box = absoluteRect(shape.rect, in: fitted)
+        let moved = SelectionHandle.moved(box, dx: translation.width, dy: translation.height, in: fitted)
+        let dx = (moved.minX - box.minX) / fitted.width
+        let dy = (moved.minY - box.minY) / fitted.height
+        var out = shape
+        out.start = clamp01(CGPoint(x: shape.start.x + dx, y: shape.start.y + dy))
+        out.end = clamp01(CGPoint(x: shape.end.x + dx, y: shape.end.y + dy))
+        return out
     }
 
     // MARK: - Side panel
@@ -719,6 +978,7 @@ struct EditorView: View {
         draft = nil
         dragStartPosition = nil
         dragUndoSnapshot = nil
+        shapeDragOrigin = nil
 
         image = state.image
         pins = state.pins
@@ -1100,6 +1360,57 @@ struct ArrowShape: Shape {
         path.move(to: end)
         path.addLine(to: CGPoint(x: end.x - headLength * cos(rightAngle), y: end.y - headLength * sin(rightAngle)))
         return path
+    }
+}
+
+/// Another shape's outline thickened into a grab band, used as a
+/// `contentShape` so a click lands on a stroke instead of on the empty area the
+/// stroke encloses.
+struct OutlineHitShape<Base: Shape>: Shape {
+    var base: Base
+    var width: CGFloat
+
+    func path(in rect: CGRect) -> Path {
+        base.path(in: rect)
+            .strokedPath(StrokeStyle(lineWidth: width, lineCap: .round, lineJoin: .round))
+    }
+}
+
+/// Shows `cursor` while the pointer is over the view.
+///
+/// Push/pop rather than `set()`: AppKit resets the cursor from the window's
+/// tracking areas on every mouse move, and a bare `set()` loses that race. The
+/// pushed state is tracked so a view that vanishes mid-hover — a handle whose
+/// shape gets deselected, a shape an undo takes away, a tool switch retiring a
+/// whole grab band — still balances its push.
+private struct HoverCursor: ViewModifier {
+    let cursor: NSCursor
+    @State private var pushed = false
+
+    func body(content: Content) -> some View {
+        content
+            .onHover { inside in
+                if inside {
+                    guard !pushed else { return }
+                    pushed = true
+                    cursor.push()
+                } else {
+                    pop()
+                }
+            }
+            .onDisappear(perform: pop)
+    }
+
+    private func pop() {
+        guard pushed else { return }
+        pushed = false
+        NSCursor.pop()
+    }
+}
+
+private extension View {
+    func hoverCursor(_ cursor: NSCursor) -> some View {
+        modifier(HoverCursor(cursor: cursor))
     }
 }
 

--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -320,9 +320,19 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Glisse pour tracer une flèche" } }
       }
     },
+    "Drag to draw an arrow · click one to move or re-aim it" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Glisse pour tracer une flèche · clique-en une pour la déplacer ou la réorienter" } }
+      }
+    },
     "Drag to draw a rectangle" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Glisse pour tracer un rectangle" } }
+      }
+    },
+    "Drag to draw a rectangle · click one to move or resize it" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Glisse pour tracer un rectangle · clique-en un pour le déplacer ou le redimensionner" } }
       }
     },
     "Drop screenshots into %@ or change the watched folder in Settings." : {

--- a/Pinpoint/SelectionHandle.swift
+++ b/Pinpoint/SelectionHandle.swift
@@ -3,19 +3,53 @@ import AppKit
 /// The eight resize handles of an adjustable rectangle: four corners plus four
 /// edge midpoints.
 ///
-/// This mirrors `CropOverlay`'s handle semantics in the editor so both surfaces
-/// behave the same way — a corner moves two edges, an edge handle moves one,
-/// free aspect ratio, a minimum side is enforced. The two can't share a type as
-/// is: the crop overlay works on a normalized SwiftUI rect (top-left origin),
-/// this one on view-local AppKit points. Geometry here is therefore expressed
-/// in AppKit's default bottom-left origin space (`RegionSelectionView` isn't
-/// flipped), so `top` means the *larger* `y`.
+/// This mirrors `CropOverlay`'s handle semantics so every adjustable rectangle
+/// in the app behaves the same way — a corner moves two edges, an edge handle
+/// moves one, free aspect ratio, a minimum side is enforced. Two surfaces use
+/// it, in opposite vertical conventions: the capture overlay works in an
+/// unflipped `NSView` (bottom-left origin) and the editor canvas in SwiftUI
+/// (top-left origin), so every geometry call takes an `Orientation`. The
+/// geometry itself is written in `.yUp` terms, which is the default — the
+/// AppKit caller reads exactly as it did before.
 enum SelectionHandle: CaseIterable {
     case topLeft, top, topRight, right, bottomRight, bottom, bottomLeft, left
 
-    /// Where the handle sits on `rect`.
-    func point(in rect: CGRect) -> CGPoint {
+    /// Which way "up" runs in the coordinate space a call is working in.
+    ///
+    /// Handle names describe what the user sees, not a sign convention: the
+    /// same `.topLeft` has to land on the smaller `y` in SwiftUI and on the
+    /// larger one in an unflipped `NSView`.
+    enum Orientation {
+        /// Bottom-left origin — AppKit's unflipped views (`RegionSelectionView`).
+        case yUp
+        /// Top-left origin — SwiftUI, and the normalized image space the editor
+        /// stores annotations in.
+        case yDown
+    }
+
+    /// The handle owning the same *edges* once the vertical axis is flipped.
+    /// Only the vertical component moves; `left`/`right` own no horizontal
+    /// mirror image and stay put.
+    private var verticallyMirrored: SelectionHandle {
         switch self {
+        case .topLeft:     return .bottomLeft
+        case .top:         return .bottom
+        case .topRight:    return .bottomRight
+        case .bottomRight: return .topRight
+        case .bottom:      return .top
+        case .bottomLeft:  return .topLeft
+        case .right, .left: return self
+        }
+    }
+
+    /// The handle to compute with, given the caller's convention.
+    private func resolved(_ orientation: Orientation) -> SelectionHandle {
+        orientation == .yUp ? self : verticallyMirrored
+    }
+
+    /// Where the handle sits on `rect`.
+    func point(in rect: CGRect, orientation: Orientation = .yUp) -> CGPoint {
+        switch resolved(orientation) {
         case .topLeft:     return CGPoint(x: rect.minX, y: rect.maxY)
         case .top:         return CGPoint(x: rect.midX, y: rect.maxY)
         case .topRight:    return CGPoint(x: rect.maxX, y: rect.maxY)
@@ -31,13 +65,14 @@ enum SelectionHandle: CaseIterable {
     ///
     /// Corners are tested before edges: on a small rect their hit areas overlap,
     /// and a corner (two edges at once) is the more useful of the two.
-    static func hit(_ point: CGPoint, in rect: CGRect, tolerance: CGFloat) -> SelectionHandle? {
+    static func hit(_ point: CGPoint, in rect: CGRect, tolerance: CGFloat,
+                    orientation: Orientation = .yUp) -> SelectionHandle? {
         let ordered: [SelectionHandle] = [
             .topLeft, .topRight, .bottomRight, .bottomLeft,  // corners first
             .top, .right, .bottom, .left
         ]
         return ordered.first { handle in
-            let p = handle.point(in: rect)
+            let p = handle.point(in: rect, orientation: orientation)
             return abs(point.x - p.x) <= tolerance && abs(point.y - p.y) <= tolerance
         }
     }
@@ -46,33 +81,38 @@ enum SelectionHandle: CaseIterable {
     /// never thinner than `minSide` on either axis and never leaving `bounds`.
     ///
     /// Built from explicit x/y/width/height because `CGRect`'s `minX`/`maxX` are
-    /// read-only, same as the editor's crop overlay.
-    func resize(_ rect: CGRect, dx: CGFloat, dy: CGFloat, minSide: CGFloat, in bounds: CGRect) -> CGRect {
+    /// read-only, same as the editor's crop overlay. The deltas are taken in the
+    /// caller's own space, so a `.yDown` caller passes the translation it got
+    /// from SwiftUI unchanged: mirroring the handle is enough, because each
+    /// branch below owns a `min`/`max` *edge*, not a screen direction.
+    func resize(_ rect: CGRect, dx: CGFloat, dy: CGFloat, minSide: CGFloat, in bounds: CGRect,
+                orientation: Orientation = .yUp) -> CGRect {
+        let handle = resolved(orientation)
         var x = rect.minX
         var y = rect.minY
         var w = rect.width
         var h = rect.height
 
-        switch self {
+        switch handle {
         case .topLeft, .left, .bottomLeft:            // left edge
             let nx = min(max(bounds.minX, x + dx), x + w - minSide)
             w += x - nx
             x = nx
         default: break
         }
-        switch self {
+        switch handle {
         case .topRight, .right, .bottomRight:         // right edge
             w = max(minSide, min(x + w + dx, bounds.maxX) - x)
         default: break
         }
-        switch self {
+        switch handle {
         case .bottomLeft, .bottom, .bottomRight:      // bottom edge (smaller y)
             let ny = min(max(bounds.minY, y + dy), y + h - minSide)
             h += y - ny
             y = ny
         default: break
         }
-        switch self {
+        switch handle {
         case .topLeft, .top, .topRight:               // top edge (larger y)
             h = max(minSide, min(y + h + dy, bounds.maxY) - y)
         default: break
@@ -82,7 +122,8 @@ enum SelectionHandle: CaseIterable {
     }
 
     /// Translates `rect` by `dx`/`dy`, keeping it fully inside `bounds` (the
-    /// rect keeps its size and slides along the edge it runs into).
+    /// rect keeps its size and slides along the edge it runs into). Orientation
+    /// free: it moves both edges of each axis by the same amount.
     static func moved(_ rect: CGRect, dx: CGFloat, dy: CGFloat, in bounds: CGRect) -> CGRect {
         var moved = rect
         moved.origin.x = min(max(bounds.minX, rect.minX + dx), max(bounds.minX, bounds.maxX - rect.width))
@@ -91,6 +132,8 @@ enum SelectionHandle: CaseIterable {
     }
 
     /// The matching system frame-resize cursor, so a handle looks like one.
+    /// Orientation free: the cases are named for what the user sees, and so are
+    /// AppKit's cursor positions.
     var cursor: NSCursor {
         switch self {
         case .topLeft:     return .frameResize(position: .topLeft, directions: .all)


### PR DESCRIPTION
Closes #45

Les formes (flèches, rectangles) portaient `.allowsHitTesting(false)` : une fois tracées,
elles étaient figées. Une flèche mal placée devait être supprimée puis refaite —
incohérent avec les repères, déplaçables depuis le Tier 0. Elles se manipulent
désormais directement sur le canvas.

## Ce que ça donne

- **Sélection** par clic sur le tracé de la forme. Volontairement *pas* sur son
  intérieur : un rectangle d'annotation est surtout du vide, et cliquer au travers doit
  continuer à poser un repère ou à dessiner une nouvelle forme par-dessus.
- **Déplacement** en glissant n'importe où sur ce tracé. La forme garde sa taille et
  glisse le long du bord quand elle atteint l'image, plutôt que de s'y écraser.
- **Redimensionnement** par poignées : les deux extrémités pour une flèche (donc
  re-cibler une flèche = tirer sa pointe), les huit poignées habituelles pour un
  rectangle, avec les curseurs système correspondants.
- Le survol change le curseur (main ouverte sur le tracé, curseur de redimensionnement
  sur une poignée), pour rendre la manipulation découvrable.
- Le libellé d'aide de la barre d'outils l'annonce dès qu'une forme du type actif
  existe : « Glisse pour tracer une flèche · clique-en une pour la déplacer ou la
  réorienter ».

## Décision d'UX : quand une forme est-elle manipulable ?

**Une forme prend les clics exactement quand l'outil qui la dessine est actif** —
c'est déjà la règle des repères (`allowsHitTesting(tool == .pin && !isCropping)`).
Chaque outil possède ses propres objets, et ⌘1/⌘2/⌘3 restent le seul sélecteur de
contexte de l'éditeur.

L'autre option était un vrai outil « sélection ». Elle a été écartée : elle ajoute un
quatrième segment au picker et un mode dont il faut ressortir, alors que les deux règles
ne divergent que dans un cas — re-modifier une forme dont l'outil n'est pas l'outil
courant — qui coûte une frappe (⌘2/⌘3) dans un cas comme dans l'autre. Le scénario
dominant de l'issue (« je viens de tracer cette flèche, elle est mal placée ») est servi
sans changer d'outil du tout.

Conséquences retenues telles quelles :
- Une forme sélectionnée reste sélectionnée quand on change d'outil (⌫ la supprime
  toujours, la ligne du panneau reste surlignée) ; elle perd seulement ses poignées.
- Tout est neutralisé pendant le recadrage, comme l'undo/redo : `enterCropMode` vide la
  sélection et l'overlay de crop est modal.

## Intégration avec ce qui vient d'être mergé

**Undo/redo (#44).** Chaque geste passe par le mécanisme de coalescence de
`EditorView` : instantané capturé au premier événement, consigné au relâchement, via le
même `dragUndoSnapshot` que `pinDrag` (un seul geste peut être en vol à la fois). Donc
un déplacement, un redimensionnement ou un re-ciblage = **une** entrée d'annulation ; un
simple clic, qui ne fait que sélectionner, n'en produit aucune (`snapshot() != before`
tranche, et `EditorSnapshot` exclut déjà la sélection de sa comparaison). `restore()`
remet aussi à zéro le geste en cours.

**Poignées de sélection (#47).** `SelectionHandle` est **généralisé plutôt que
dupliqué**. Il était écrit pour l'espace AppKit (origine en bas à gauche) et l'éditeur
est en SwiftUI (origine en haut à gauche) ; les trois fonctions de géométrie prennent
maintenant une `Orientation`, `.yUp` par défaut. **`RegionSelectionView` est inchangé** :
aucun de ses appels n'a bougé, la valeur par défaut lui rend le comportement d'origine.
En interne, `.yDown` réfléchit simplement le handle verticalement — chaque branche de
`resize` possède un bord `min`/`max`, pas une direction d'écran, donc le delta SwiftUI
s'applique tel quel. `moved(_:dx:dy:in:)` et `cursor` sont indifférents à l'orientation
et n'ont pas été touchés.

## Vérifications

- `xcodegen generate` + `xcodebuild -scheme Pinpoint -destination 'platform=macOS'` :
  vert.
- Géométrie de `SelectionHandle` couverte par 18 assertions dans les deux orientations
  (placement des 8 poignées, redimensionnement par coin/bord, clamp aux bornes, côté
  minimum, non-régression `.yUp`) — exécutées hors du dépôt, pas de cible de test dans
  le projet.
- Pilotage manuel de `EditorView` dans un hôte SwiftUI jetable : les 8 poignées d'un
  rectangle et les 2 d'une flèche s'affichent aux bons endroits, le clic sur le tracé
  sélectionne, le clic à l'intérieur traverse et désélectionne, changer d'outil retire
  les poignées, ⌫ supprime une forme sélectionnée par hit-test (une seule entrée
  d'annulation), l'undo la restaure, et le mode recadrage neutralise le tout.
  Les glisser-déplacer eux-mêmes n'ont pas pu être rejoués par ce biais (le drag
  synthétique de l'outil de pilotage ne produit pas d'événements que `DragGesture`
  accepte) ; leur arithmétique est celle, déjà en production, de `pinDrag`.
