### PR TITLE
Éditeur : aligne l'échelle des repères et des traits sur celle de l'export

### DIFF
--- a/Pinpoint/EditorView.swift
+++ b/Pinpoint/EditorView.swift
@@ -314,6 +314,10 @@ struct EditorView: View {
     private var canvas: some View {
         GeometryReader { geo in
             let fitted = fittedRect(imageSize: image.size, in: geo.size)
+            // Sizes every annotation against the capture, then down to the
+            // fitted rect — so what the canvas shows is what the export draws
+            // (#48). One instance per layout pass, shared by every layer below.
+            let metrics = MarkupMetrics(imageSize: image.size, fitted: fitted)
             ZStack(alignment: .topLeading) {
                 Color(nsColor: .windowBackgroundColor)
 
@@ -329,7 +333,7 @@ struct EditorView: View {
                 // manipulable ones take them on top, so a handle is never
                 // buried under the outline of a shape drawn after it.
                 ForEach(shapes) { shape in
-                    markupView(shape, in: fitted, selected: shape.id == selectedShapeID)
+                    markupView(shape, in: fitted, metrics: metrics, selected: shape.id == selectedShapeID)
                 }
                 .allowsHitTesting(false)
 
@@ -338,7 +342,7 @@ struct EditorView: View {
                 // of the layer entirely rather than hit-test-disabled inside it,
                 // so switching tools mid-hover takes their cursor with them.
                 ForEach(shapes.filter(isManipulable)) { shape in
-                    shapeGrabBand(shape, in: fitted)
+                    shapeGrabBand(shape, in: fitted, metrics: metrics)
                 }
                 if let shape = selectedShape, isManipulable(shape) {
                     shapeHandles(shape, in: fitted)
@@ -346,16 +350,24 @@ struct EditorView: View {
 
                 // Live preview while drawing.
                 if let draft {
-                    markupView(draft, in: fitted, selected: true)
+                    markupView(draft, in: fitted, metrics: metrics, selected: true)
                         .allowsHitTesting(false)
                         .opacity(0.9)
                 }
 
                 // Numbered pins.
                 ForEach($pins) { $pin in
-                    let anchor = clampedMarkerAnchor(absolutePoint(pin.position, in: fitted), in: fitted)
-                    PinMarker(number: pin.number, style: pinStyle, selected: pin.id == selectedPinID)
-                        .position(x: anchor.x, y: anchor.y + PinMarker.anchorYOffset(pinStyle))
+                    let anchor = clampedMarkerAnchor(absolutePoint(pin.position, in: fitted),
+                                                     in: fitted, metrics: metrics)
+                    let markerSize = PinMarker.size(pinStyle, metrics: metrics)
+                    PinMarker(number: pin.number, metrics: metrics, style: pinStyle,
+                              selected: pin.id == selectedPinID)
+                        // The badge is centred inside its grab area, so the
+                        // anchor offset keeps measuring the same distance.
+                        .frame(width: max(Self.pinGrabSize, markerSize.width),
+                               height: max(Self.pinGrabSize, markerSize.height))
+                        .contentShape(Rectangle())
+                        .position(x: anchor.x, y: anchor.y + PinMarker.anchorYOffset(pinStyle, metrics: metrics))
                         .gesture(pinDrag($pin, in: fitted))
                         .allowsHitTesting(tool == .pin && !isCropping)
                 }
@@ -427,12 +439,15 @@ struct EditorView: View {
     }
 
     @ViewBuilder
-    private func markupView(_ shape: Markup, in fitted: CGRect, selected: Bool) -> some View {
-        let width: CGFloat = selected ? 5 : 3.5
+    private func markupView(_ shape: Markup, in fitted: CGRect, metrics: MarkupMetrics,
+                            selected: Bool) -> some View {
+        // The stroke the export will use, thickened while selected — that part
+        // is an editor affordance and never reaches the exported image.
+        let width = metrics.lineWidth * (selected ? Self.selectedStrokeBoost : 1)
         switch shape.kind {
         case .rectangle:
             let r = absoluteRect(shape.rect, in: fitted)
-            RoundedRectangle(cornerRadius: 4)
+            RoundedRectangle(cornerRadius: metrics.cornerRadius)
                 .stroke(Color.pinpointVermillon, lineWidth: width)
                 .shadow(color: .black.opacity(0.25), radius: 1, y: 0.5)
                 .frame(width: r.width, height: r.height)
@@ -440,7 +455,8 @@ struct EditorView: View {
         case .arrow:
             ArrowShape(
                 start: absolutePoint(shape.start, in: fitted),
-                end: absolutePoint(shape.end, in: fitted)
+                end: absolutePoint(shape.end, in: fitted),
+                headLength: metrics.arrowHeadLength
             )
             .stroke(Color.pinpointVermillon, style: StrokeStyle(lineWidth: width, lineCap: .round, lineJoin: .round))
             .shadow(color: .black.opacity(0.25), radius: 1, y: 0.5)
@@ -450,7 +466,29 @@ struct EditorView: View {
     // MARK: - Shape manipulation
 
     /// Width of the invisible band that makes a shape's outline clickable.
+    /// A floor, not the whole story: `grabBandWidth(_:)` widens it when the
+    /// stroke it has to cover is wider still.
     private static let shapeGrabBand: CGFloat = 14
+
+    /// The grab band actually used, never narrower than the outline it covers —
+    /// a small capture blown up to fill the canvas draws strokes far thicker
+    /// than 14 pt, and a band thinner than its own outline would leave the
+    /// middle of the stroke unclickable.
+    private static func grabBandWidth(_ metrics: MarkupMetrics) -> CGFloat {
+        max(shapeGrabBand, metrics.lineWidth * 2)
+    }
+
+    /// Floor on a marker's grab area. Badges scale with the preview now, so a
+    /// large capture in a small window draws them genuinely small: the dot
+    /// stays faithful to the export while the area you can grab it by doesn't
+    /// shrink past what a pointer can hit — the same split `shapeHandleSize` /
+    /// `shapeHandleHitSize` already make for handles.
+    private static let pinGrabSize: CGFloat = 24
+
+    /// How much heavier a selected shape's outline is drawn. Editor-only: the
+    /// export always renders `MarkupMetrics.lineWidth`.
+    private static let selectedStrokeBoost: CGFloat = 1.4
+
     /// Visible diameter of a manipulation handle, and the larger square that
     /// actually takes the click — the dots are small, the grab area is not
     /// (`RegionSelectionView` is equally generous with its 10pt tolerance).
@@ -487,15 +525,16 @@ struct EditorView: View {
     /// interior: a rectangle annotation is mostly hole, and clicking through it
     /// has to keep dropping markers and drawing new shapes.
     @ViewBuilder
-    private func shapeGrabBand(_ shape: Markup, in fitted: CGRect) -> some View {
+    private func shapeGrabBand(_ shape: Markup, in fitted: CGRect, metrics: MarkupMetrics) -> some View {
+        let band = Self.grabBandWidth(metrics)
         Group {
             switch shape.kind {
             case .rectangle:
                 let r = absoluteRect(shape.rect, in: fitted)
                 Color.clear
                     .frame(width: r.width, height: r.height)
-                    .contentShape(OutlineHitShape(base: RoundedRectangle(cornerRadius: 4),
-                                                  width: Self.shapeGrabBand))
+                    .contentShape(OutlineHitShape(base: RoundedRectangle(cornerRadius: metrics.cornerRadius),
+                                                  width: band))
                     .position(x: r.midX, y: r.midY)
             case .arrow:
                 // Sized to the arrow's bounding box, band included, and the
@@ -504,15 +543,22 @@ struct EditorView: View {
                 // shape keeps the hover cursor off the rest of the canvas.
                 let a = absolutePoint(shape.start, in: fitted)
                 let b = absolutePoint(shape.end, in: fitted)
+                // The head splays out sideways from the tip, so the box is
+                // grown by its length as well as by the band — otherwise a
+                // scaled-up arrowhead would stick out of the view holding its
+                // own hit shape. `contentShape` still narrows the clickable
+                // area back down to the outline itself.
+                let margin = band + metrics.arrowHeadLength
                 let box = CGRect(x: min(a.x, b.x), y: min(a.y, b.y),
                                  width: abs(b.x - a.x), height: abs(b.y - a.y))
-                    .insetBy(dx: -Self.shapeGrabBand, dy: -Self.shapeGrabBand)
+                    .insetBy(dx: -margin, dy: -margin)
                 Color.clear
                     .frame(width: box.width, height: box.height)
                     .contentShape(OutlineHitShape(
                         base: ArrowShape(start: CGPoint(x: a.x - box.minX, y: a.y - box.minY),
-                                         end: CGPoint(x: b.x - box.minX, y: b.y - box.minY)),
-                        width: Self.shapeGrabBand
+                                         end: CGPoint(x: b.x - box.minX, y: b.y - box.minY),
+                                         headLength: metrics.arrowHeadLength),
+                        width: band
                     ))
                     .position(x: box.midX, y: box.midY)
             }
@@ -1108,16 +1154,17 @@ struct EditorView: View {
     /// even when the point is near an edge. Only affects where the badge is
     /// drawn — `pin.position` is untouched — and mirrors `Exporter`'s clamping so
     /// the editor and the exported image agree.
-    private func clampedMarkerAnchor(_ anchor: CGPoint, in fitted: CGRect) -> CGPoint {
-        let side = PinMarker.headDiameter / 2 + 2  // circle half-width incl. ring
+    private func clampedMarkerAnchor(_ anchor: CGPoint, in fitted: CGRect,
+                                     metrics: MarkupMetrics) -> CGPoint {
+        let side = metrics.badgeHalfSide  // circle half-width incl. ring
         let x = min(max(anchor.x, fitted.minX + side), max(fitted.minX + side, fitted.maxX - side))
         switch pinStyle {
         case .disc, .outline:
             let y = min(max(anchor.y, fitted.minY + side), max(fitted.minY + side, fitted.maxY - side))
             return CGPoint(x: x, y: y)
         case .pointer:
-            // The 28×42 marker sits with its tip at the anchor, extending upward.
-            let top = fitted.minY + PinMarker.pointerHeight
+            // The marker sits with its tip at the anchor, extending upward.
+            let top = fitted.minY + metrics.pointerHeight
             let y = min(max(anchor.y, top), max(top, fitted.maxY))
             return CGPoint(x: x, y: y)
         }
@@ -1343,6 +1390,10 @@ struct CropOverlay: View {
 struct ArrowShape: Shape {
     var start: CGPoint
     var end: CGPoint
+    /// Length of the two strokes forming the head. Supplied by the caller from
+    /// `MarkupMetrics` rather than fixed here, so the preview's arrowhead is
+    /// the one the export draws — see #48.
+    var headLength: CGFloat
 
     func path(in rect: CGRect) -> Path {
         var path = Path()
@@ -1350,8 +1401,7 @@ struct ArrowShape: Shape {
         path.addLine(to: end)
 
         let angle = atan2(end.y - start.y, end.x - start.x)
-        let headLength: CGFloat = 16
-        let spread = CGFloat.pi / 6.5
+        let spread = MarkupMetrics.arrowHeadSpread
 
         let leftAngle = angle - spread
         let rightAngle = angle + spread
@@ -1416,6 +1466,10 @@ private extension View {
 
 /// Map-pin silhouette filling its rect: a circular head at the top tapering to
 /// a tip at the bottom-centre. Used for the `.pointer` marker style.
+///
+/// Everything is derived from the rect, so the caller sets the proportions: a
+/// rect of `2r × 3r` puts the head's centre `2r` above the tip, which is what
+/// `Exporter` draws for the same style.
 struct PinShape: Shape {
     func path(in rect: CGRect) -> Path {
         let diameter = rect.width
@@ -1436,18 +1490,28 @@ struct PinShape: Shape {
 }
 
 /// The numbered marker, rendered in one of the three design-system styles.
+///
+/// Sized entirely from `MarkupMetrics`, which is what makes it the same badge
+/// `Exporter.drawMarker` renders: it used to be a fixed 28 pt disc, so the
+/// export of a small capture came out proportionally much heavier than the
+/// preview that produced it (#48).
 struct PinMarker: View {
     let number: Int
+    let metrics: MarkupMetrics
     var style: PinStyle = .disc
     var selected: Bool = false
 
-    static let headDiameter: CGFloat = 28
-    static let pointerHeight: CGFloat = 42
-
     /// Vertical offset to apply when positioning the marker so its anchor lands
     /// on the marked point: centred for disc/outline, tip-anchored for pointer.
-    static func anchorYOffset(_ style: PinStyle) -> CGFloat {
-        style == .pointer ? -(pointerHeight / 2) : 0
+    static func anchorYOffset(_ style: PinStyle, metrics: MarkupMetrics) -> CGFloat {
+        style == .pointer ? -(metrics.pointerHeight / 2) : 0
+    }
+
+    /// The marker's laid-out size — its footprint on the canvas, which is also
+    /// the grab area `EditorView` starts from before applying its own floor.
+    static func size(_ style: PinStyle, metrics: MarkupMetrics) -> CGSize {
+        CGSize(width: metrics.pinRadius * 2,
+               height: style == .pointer ? metrics.pointerHeight : metrics.pinRadius * 2)
     }
 
     var body: some View {
@@ -1458,16 +1522,23 @@ struct PinMarker: View {
         }
     }
 
+    private var headDiameter: CGFloat { metrics.pinRadius * 2 }
+
+    /// The ring around the badge, drawn heavier while selected. The extra
+    /// weight is an editor affordance only — the export always strokes
+    /// `metrics.ringWidth`.
+    private var ringWidth: CGFloat { metrics.ringWidth * (selected ? 1.4 : 1) }
+
     private var numberText: some View {
-        Text("\(number)").font(.system(size: 14, weight: .bold))
+        Text("\(number)").font(.system(size: metrics.numberFontSize, weight: .bold))
     }
 
     private var disc: some View {
         numberText
             .foregroundStyle(.white)
-            .frame(width: Self.headDiameter, height: Self.headDiameter)
+            .frame(width: headDiameter, height: headDiameter)
             .background(Circle().fill(Color.pinpointVermillon))
-            .overlay(Circle().stroke(.white, lineWidth: selected ? 3.5 : 2.5))
+            .overlay(Circle().stroke(.white, lineWidth: ringWidth))
             .overlay(Circle().stroke(.black.opacity(0.18), lineWidth: 0.5))
             .shadow(color: .black.opacity(0.35), radius: 2, y: 1)
     }
@@ -1475,9 +1546,9 @@ struct PinMarker: View {
     private var outline: some View {
         numberText
             .foregroundStyle(Color.pinpointVermillon)
-            .frame(width: Self.headDiameter, height: Self.headDiameter)
-            .overlay(Circle().stroke(.white, lineWidth: selected ? 5 : 4))
-            .overlay(Circle().stroke(Color.pinpointVermillon, lineWidth: selected ? 3 : 2))
+            .frame(width: headDiameter, height: headDiameter)
+            .overlay(Circle().stroke(.white, lineWidth: ringWidth * 1.7))
+            .overlay(Circle().stroke(Color.pinpointVermillon, lineWidth: ringWidth))
             .shadow(color: .black.opacity(0.25), radius: 1.5, y: 0.5)
     }
 
@@ -1487,12 +1558,12 @@ struct PinMarker: View {
                 .fill(Color.pinpointVermillon)
                 .shadow(color: .black.opacity(0.35), radius: 2, y: 1)
             Circle()
-                .stroke(.white, lineWidth: selected ? 3 : 2)
-                .frame(width: Self.headDiameter, height: Self.headDiameter)
+                .stroke(.white, lineWidth: ringWidth)
+                .frame(width: headDiameter, height: headDiameter)
             numberText
                 .foregroundStyle(.white)
-                .frame(width: Self.headDiameter, height: Self.headDiameter)
+                .frame(width: headDiameter, height: headDiameter)
         }
-        .frame(width: Self.headDiameter, height: Self.pointerHeight)
+        .frame(width: headDiameter, height: metrics.pointerHeight)
     }
 }

--- a/Pinpoint/Exporter.swift
+++ b/Pinpoint/Exporter.swift
@@ -12,12 +12,14 @@ enum Exporter {
         base.draw(in: NSRect(origin: .zero, size: size),
                   from: .zero, operation: .copy, fraction: 1.0)
 
-        let lineWidth = max(3, size.width * 0.004)
+        // Drawn at 1:1 into the image's own pixel grid, so the metrics need
+        // no scaling here. `EditorView` builds the same metrics with the
+        // canvas' scale factor, which is what makes the preview WYSIWYG.
+        let metrics = MarkupMetrics(imageWidth: size.width)
         for shape in shapes {
-            drawMarkup(shape, in: size, lineWidth: lineWidth)
+            drawMarkup(shape, in: size, metrics: metrics)
         }
 
-        let radius = max(16, size.width * 0.014)
         for pin in pins {
             // Pin position is the marked point (top-left origin); NSImage
             // drawing is bottom-left, so flip y.
@@ -27,16 +29,17 @@ enum Exporter {
             )
             // Keep the badge fully inside the image when the point is near an
             // edge; the exact point is still carried by the % in the text.
-            let drawAnchor = clampedMarkerAnchor(anchor, radius: radius, style: style, in: size)
-            drawMarker(number: pin.number, anchor: drawAnchor, radius: radius, style: style)
+            let drawAnchor = clampedMarkerAnchor(anchor, metrics: metrics, style: style, in: size)
+            drawMarker(number: pin.number, anchor: drawAnchor, metrics: metrics, style: style)
         }
 
         result.unlockFocus()
         return result
     }
 
-    private static func drawMarkup(_ shape: Markup, in size: CGSize, lineWidth: CGFloat) {
+    private static func drawMarkup(_ shape: Markup, in size: CGSize, metrics: MarkupMetrics) {
         NSColor.pinpointVermillon.setStroke()
+        let lineWidth = metrics.lineWidth
 
         // Normalized (top-left origin) → image space (bottom-left origin).
         func px(_ p: CGPoint) -> CGPoint {
@@ -52,7 +55,8 @@ enum Exporter {
                 width: r.width * size.width,
                 height: r.height * size.height
             )
-            let path = NSBezierPath(roundedRect: rect, xRadius: lineWidth, yRadius: lineWidth)
+            let path = NSBezierPath(roundedRect: rect,
+                                    xRadius: metrics.cornerRadius, yRadius: metrics.cornerRadius)
             path.lineWidth = lineWidth
             path.stroke()
 
@@ -67,8 +71,8 @@ enum Exporter {
             path.line(to: end)
 
             let angle = atan2(end.y - start.y, end.x - start.x)
-            let headLength = max(14, size.width * 0.018)
-            let spread = CGFloat.pi / 6.5
+            let headLength = metrics.arrowHeadLength
+            let spread = MarkupMetrics.arrowHeadSpread
 
             let leftAngle = angle - spread
             let rightAngle = angle + spread
@@ -88,15 +92,15 @@ enum Exporter {
     /// space, y up). For the pointer the tip is at the anchor and the head sits
     /// above it (+y); disc/outline are centred on the anchor. Mirrors the
     /// clamping done on screen in `EditorView` so export and editor agree.
-    private static func clampedMarkerAnchor(_ anchor: CGPoint, radius: CGFloat, style: PinStyle, in size: CGSize) -> CGPoint {
-        let side = radius + max(2, radius * 0.16)  // half-width incl. ring
+    private static func clampedMarkerAnchor(_ anchor: CGPoint, metrics: MarkupMetrics, style: PinStyle, in size: CGSize) -> CGPoint {
+        let side = metrics.badgeHalfSide  // half-width incl. ring
         let x = clamp(anchor.x, side, size.width - side)
         switch style {
         case .disc, .outline:
             return CGPoint(x: x, y: clamp(anchor.y, side, size.height - side))
         case .pointer:
-            // The head reaches anchor.y + 3·radius upward; the tip is the low point.
-            return CGPoint(x: x, y: clamp(anchor.y, 0, size.height - radius * 3))
+            // The head reaches anchor.y + pointerHeight upward; the tip is the low point.
+            return CGPoint(x: x, y: clamp(anchor.y, 0, size.height - metrics.pointerHeight))
         }
     }
 
@@ -107,9 +111,10 @@ enum Exporter {
     /// Draws a numbered marker at `anchor` (image space) in the chosen style.
     /// `anchor` is the marker centre for disc/outline and the tip for pointer —
     /// matching the on-screen `PinMarker` so the export looks identical.
-    private static func drawMarker(number: Int, anchor: CGPoint, radius: CGFloat, style: PinStyle) {
+    private static func drawMarker(number: Int, anchor: CGPoint, metrics: MarkupMetrics, style: PinStyle) {
         let vermillon = NSColor.pinpointVermillon
-        let ringWidth = max(2, radius * 0.16)
+        let radius = metrics.pinRadius
+        let ringWidth = metrics.ringWidth
 
         switch style {
         case .disc:
@@ -120,7 +125,7 @@ enum Exporter {
             NSColor.white.setStroke()
             circle.lineWidth = ringWidth
             circle.stroke()
-            drawNumber(number, center: anchor, radius: radius, color: .white)
+            drawNumber(number, center: anchor, fontSize: metrics.numberFontSize, color: .white)
 
         case .outline:
             let rect = NSRect(x: anchor.x - radius, y: anchor.y - radius, width: radius * 2, height: radius * 2)
@@ -132,11 +137,11 @@ enum Exporter {
             vermillon.setStroke()
             ring.lineWidth = ringWidth
             ring.stroke()
-            drawNumber(number, center: anchor, radius: radius, color: vermillon)
+            drawNumber(number, center: anchor, fontSize: metrics.numberFontSize, color: vermillon)
 
         case .pointer:
             // Tip at the anchor; head above it (image space y grows upward).
-            let headCenter = CGPoint(x: anchor.x, y: anchor.y + radius * 2.0)
+            let headCenter = CGPoint(x: anchor.x, y: anchor.y + metrics.pointerHeadOffset)
             let baseY = headCenter.y - radius * 0.55
             let halfWidth = radius * 0.7
 
@@ -155,13 +160,13 @@ enum Exporter {
             NSColor.white.setStroke()
             head.lineWidth = ringWidth
             head.stroke()
-            drawNumber(number, center: headCenter, radius: radius, color: .white)
+            drawNumber(number, center: headCenter, fontSize: metrics.numberFontSize, color: .white)
         }
     }
 
-    private static func drawNumber(_ number: Int, center: CGPoint, radius: CGFloat, color: NSColor) {
+    private static func drawNumber(_ number: Int, center: CGPoint, fontSize: CGFloat, color: NSColor) {
         let label = "\(number)" as NSString
-        let font = NSFont.systemFont(ofSize: radius * 1.05, weight: .bold)
+        let font = NSFont.systemFont(ofSize: fontSize, weight: .bold)
         let attrs: [NSAttributedString.Key: Any] = [
             .font: font,
             .foregroundColor: color

--- a/Pinpoint/MarkupMetrics.swift
+++ b/Pinpoint/MarkupMetrics.swift
@@ -1,0 +1,86 @@
+import CoreGraphics
+
+/// Every drawn dimension of an annotation — stroke widths, badge radius,
+/// arrowhead length — derived from the capture's width, so the editor preview
+/// and the exported image show the same annotation at the same relative size.
+///
+/// The formulas are written in *image space*: the pixel grid `Exporter` draws
+/// into, where the same marker is genuinely larger on a 3840 px capture than on
+/// a 400 px one. `scale` then maps them into whatever space the caller draws in.
+/// The exporter renders the capture at 1:1 and leaves `scale` at 1; the editor
+/// renders it into the fitted rect and passes `fitted.width / image.size.width`,
+/// so its annotations shrink and grow by exactly the amount the preview itself
+/// does.
+///
+/// Before this type the editor drew at fixed point sizes (a 28 pt badge, a
+/// 3.5 pt stroke) while the exporter scaled with the image, so the export of a
+/// small capture came out far heavier than its preview (#48). Keeping both
+/// sides on one set of formulas is what makes the preview WYSIWYG — and what
+/// keeps the two `clampedMarkerAnchor` implementations agreeing on where a
+/// badge near an edge lands (#34/#35).
+///
+/// Note the floors (`max(3, …)`, `max(16, …)`): they are expressed in image
+/// pixels, so a Retina capture — whose `size` is its pixel count, twice the
+/// points it covered on screen — clears them where the 1x capture of the same
+/// region would be held at the floor. That is the exporter's long-standing
+/// behaviour; the preview now reproduces it instead of hiding it.
+struct MarkupMetrics {
+    /// The capture's width in image space (pixels). Never below 1, so the
+    /// derived sizes stay finite for a degenerate image.
+    let imageWidth: CGFloat
+    /// Image space → drawing space. 1 when drawing the capture at full size.
+    let scale: CGFloat
+
+    init(imageWidth: CGFloat, scale: CGFloat = 1) {
+        self.imageWidth = max(1, imageWidth)
+        self.scale = scale.isFinite && scale > 0 ? scale : 1
+    }
+
+    /// Metrics for a preview of `imageSize` drawn into `fitted` — the editor
+    /// canvas. Falls back to 1:1 for a degenerate size, since a canvas that
+    /// hasn't been laid out yet reports a zero-width rect.
+    init(imageSize: CGSize, fitted: CGRect) {
+        self.init(imageWidth: imageSize.width,
+                  scale: imageSize.width > 0 ? fitted.width / imageSize.width : 1)
+    }
+
+    // MARK: - Shapes
+
+    /// Stroke width of arrows and rectangles.
+    var lineWidth: CGFloat { max(3, imageWidth * 0.004) * scale }
+
+    /// Corner radius of a rectangle markup. Tied to the stroke width, which is
+    /// what the exporter has always rounded its rectangles by.
+    var cornerRadius: CGFloat { lineWidth }
+
+    /// Length of the two strokes forming an arrow's head.
+    var arrowHeadLength: CGFloat { max(14, imageWidth * 0.018) * scale }
+
+    /// Half-angle between an arrow's shaft and each of its head strokes.
+    static let arrowHeadSpread = CGFloat.pi / 6.5
+
+    // MARK: - Markers
+
+    /// The badge radius in image space, before `scale`. The ring's own floor is
+    /// expressed against this, so it has to stay unscaled.
+    private var imagePinRadius: CGFloat { max(16, imageWidth * 0.014) }
+
+    /// Radius of a marker's badge — of its head, in the pointer style.
+    var pinRadius: CGFloat { imagePinRadius * scale }
+
+    /// Width of the ring drawn around a badge.
+    var ringWidth: CGFloat { max(2, imagePinRadius * 0.16) * scale }
+
+    /// Point size of the number inside a badge.
+    var numberFontSize: CGFloat { pinRadius * 1.05 }
+
+    /// How far a marker's badge extends from its anchor on either side, ring
+    /// included: the margin `clampedMarkerAnchor` keeps it inside the image by.
+    var badgeHalfSide: CGFloat { pinRadius + ringWidth }
+
+    /// Distance from a pointer's tip to the centre of its head.
+    var pointerHeadOffset: CGFloat { pinRadius * 2 }
+
+    /// Total height of a pointer marker, from its tip to the top of its head.
+    var pointerHeight: CGFloat { pinRadius * 3 }
+}


### PR DESCRIPTION
## Problème

À l'écran, la pastille de repère faisait 28 pt et les traits une épaisseur fixe,
alors qu'à l'export tout est relatif à la largeur de l'image
(`max(3, w * 0.004)`, `max(16, w * 0.014)`, `max(14, w * 0.018)`). Sur une petite
capture, l'export sortait proportionnellement bien plus lourd que l'aperçu qui
l'avait produit — l'éditeur n'était pas WYSIWYG.

## Correctif

Nouveau `Pinpoint/MarkupMetrics.swift` : une source de vérité unique pour chaque
dimension dessinée (épaisseur de trait, rayon de pastille, anneau, pointe de
flèche, corps du numéro, hauteur du pointeur). Les formules y sont écrites en
**espace image** — la grille de pixels dans laquelle `Exporter` dessine — puis
ramenées dans l'espace du dessinateur par un facteur `scale` :

- `Exporter` dessine la capture à 1:1 et garde `scale = 1` (comportement
  strictement inchangé) ;
- `EditorView` dessine dans le rectangle ajusté et passe
  `fitted.width / image.size.width`.

`PinMarker`, `ArrowShape`, `markupView`, `shapeGrabBand` et les **deux**
`clampedMarkerAnchor` (écran et export) lisent désormais ces mêmes métriques.
Ce dernier point resserre au passage l'accord près des bords traité par #34/#35 :
la marge écran était figée à 16 pt face à une marge d'export proportionnelle, les
deux sont maintenant identiques une fois normalisées.

Les repères suivant l'échelle de l'aperçu, deux planchers d'interaction (et eux
seuls) restent fixes pour ne pas dégrader l'ergonomie :

- `pinGrabSize` — au moins 24 pt de zone de préhension sous la pastille, même
  quand elle est dessinée plus petite ;
- `grabBandWidth(_:)` — la bande de sélection d'une forme n'est jamais plus fine
  que le trait qu'elle recouvre.

Les poignées de redimensionnement (`SelectionHandle`, #72) sont inchangées :
elles se placent sur `absoluteRect(shape.rect, in: fitted)`, indépendant des
métriques, et gardent leurs tailles de hit-test.

## Vérification

Build CI local vert (`xcodegen generate` + `xcodebuild -scheme Pinpoint`).

Au-delà du build, un harnais hors-arbre rend le canvas de l'éditeur avec le vrai
`PinMarker`/`ArrowShape` et le compare à `Exporter.annotatedImage` pour les trois
styles de repère × trois tailles de capture (400×300, 1600×1200, 3840×2160), en
incluant un repère dans un coin pour exercer le clamp. Part des pixels annotés
qui ne coïncident pas entre aperçu et export :

| Capture | Avant | Après |
| --- | --- | --- |
| 400×300 | 63–70 % | 6–12 % |
| 1600×1200 (2x) | 22–31 % | 13–16 % |
| 3840×2160 | 15–24 % | 6–8 % |

Le résidu est de l'anti-aliasing, du rééchantillonnage et l'ombre portée que
l'éditeur dessine et que l'export n'a pas. À l'œil, l'aperçu et l'export se
superposent désormais dans les trois styles.

Note sur le Retina : `image.size` vaut les pixels natifs partout dans ce flux
(`ScreenCapture` et `AppDelegate.loadImage` construisent l'image ainsi), des deux
côtés de la comparaison — la correspondance aperçu/export est donc exacte à 1x
comme à 2x. Les planchers `max(16, …)` de l'export restent exprimés en pixels
d'image : une capture 1x les atteint là où son équivalent 2x ne les atteint pas.
C'est le comportement historique de l'export, que l'aperçu reflète désormais au
lieu de le masquer.

Closes #48