### PR TITLE
Accessibilité : VoiceOver, Dynamic Type et reduce-motion dans l'éditeur et l'étagère

### DIFF
--- a/Pinpoint/EditorView.swift
+++ b/Pinpoint/EditorView.swift
@@ -50,6 +50,56 @@ private enum ArrowEnd: CaseIterable {
     func point(of shape: Markup) -> CGPoint {
         self == .tail ? shape.start : shape.end
     }
+
+    /// VoiceOver name of the handle that drags this end.
+    var accessibilityLabel: String {
+        switch self {
+        case .tail: return String(localized: "a11y.handle.arrow.tail", defaultValue: "Arrow tail handle")
+        case .tip: return String(localized: "a11y.handle.arrow.tip", defaultValue: "Arrow tip handle")
+        }
+    }
+}
+
+/// The eight box-handle positions, named for VoiceOver.
+///
+/// `SelectionHandle` (the shape handles) and `CropOverlay.Handle` are two
+/// separate enums covering the same eight spots; both map onto this one so the
+/// wording is written once and the two surfaces can't drift apart.
+private enum HandleSpot {
+    case topLeft, top, topRight, right, bottomRight, bottom, bottomLeft, left
+
+    var name: String {
+        switch self {
+        case .topLeft: return String(localized: "a11y.handle.topLeft", defaultValue: "top-left corner")
+        case .top: return String(localized: "a11y.handle.top", defaultValue: "top edge")
+        case .topRight: return String(localized: "a11y.handle.topRight", defaultValue: "top-right corner")
+        case .right: return String(localized: "a11y.handle.right", defaultValue: "right edge")
+        case .bottomRight: return String(localized: "a11y.handle.bottomRight", defaultValue: "bottom-right corner")
+        case .bottom: return String(localized: "a11y.handle.bottom", defaultValue: "bottom edge")
+        case .bottomLeft: return String(localized: "a11y.handle.bottomLeft", defaultValue: "bottom-left corner")
+        case .left: return String(localized: "a11y.handle.left", defaultValue: "left edge")
+        }
+    }
+
+    /// "Resize handle, top-left corner".
+    var resizeLabel: String {
+        String(localized: "a11y.handle.resize", defaultValue: "Resize handle, \(name)")
+    }
+}
+
+private extension SelectionHandle {
+    var spot: HandleSpot {
+        switch self {
+        case .topLeft: return .topLeft
+        case .top: return .top
+        case .topRight: return .topRight
+        case .right: return .right
+        case .bottomRight: return .bottomRight
+        case .bottom: return .bottom
+        case .bottomLeft: return .bottomLeft
+        case .left: return .left
+        }
+    }
 }
 
 struct EditorView: View {
@@ -82,6 +132,13 @@ struct EditorView: View {
     /// Which text field is being edited, if any. Only used to step aside: the
     /// Delete key equivalent is disabled while typing so ⌫ keeps editing text.
     @FocusState private var focusedField: EditorField?
+
+    /// System-wide "Reduce motion". Every animated state change in the editor
+    /// goes through `withMotion`, which drops the animation when this is on.
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// Side of the numbered badge in the side panel. Scaled with the caption
+    /// text it wraps, so a larger Dynamic Type size doesn't clip the number.
+    @ScaledMetric(relativeTo: .caption) private var pinBadgeSide: CGFloat = 22
 
     // Crop mode state. `cropRect` is normalized (0...1, top-left origin), same
     // convention as pins/markups.
@@ -186,6 +243,9 @@ struct EditorView: View {
                 .labelsHidden()
                 .fixedSize()
                 .help(toolPickerHelp)
+                // No `accessibilityLabel` here: `labelsHidden()` only takes the
+                // picker's title off screen, VoiceOver still reads it, and a
+                // second label is appended to it rather than replacing it.
                 .background(hiddenShortcuts)
 
                 Button {
@@ -323,13 +383,20 @@ struct EditorView: View {
                     .frame(width: fitted.width, height: fitted.height)
                     .position(x: fitted.midX, y: fitted.midY)
                     .shadow(radius: 8, y: 2)
+                    .accessibilityLabel(String(localized: "a11y.canvas.image", defaultValue: "Screenshot being annotated"))
 
                 // Committed markups. Drawing and interaction are two layers:
                 // every shape draws first and takes no clicks, then the
                 // manipulable ones take them on top, so a handle is never
                 // buried under the outline of a shape drawn after it.
                 ForEach(shapes) { shape in
+                    // The drawing layer is what VoiceOver reads: it carries
+                    // every shape, where the grab bands below only exist for
+                    // the ones the active tool can manipulate.
                     markupView(shape, in: fitted, selected: shape.id == selectedShapeID)
+                        .accessibilityElement()
+                        .accessibilityLabel(accessibilityLabel(for: shape))
+                        .accessibilityAddTraits(shape.id == selectedShapeID ? .isSelected : [])
                 }
                 .allowsHitTesting(false)
 
@@ -338,7 +405,11 @@ struct EditorView: View {
                 // of the layer entirely rather than hit-test-disabled inside it,
                 // so switching tools mid-hover takes their cursor with them.
                 ForEach(shapes.filter(isManipulable)) { shape in
+                    // Pure hit-test surface: the drawing layer above already
+                    // announces the shape, and two elements for one annotation
+                    // would only make VoiceOver say it twice.
                     shapeGrabBand(shape, in: fitted)
+                        .accessibilityHidden(true)
                 }
                 if let shape = selectedShape, isManipulable(shape) {
                     shapeHandles(shape, in: fitted)
@@ -358,6 +429,11 @@ struct EditorView: View {
                         .position(x: anchor.x, y: anchor.y + PinMarker.anchorYOffset(pinStyle))
                         .gesture(pinDrag($pin, in: fitted))
                         .allowsHitTesting(tool == .pin && !isCropping)
+                        .accessibilityElement()
+                        .accessibilityLabel(accessibilityLabel(for: pin))
+                        .accessibilityValue(accessibilityPosition(of: pin))
+                        .accessibilityHint(String(localized: "a11y.marker.hint", defaultValue: "Drag to move this marker"))
+                        .accessibilityAddTraits(pin.id == selectedPinID ? .isSelected : [])
                 }
 
                 // Crop overlay sits on top and owns interaction while active.
@@ -368,6 +444,38 @@ struct EditorView: View {
             }
             .contentShape(Rectangle())
             .gesture(canvasGesture(in: fitted))
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel(String(localized: "a11y.canvas", defaultValue: "Annotation canvas"))
+        }
+    }
+
+    // MARK: - Accessibility wording
+
+    /// What VoiceOver reads for a marker: its number and the note, or a plain
+    /// statement that it has none yet — "Marker 3" alone would leave the
+    /// listener wondering whether the description failed to load.
+    private func accessibilityLabel(for pin: Pin) -> String {
+        let note = pin.note.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard note.isEmpty == false else {
+            return String(localized: "a11y.marker.untitled", defaultValue: "Marker \(pin.number), no description")
+        }
+        return String(localized: "a11y.marker", defaultValue: "Marker \(pin.number): \(note)")
+    }
+
+    /// Where the marker sits, as whole percentages of the image. Spelled out in
+    /// words rather than with a percent sign, which VoiceOver reads unevenly
+    /// depending on the voice.
+    private func accessibilityPosition(of pin: Pin) -> String {
+        let x = Int((pin.position.x * 100).rounded())
+        let y = Int((pin.position.y * 100).rounded())
+        return String(localized: "a11y.marker.position",
+                      defaultValue: "\(x) percent from the left, \(y) percent from the top")
+    }
+
+    private func accessibilityLabel(for shape: Markup) -> String {
+        switch shape.kind {
+        case .arrow: return String(localized: "a11y.shape.arrow", defaultValue: "Arrow annotation")
+        case .rectangle: return String(localized: "a11y.shape.rectangle", defaultValue: "Rectangle annotation")
         }
     }
 
@@ -530,13 +638,17 @@ struct EditorView: View {
         switch shape.kind {
         case .arrow:
             ForEach(ArrowEnd.allCases, id: \.self) { end in
-                handleDot(at: absolutePoint(end.point(of: shape), in: fitted), cursor: .crosshair)
+                handleDot(at: absolutePoint(end.point(of: shape), in: fitted),
+                          cursor: .crosshair,
+                          label: end.accessibilityLabel)
                     .gesture(arrowEndDrag(shape, end: end, in: fitted))
             }
         case .rectangle:
             let r = absoluteRect(shape.rect, in: fitted)
             ForEach(SelectionHandle.allCases, id: \.self) { handle in
-                handleDot(at: handle.point(in: r, orientation: .yDown), cursor: handle.cursor)
+                handleDot(at: handle.point(in: r, orientation: .yDown),
+                          cursor: handle.cursor,
+                          label: handle.spot.resizeLabel)
                     .gesture(rectangleResizeDrag(shape, handle: handle, in: fitted))
             }
         }
@@ -544,7 +656,7 @@ struct EditorView: View {
 
     /// One handle dot, styled like the crop overlay's so the two read as the
     /// same control. The outer frame is the grab area, the inner one the dot.
-    private func handleDot(at point: CGPoint, cursor: NSCursor) -> some View {
+    private func handleDot(at point: CGPoint, cursor: NSCursor, label: String) -> some View {
         ZStack {
             Circle().fill(Color.white)
             Circle().stroke(Color.pinpointVermillon, lineWidth: 2)
@@ -554,6 +666,8 @@ struct EditorView: View {
         .contentShape(Rectangle())
         .position(point)
         .hoverCursor(cursor)
+        .accessibilityElement()
+        .accessibilityLabel(label)
     }
 
     // MARK: Shape gestures
@@ -681,9 +795,11 @@ struct EditorView: View {
 
             Text("Instructions for the agent")
                 .font(.headline)
+                .accessibilityAddTraits(.isHeader)
             TextEditor(text: $context)
                 .focused($focusedField, equals: .context)
                 .font(.body)
+                .accessibilityLabel(String(localized: "Instructions for the agent"))
                 .frame(minHeight: 70, maxHeight: 120)
                 .overlay(RoundedRectangle(cornerRadius: 6).stroke(.quaternary))
 
@@ -711,6 +827,7 @@ struct EditorView: View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Markers")
                 .font(.headline)
+                .accessibilityAddTraits(.isHeader)
 
             if pins.isEmpty {
                 Text("Click the image to drop a numbered marker.")
@@ -728,6 +845,7 @@ struct EditorView: View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Annotations")
                 .font(.headline)
+                .accessibilityAddTraits(.isHeader)
 
             ForEach(shapes) { shape in
                 shapeRow(shape)
@@ -736,16 +854,27 @@ struct EditorView: View {
     }
 
     private func pinRow(_ pin: Binding<Pin>) -> some View {
-        HStack(alignment: .top, spacing: 8) {
-            Text("\(pin.wrappedValue.number)")
+        let number = pin.wrappedValue.number
+        let isSelected = pin.wrappedValue.id == selectedPinID
+        let deleteLabel = String(localized: "a11y.marker.delete", defaultValue: "Delete marker \(number)")
+
+        return HStack(alignment: .top, spacing: 8) {
+            Text("\(number)")
                 .font(.caption.bold())
                 .foregroundStyle(.white)
-                .frame(width: 22, height: 22)
+                .frame(width: pinBadgeSide, height: pinBadgeSide)
                 .background(Circle().fill(Color.pinpointVermillon))
+                // The number is repeated in the field's label right after it,
+                // so VoiceOver reads it once instead of twice.
+                .accessibilityHidden(true)
 
             TextField("Describe this marker…", text: pin.note)
                 .textFieldStyle(.roundedBorder)
                 .focused($focusedField, equals: .note(pin.wrappedValue.id))
+                // Without this the placeholder is the label, and every field in
+                // the list announces itself identically.
+                .accessibilityLabel(String(localized: "a11y.marker.note",
+                                           defaultValue: "Description of marker \(number)"))
 
             Button {
                 removePin(pin.wrappedValue)
@@ -754,20 +883,43 @@ struct EditorView: View {
             }
             .buttonStyle(.borderless)
             .foregroundStyle(.secondary)
+            .accessibilityLabel(deleteLabel)
+            .help(deleteLabel)
         }
         .padding(6)
-        .background(
-            RoundedRectangle(cornerRadius: 8)
-                .fill(pin.wrappedValue.id == selectedPinID ? Color.pinpointVermillon.opacity(0.12) : Color.clear)
-        )
+        .background(rowSelectionBackground(isSelected))
         .onTapGesture { selectPin(pin.wrappedValue.id) }
+        .accessibilityElement(children: .contain)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        // `onTapGesture` is a mouse affordance and nothing else; the same
+        // selection has to be reachable from VoiceOver's actions menu.
+        .accessibilityAction { selectPin(pin.wrappedValue.id) }
+    }
+
+    /// Highlight for the selected row of the side panel.
+    ///
+    /// A 12 % tint on its own barely separated from the panel background, and
+    /// carried the whole "this one is selected" message in hue alone. The fill
+    /// is stronger now and an outline says the same thing as a shape, so the
+    /// row still reads as selected without relying on colour perception.
+    private func rowSelectionBackground(_ isSelected: Bool) -> some View {
+        RoundedRectangle(cornerRadius: 8)
+            .fill(isSelected ? Color.pinpointVermillon.opacity(0.20) : Color.clear)
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(Color.pinpointVermillon.opacity(isSelected ? 0.75 : 0), lineWidth: 1.5)
+            )
     }
 
     private func shapeRow(_ shape: Markup) -> some View {
-        HStack(spacing: 8) {
+        let isSelected = shape.id == selectedShapeID
+        let deleteLabel = String(localized: "a11y.shape.delete", defaultValue: "Delete this annotation")
+
+        return HStack(spacing: 8) {
             Image(systemName: shape.symbol)
                 .foregroundStyle(Color.pinpointVermillon)
-                .frame(width: 22, height: 22)
+                .frame(width: pinBadgeSide, height: pinBadgeSide)
+                .accessibilityHidden(true)
 
             Text(shape.label)
 
@@ -780,13 +932,15 @@ struct EditorView: View {
             }
             .buttonStyle(.borderless)
             .foregroundStyle(.secondary)
+            .accessibilityLabel(deleteLabel)
+            .help(deleteLabel)
         }
         .padding(6)
-        .background(
-            RoundedRectangle(cornerRadius: 8)
-                .fill(shape.id == selectedShapeID ? Color.pinpointVermillon.opacity(0.12) : Color.clear)
-        )
+        .background(rowSelectionBackground(isSelected))
         .onTapGesture { selectShape(shape.id) }
+        .accessibilityElement(children: .contain)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityAction { selectShape(shape.id) }
     }
 
     // MARK: - Actions
@@ -878,9 +1032,9 @@ struct EditorView: View {
             return
         }
         onPersist(pins, shapes, context, image)
-        withAnimation { didCopy = true }
+        withMotion { didCopy = true }
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) {
-            withAnimation { didCopy = false }
+            withMotion { didCopy = false }
         }
     }
 
@@ -908,6 +1062,14 @@ struct EditorView: View {
     }
 
     // MARK: - Undo / redo
+
+    /// Runs `body` animated, or plainly when the system asks for reduced
+    /// motion. Every animated state change in the editor goes through this, so
+    /// honouring the setting stays one decision instead of one per call site —
+    /// and the animations themselves are left intact for everyone else.
+    private func withMotion<Result>(_ animation: Animation = .default, _ body: () -> Result) -> Result {
+        reduceMotion ? body() : withAnimation(animation, body)
+    }
 
     private func snapshot() -> EditorSnapshot {
         EditorSnapshot(
@@ -998,11 +1160,11 @@ struct EditorView: View {
         cropRect = CGRect(x: 0, y: 0, width: 1, height: 1)
         selectedPinID = nil
         selectedShapeID = nil
-        withAnimation(.easeInOut(duration: 0.15)) { isCropping = true }
+        withMotion(.easeInOut(duration: 0.15)) { isCropping = true }
     }
 
     private func cancelCrop() {
-        withAnimation(.easeInOut(duration: 0.15)) { isCropping = false }
+        withMotion(.easeInOut(duration: 0.15)) { isCropping = false }
     }
 
     /// Undoable wrapper around `performCrop()`. `isCropping` isn't part of a
@@ -1020,12 +1182,12 @@ struct EditorView: View {
         // hit Done on the default rect without an identity crop round-trip.
         if abs(c.minX) < 0.001 && abs(c.minY) < 0.001
             && abs(c.width - 1) < 0.001 && abs(c.height - 1) < 0.001 {
-            withAnimation(.easeInOut(duration: 0.15)) { isCropping = false }
+            withMotion(.easeInOut(duration: 0.15)) { isCropping = false }
             return
         }
         guard c.width > 0, c.height > 0,
               let base = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
-            withAnimation(.easeInOut(duration: 0.15)) { isCropping = false }
+            withMotion(.easeInOut(duration: 0.15)) { isCropping = false }
             return
         }
 
@@ -1040,7 +1202,7 @@ struct EditorView: View {
         ).intersection(CGRect(x: 0, y: 0, width: W, height: H))
         guard px.width > 1, px.height > 1,
               let cropped = base.cropping(to: px) else {
-            withAnimation(.easeInOut(duration: 0.15)) { isCropping = false }
+            withMotion(.easeInOut(duration: 0.15)) { isCropping = false }
             return
         }
 
@@ -1083,7 +1245,7 @@ struct EditorView: View {
         shapes = newShapes
         selectedPinID = nil
         selectedShapeID = nil
-        withAnimation(.easeInOut(duration: 0.15)) { isCropping = false }
+        withMotion(.easeInOut(duration: 0.15)) { isCropping = false }
     }
 
     // MARK: - Geometry
@@ -1182,6 +1344,7 @@ struct CropOverlay: View {
                     .fill(style: FillStyle(eoFill: true))
                 )
                 .allowsHitTesting(false)
+                .accessibilityHidden(true)
 
             // Border + thirds grid inside the crop rect.
             ZStack {
@@ -1191,6 +1354,7 @@ struct CropOverlay: View {
             .frame(width: r.width, height: r.height)
             .position(x: r.midX, y: r.midY)
             .allowsHitTesting(false)
+            .accessibilityHidden(true)
 
             // Interior drag → move the whole rect (clamped to the image). The
             // DragGesture translation is cumulative from drag start, so we keep
@@ -1210,12 +1374,16 @@ struct CropOverlay: View {
                         }
                         .onEnded { _ in lastMove = .zero }
                 )
+                .accessibilityLabel(String(localized: "a11y.crop.move",
+                                           defaultValue: "Drag to move the crop area"))
 
             // 8 handles.
             ForEach(Handle.allCases) { h in
                 handleView(h, in: r)
             }
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(String(localized: "a11y.crop.overlay", defaultValue: "Crop area"))
     }
 
     /// Two thirds lines each way, thin and semi-transparent.
@@ -1244,6 +1412,7 @@ struct CropOverlay: View {
         }
         .frame(width: handleSize, height: handleSize)
         .position(p)
+        .accessibilityLabel(h.spot.resizeLabel)
         .gesture(
             DragGesture(minimumDistance: 0)
                 .onChanged { v in
@@ -1321,6 +1490,21 @@ struct CropOverlay: View {
     private enum Handle: String, CaseIterable, Identifiable {
         case topLeft, top, topRight, right, bottomRight, bottom, bottomLeft, left
         var id: String { rawValue }
+
+        /// The shared VoiceOver naming, so a crop handle and a rectangle handle
+        /// in the same corner are announced the same way.
+        var spot: HandleSpot {
+            switch self {
+            case .topLeft: return .topLeft
+            case .top: return .top
+            case .topRight: return .topRight
+            case .right: return .right
+            case .bottomRight: return .bottomRight
+            case .bottom: return .bottom
+            case .bottomLeft: return .bottomLeft
+            case .left: return .left
+            }
+        }
 
         func point(in r: CGRect) -> CGPoint {
             switch self {

--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -58,6 +58,222 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "10 secondes" } }
       }
     },
+    "a11y.canvas" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Annotation canvas" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Zone d’annotation" } }
+      }
+    },
+    "a11y.canvas.image" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Screenshot being annotated" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Capture en cours d’annotation" } }
+      }
+    },
+    "a11y.card.notSelected" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Not selected" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Non sélectionnée" } }
+      }
+    },
+    "a11y.card.selected" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Selected" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Sélectionnée" } }
+      }
+    },
+    "a11y.card.thumbnail" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Preview of %@" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Aperçu de %@" } }
+      }
+    },
+    "a11y.crop.move" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Drag to move the crop area" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Faites glisser pour déplacer la zone de recadrage" } }
+      }
+    },
+    "a11y.crop.overlay" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Crop area" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Zone de recadrage" } }
+      }
+    },
+    "a11y.handle.arrow.tail" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Arrow tail handle" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Poignée de départ de la flèche" } }
+      }
+    },
+    "a11y.handle.arrow.tip" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Arrow tip handle" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Poignée de pointe de la flèche" } }
+      }
+    },
+    "a11y.handle.bottom" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "bottom edge" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "bord bas" } }
+      }
+    },
+    "a11y.handle.bottomLeft" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "bottom-left corner" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "coin bas-gauche" } }
+      }
+    },
+    "a11y.handle.bottomRight" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "bottom-right corner" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "coin bas-droit" } }
+      }
+    },
+    "a11y.handle.left" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "left edge" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "bord gauche" } }
+      }
+    },
+    "a11y.handle.resize" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Resize handle, %@" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Poignée de redimensionnement, %@" } }
+      }
+    },
+    "a11y.handle.right" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "right edge" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "bord droit" } }
+      }
+    },
+    "a11y.handle.top" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "top edge" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "bord haut" } }
+      }
+    },
+    "a11y.handle.topLeft" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "top-left corner" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "coin haut-gauche" } }
+      }
+    },
+    "a11y.handle.topRight" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "top-right corner" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "coin haut-droit" } }
+      }
+    },
+    "a11y.marker" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Marker %1$lld: %2$@" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Repère %1$lld : %2$@" } }
+      }
+    },
+    "a11y.marker.delete" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Delete marker %lld" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Supprimer le repère %lld" } }
+      }
+    },
+    "a11y.marker.hint" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Drag to move this marker" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Faites glisser pour déplacer ce repère" } }
+      }
+    },
+    "a11y.marker.note" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Description of marker %lld" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Description du repère %lld" } }
+      }
+    },
+    "a11y.marker.position" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "%1$lld percent from the left, %2$lld percent from the top" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "%1$lld pour cent depuis la gauche, %2$lld pour cent depuis le haut" } }
+      }
+    },
+    "a11y.marker.untitled" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Marker %lld, no description" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Repère %lld, sans description" } }
+      }
+    },
+    "a11y.region.empty" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "No region selected yet" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Aucune région sélectionnée" } }
+      }
+    },
+    "a11y.region.selection" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Region selection" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Sélection de région" } }
+      }
+    },
+    "a11y.region.size" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "%1$lld by %2$lld" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "%1$lld sur %2$lld" } }
+      }
+    },
+    "a11y.section" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "%1$@, %2$lld screenshots" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "%1$@, %2$lld captures" } }
+      }
+    },
+    "a11y.shape.arrow" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Arrow annotation" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Annotation flèche" } }
+      }
+    },
+    "a11y.shape.delete" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Delete this annotation" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Supprimer cette annotation" } }
+      }
+    },
+    "a11y.shape.rectangle" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Rectangle annotation" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Annotation rectangle" } }
+      }
+    },
+    "a11y.shelf.dateFilter" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Date filter" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Filtre par date" } }
+      }
+    },
+    "a11y.shelf.refresh" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Refresh the shelf" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Actualiser l’étagère" } }
+      }
+    },
+    "a11y.shelf.results" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "%lld screenshots shown" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "%lld captures affichées" } }
+      }
+    },
+    "a11y.shelf.settings" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Open settings" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Ouvrir les réglages" } }
+      }
+    },
+    "a11y.shelf.sortOrder" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Sort order" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Ordre de tri" } }
+      }
+    },
     "Add to favorites" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Ajouter aux favoris" } }

--- a/Pinpoint/RegionSelectionView.swift
+++ b/Pinpoint/RegionSelectionView.swift
@@ -160,6 +160,7 @@ final class RegionSelectionView: NSView {
         gesture = .none
         pressPoint = nil
         lastDragPoint = nil
+        defer { announceSelection() }
 
         switch finished {
         case .drawing:
@@ -210,6 +211,7 @@ final class RegionSelectionView: NSView {
         guard isAdjusting, case .none = gesture, let selection else { return }
         self.selection = SelectionHandle.moved(selection, dx: dx, dy: dy, in: bounds)
         needsDisplay = true
+        announceSelection()
     }
 
     /// Hands the settled selection over in global coordinates. Silent when
@@ -221,6 +223,43 @@ final class RegionSelectionView: NSView {
         let anchor = globalAnchor
             ?? window.convertPoint(toScreen: CGPoint(x: selection.midX, y: selection.midY))
         onComplete?(globalRect, anchor)
+    }
+
+    // MARK: - Accessibility
+
+    /// The overlay is one element as far as VoiceOver is concerned: it has no
+    /// subviews, everything it shows is drawn by hand, and the one thing worth
+    /// announcing is how big the rectangle currently is.
+    override func isAccessibilityElement() -> Bool { true }
+
+    override func accessibilityRole() -> NSAccessibility.Role? { .group }
+
+    override func accessibilityLabel() -> String? {
+        String(localized: "a11y.region.selection", defaultValue: "Region selection")
+    }
+
+    override func accessibilityValue() -> Any? {
+        guard let selection else {
+            return String(localized: "a11y.region.empty", defaultValue: "No region selected yet")
+        }
+        return String(
+            localized: "a11y.region.size",
+            defaultValue: "\(Int(selection.width.rounded())) by \(Int(selection.height.rounded()))"
+        )
+    }
+
+    /// The same sentence the on-screen hint carries, so the keyboard steps are
+    /// reachable without reading the badge.
+    override func accessibilityHelp() -> String? {
+        isAdjusting
+            ? String(localized: "Drag or nudge with arrows · ↵ to capture · Esc to cancel")
+            : String(localized: "Drag a rectangle · Esc to cancel")
+    }
+
+    /// Announces the new size once a gesture settles. Deliberately not called
+    /// per drag event: VoiceOver would read a new figure every frame.
+    private func announceSelection() {
+        NSAccessibility.post(element: self, notification: .valueChanged)
     }
 
     // MARK: - Cursor
@@ -317,7 +356,7 @@ final class RegionSelectionView: NSView {
     private func drawDimensions(_ sel: CGRect) {
         let text = "\(Int(sel.width.rounded())) × \(Int(sel.height.rounded()))" as NSString
         let attrs: [NSAttributedString.Key: Any] = [
-            .font: NSFont.monospacedSystemFont(ofSize: 12, weight: .medium),
+            .font: NSFont.monospacedSystemFont(ofSize: 12, weight: .semibold),
             .foregroundColor: NSColor.white
         ]
         let textSize = text.size(withAttributes: attrs)
@@ -328,7 +367,9 @@ final class RegionSelectionView: NSView {
         if origin.y < bounds.minY + 4 { origin.y = sel.minY + 8 } // no room below → inside
         let rect = CGRect(origin: origin, size: badge)
 
-        NSColor.black.withAlphaComponent(0.75).setFill()
+        // Nearly opaque: the badge sits over whatever the user is framing, and
+        // white-on-translucent-black was only legible over dark content.
+        NSColor.black.withAlphaComponent(0.88).setFill()
         NSBezierPath(roundedRect: rect, xRadius: 6, yRadius: 6).fill()
         text.draw(at: CGPoint(x: rect.minX + padX, y: rect.minY + padY), withAttributes: attrs)
     }
@@ -337,7 +378,7 @@ final class RegionSelectionView: NSView {
         let text = string as NSString
         let attrs: [NSAttributedString.Key: Any] = [
             .font: NSFont.systemFont(ofSize: 13, weight: .medium),
-            .foregroundColor: NSColor.white.withAlphaComponent(0.9)
+            .foregroundColor: NSColor.white
         ]
         let textSize = text.size(withAttributes: attrs)
         let padX: CGFloat = 14, padY: CGFloat = 8
@@ -348,7 +389,9 @@ final class RegionSelectionView: NSView {
             width: badge.width,
             height: badge.height
         )
-        NSColor.black.withAlphaComponent(0.55).setFill()
+        // Same reasoning as the dimensions badge: 55 % black under 90 % white
+        // left the hint hard to read over a light window.
+        NSColor.black.withAlphaComponent(0.82).setFill()
         NSBezierPath(roundedRect: rect, xRadius: 10, yRadius: 10).fill()
         text.draw(at: CGPoint(x: rect.minX + padX, y: rect.minY + padY), withAttributes: attrs)
     }

--- a/Pinpoint/Shelf/Views/Components/MultiFileDragButton.swift
+++ b/Pinpoint/Shelf/Views/Components/MultiFileDragButton.swift
@@ -49,10 +49,15 @@ final class MultiFileDragNSButton: NSButton, NSDraggingSource {
     func configure(with items: [ScreenshotItem], compact: Bool) {
         itemURLs = items.map(\.url)
         self.compact = compact
-        title = compact ? "" : (itemURLs.count == 1
+        let name = itemURLs.count == 1
             ? String(localized: "Drag file")
-            : String(localized: "drag.files", defaultValue: "Drag \(itemURLs.count) files"))
+            : String(localized: "drag.files", defaultValue: "Drag \(itemURLs.count) files")
+        title = compact ? "" : name
         toolTip = String(localized: "Drag the selected screenshots into another app")
+        // In compact mode the button has no title, which leaves VoiceOver with
+        // nothing but the symbol to go on.
+        setAccessibilityLabel(name)
+        setAccessibilityHelp(toolTip)
         isEnabled = itemURLs.isEmpty == false
         alphaValue = isEnabled ? 1 : 0.45
         invalidateIntrinsicContentSize()

--- a/Pinpoint/Shelf/Views/Components/ScreenshotCardView.swift
+++ b/Pinpoint/Shelf/Views/Components/ScreenshotCardView.swift
@@ -43,6 +43,8 @@ struct ScreenshotCardView: View {
                         .resizable()
                         .scaledToFill()
                         .frame(width: thumbnailWidth, height: 126)
+                        .accessibilityLabel(String(localized: "a11y.card.thumbnail",
+                                                   defaultValue: "Preview of \(title)"))
                 } else {
                     ProgressView()
                         .controlSize(.small)
@@ -56,13 +58,14 @@ struct ScreenshotCardView: View {
                     if !selectionMode {
                         Button(action: onEditInPinpoint) {
                             Image(systemName: "pin.circle.fill")
-                                .font(.system(size: 16, weight: .semibold))
+                                .font(.title3.weight(.semibold))
                                 .foregroundStyle(.white, .black.opacity(0.45))
                                 .padding(.vertical, 8)
                                 .padding(.leading, 8)
                         }
                         .buttonStyle(.plain)
                         .help("Edit in Pinpoint")
+                        .accessibilityLabel(Text("Edit in Pinpoint"))
                     }
 
                     Menu {
@@ -85,27 +88,31 @@ struct ScreenshotCardView: View {
                         Button("Delete", systemImage: "trash", role: .destructive, action: onDelete)
                     } label: {
                         Image(systemName: "ellipsis.circle.fill")
-                            .font(.system(size: 16, weight: .semibold))
+                            .font(.title3.weight(.semibold))
                             .foregroundStyle(.white, .black.opacity(0.45))
                             .padding(8)
                     }
                     .menuStyle(.borderlessButton)
+                    .accessibilityLabel(Text("More actions"))
                 }
             }
             .overlay(alignment: .topLeading) {
                 if selectionMode {
                     Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
-                        .font(.system(size: 18, weight: .semibold))
+                        .font(.title2.weight(.semibold))
                         .foregroundStyle(isSelected ? .white : .secondary, isSelected ? Color.accentColor : .clear)
                         .padding(8)
+                        .accessibilityLabel(selectionStateLabel)
                 } else {
                     Button(action: onToggleFavorite) {
                         Image(systemName: isFavorite ? "star.fill" : "star")
-                            .font(.system(size: 15, weight: .semibold))
+                            .font(.title3.weight(.semibold))
                             .foregroundStyle(isFavorite ? .yellow : .secondary, .thinMaterial)
                             .padding(8)
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel(favoriteLabel)
+                    .help(favoriteLabel)
                 }
             }
 
@@ -141,6 +148,19 @@ struct ScreenshotCardView: View {
         .draggable(item.url) {
             dragPreview
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(title)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        // Single and double click are mouse-only affordances; both need an
+        // equivalent in VoiceOver's actions menu.
+        .accessibilityAction {
+            onActivate()
+            if selectionMode { onSelect() }
+        }
+        .accessibilityAction(named: Text("Open details")) {
+            onActivate()
+            onOpenDetails()
+        }
         .task(id: item.url) {
             thumbnail = await ThumbnailService.shared.thumbnail(for: item.url)
         }
@@ -151,7 +171,7 @@ struct ScreenshotCardView: View {
         if isEditingTitle {
             TextField("Title", text: $draftTitle)
                 .textFieldStyle(.roundedBorder)
-                .font(.system(size: 13, weight: .semibold))
+                .font(.headline)
                 .focused($titleFieldFocused)
                 .onAppear { titleFieldFocused = true }
                 .onSubmit(commitTitleEdit)
@@ -161,7 +181,7 @@ struct ScreenshotCardView: View {
                 }
         } else {
             Text(title)
-                .font(.system(size: 13, weight: .semibold))
+                .font(.headline)
                 .lineLimit(1)
                 .truncationMode(.tail)
                 .contentShape(Rectangle())
@@ -183,6 +203,20 @@ struct ScreenshotCardView: View {
 
     private func cancelTitleEdit() {
         isEditingTitle = false
+    }
+
+    private var favoriteLabel: String {
+        isFavorite
+            ? String(localized: "Remove from favorites")
+            : String(localized: "Add to favorites")
+    }
+
+    /// The checkmark in selection mode is decoration only — the card carries the
+    /// tap target — so it has to say out loud what its shape shows.
+    private var selectionStateLabel: String {
+        isSelected
+            ? String(localized: "a11y.card.selected", defaultValue: "Selected")
+            : String(localized: "a11y.card.notSelected", defaultValue: "Not selected")
     }
 
     private var selectionBackground: some ShapeStyle {

--- a/Pinpoint/Shelf/Views/Components/SectionHeaderView.swift
+++ b/Pinpoint/Shelf/Views/Components/SectionHeaderView.swift
@@ -15,5 +15,10 @@ struct SectionHeaderView: View {
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.secondary)
         }
+        // Read as one header instead of "Today" then a bare number, and marked
+        // as a header so VoiceOver's rotor can jump between the date groups.
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(String(localized: "a11y.section", defaultValue: "\(title), \(count) screenshots"))
+        .accessibilityAddTraits(.isHeader)
     }
 }

--- a/Pinpoint/Shelf/Views/Screens/ScreenshotDetailView.swift
+++ b/Pinpoint/Shelf/Views/Screens/ScreenshotDetailView.swift
@@ -62,6 +62,7 @@ struct ScreenshotDetailView: View {
                 Text(store.displayTitle(for: item))
                     .font(.title3.weight(.semibold))
                     .lineLimit(1)
+                    .accessibilityAddTraits(.isHeader)
 
                 Text(headerSubtitle)
                     .font(.caption)
@@ -76,15 +77,23 @@ struct ScreenshotDetailView: View {
                     .foregroundStyle(isFavorite ? .yellow : .secondary)
             }
             .buttonStyle(.borderless)
-            .help(isFavorite ? String(localized: "Remove from favorites") : String(localized: "Add to favorites"))
+            .help(favoriteLabel)
+            .accessibilityLabel(favoriteLabel)
 
             Button(action: close) {
                 Image(systemName: "xmark")
             }
             .buttonStyle(.borderless)
             .help("Close")
+            .accessibilityLabel(Text("Close"))
         }
         .padding(16)
+    }
+
+    private var favoriteLabel: String {
+        isFavorite
+            ? String(localized: "Remove from favorites")
+            : String(localized: "Add to favorites")
     }
 
     /// The containing folder, prefixed with the file name whenever a custom
@@ -113,6 +122,8 @@ struct ScreenshotDetailView: View {
                     .resizable()
                     .scaledToFit()
                     .padding(20)
+                    .accessibilityLabel(String(localized: "a11y.card.thumbnail",
+                                               defaultValue: "Preview of \(store.displayTitle(for: item))"))
             } else {
                 ProgressView()
                     .controlSize(.regular)
@@ -127,6 +138,7 @@ struct ScreenshotDetailView: View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Details")
                 .font(.headline)
+                .accessibilityAddTraits(.isHeader)
 
             LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], alignment: .leading, spacing: 12) {
                 detailValue(title: String(localized: "Captured"), value: item.createdAt.formatted(date: .abbreviated, time: .shortened))
@@ -141,6 +153,7 @@ struct ScreenshotDetailView: View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Actions")
                 .font(.headline)
+                .accessibilityAddTraits(.isHeader)
 
             Button("Edit in Pinpoint", systemImage: "pin.fill") {
                 close()
@@ -183,6 +196,8 @@ struct ScreenshotDetailView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(14)
         .background(.quaternary.opacity(0.18), in: RoundedRectangle(cornerRadius: 16))
+        // Caption then value are one fact, not two stops on the way through.
+        .accessibilityElement(children: .combine)
     }
 
     private func loadContent() async {
@@ -249,6 +264,7 @@ private struct RenameDetailView: View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Rename screenshot")
                 .font(.title3.weight(.semibold))
+                .accessibilityAddTraits(.isHeader)
 
             TextField("File name", text: $newName)
                 .textFieldStyle(.roundedBorder)

--- a/Pinpoint/Shelf/Views/Screens/ShelfView.swift
+++ b/Pinpoint/Shelf/Views/Screens/ShelfView.swift
@@ -61,6 +61,7 @@ struct ShelfView: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Shelf")
                         .font(.title3.weight(.semibold))
+                        .accessibilityAddTraits(.isHeader)
 
                     Text(store.watchedFolderURL.lastPathComponent)
                         .font(.caption)
@@ -88,6 +89,8 @@ struct ShelfView: View {
                     Image(systemName: "gearshape")
                 }
                 .buttonStyle(.borderless)
+                .accessibilityLabel(settingsLabel)
+                .help(settingsLabel)
 
                 Button {
                     Task { await store.refresh() }
@@ -95,6 +98,8 @@ struct ShelfView: View {
                     Image(systemName: "arrow.clockwise")
                 }
                 .buttonStyle(.borderless)
+                .accessibilityLabel(refreshLabel)
+                .help(refreshLabel)
             }
 
             searchField
@@ -116,6 +121,10 @@ struct ShelfView: View {
                     Label(store.selectedDateFilter.title, systemImage: "calendar")
                 }
                 .menuStyle(.borderlessButton)
+                // The menu shows the active filter and nothing else, so on its
+                // own VoiceOver announces "All" with no hint of what it filters.
+                .accessibilityLabel(String(localized: "a11y.shelf.dateFilter", defaultValue: "Date filter"))
+                .accessibilityValue(store.selectedDateFilter.title)
 
                 Button {
                     store.showsFavoritesOnly.toggle()
@@ -125,6 +134,7 @@ struct ShelfView: View {
                 }
                 .buttonStyle(.borderless)
                 .help("Show favorites only")
+                .accessibilityAddTraits(store.showsFavoritesOnly ? .isSelected : [])
 
                 Spacer()
 
@@ -144,6 +154,8 @@ struct ShelfView: View {
                     Label(store.selectedSortOrder.title, systemImage: "arrow.up.arrow.down")
                 }
                 .menuStyle(.borderlessButton)
+                .accessibilityLabel(String(localized: "a11y.shelf.sortOrder", defaultValue: "Sort order"))
+                .accessibilityValue(store.selectedSortOrder.title)
             }
             .font(.subheadline)
 
@@ -161,11 +173,16 @@ struct ShelfView: View {
         HStack(spacing: 6) {
             Image(systemName: "magnifyingglass")
                 .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
 
             TextField("Search screenshots", text: $store.searchQuery)
                 .textFieldStyle(.plain)
                 .focused($isSearchFieldFocused)
                 .onSubmit { isSearchFieldFocused = false }
+                // A plain text field takes its placeholder as label only while
+                // it is empty; naming it explicitly keeps it a search field
+                // once something has been typed into it.
+                .accessibilityLabel(String(localized: "Search screenshots"))
 
             if store.searchQuery.isEmpty == false {
                 Button {
@@ -177,6 +194,7 @@ struct ShelfView: View {
                 }
                 .buttonStyle(.borderless)
                 .help("Clear search")
+                .accessibilityLabel(Text("Clear search"))
             }
         }
         .font(.subheadline)
@@ -215,7 +233,13 @@ struct ShelfView: View {
                         }
 
                         if store.selectedDateFilter != .all {
+                            // No section headers in this mode, so the grid
+                            // itself carries the "how many are we looking at"
+                            // that `SectionHeaderView` provides otherwise.
                             screenshotGrid(items: store.filteredScreenshots, columns: columns, cardWidth: cardWidth)
+                                .accessibilityElement(children: .contain)
+                                .accessibilityLabel(String(localized: "a11y.shelf.results",
+                                                           defaultValue: "\(store.filteredScreenshots.count) screenshots shown"))
                         }
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -272,6 +296,28 @@ struct ShelfView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding()
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(emptyStateAccessibilityLabel)
+    }
+
+    /// Which of the three empty states is showing, in one sentence. VoiceOver
+    /// lands on the group before its contents, and "empty" on its own doesn't
+    /// say whether it's the folder, the filters, or the shelf itself.
+    private var emptyStateAccessibilityLabel: String {
+        if store.watchedFolderIsReadable == false {
+            return String(localized: "Folder unavailable")
+        }
+        return store.hasActiveFilters
+            ? String(localized: "No matching screenshots")
+            : String(localized: "No screenshots")
+    }
+
+    private var settingsLabel: String {
+        String(localized: "a11y.shelf.settings", defaultValue: "Open settings")
+    }
+
+    private var refreshLabel: String {
+        String(localized: "a11y.shelf.refresh", defaultValue: "Refresh the shelf")
     }
 
     private var selectedItems: [ScreenshotItem] {
@@ -300,6 +346,7 @@ struct ShelfView: View {
                     Image(systemName: "space")
                 }
                 .help("Quick Look")
+                .accessibilityLabel(Text("Quick Look"))
                 .keyboardShortcut(.space, modifiers: [])
 
                 Button {
@@ -308,6 +355,7 @@ struct ShelfView: View {
                     Image(systemName: "doc.on.doc")
                 }
                 .help("Copy files")
+                .accessibilityLabel(Text("Copy files"))
                 .keyboardShortcut("c")
 
                 Button {
@@ -319,6 +367,7 @@ struct ShelfView: View {
                     Image(systemName: "folder")
                 }
                 .help("Move selection")
+                .accessibilityLabel(Text("Move selection"))
 
                 Menu {
                     Button(allSelectedItemsAreFavorites ? String(localized: "Remove from favorites") : String(localized: "Add to favorites"), systemImage: allSelectedItemsAreFavorites ? "star.slash" : "star") {
@@ -345,6 +394,7 @@ struct ShelfView: View {
                     Image(systemName: "ellipsis.circle")
                 }
                 .help("More actions")
+                .accessibilityLabel(Text("More actions"))
 
                 Button(role: .destructive) {
                     requestDeletion(of: selectedItems)
@@ -352,6 +402,7 @@ struct ShelfView: View {
                     Image(systemName: "trash")
                 }
                 .help("Delete selection")
+                .accessibilityLabel(Text("Delete selection"))
                 .keyboardShortcut(.delete, modifiers: [])
 
                 Button {
@@ -360,6 +411,7 @@ struct ShelfView: View {
                     Image(systemName: "xmark")
                 }
                 .help("Clear selection")
+                .accessibilityLabel(Text("Clear selection"))
             }
             .buttonStyle(.bordered)
         }
@@ -677,6 +729,7 @@ private struct RenameScreenshotView: View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Rename screenshot")
                 .font(.title3.weight(.semibold))
+                .accessibilityAddTraits(.isHeader)
 
             TextField("File name", text: $newName)
                 .textFieldStyle(.roundedBorder)


### PR DESCRIPTION
Closes #46

Le projet ne contenait **aucun** `accessibilityLabel` : boutons icon-only, repères, canvas, cartes de l'étagère et badge de dimensions étaient muets sous VoiceOver.

## Éditeur

- Le canvas est un groupe nommé, l'image de fond est décrite, chaque repère est lu « Repère N : note » (ou « Repère N, sans description »), avec sa position en pourcentages en valeur et un hint « faites glisser pour déplacer ». Chaque forme est annoncée par son type.
- **Boutons invisibles porteurs des raccourcis** (⌘1/⌘2/⌘3, ⌫/⌦, ⌘Z/⇧⌘Z) : **choix retenu — les masquer**. Ce sont des porte-raccourcis sans existence visuelle ni cible cliquable ; les exposer aurait ajouté cinq contrôles fantômes entre le sélecteur d'outil et le bouton Recadrer. Le `accessibilityHidden(true)` était déjà en place sur `hiddenShortcuts` ; j'ai vérifié dans l'arbre AX de l'app construite qu'ils n'y apparaissent effectivement pas. Les actions correspondantes restent atteignables par les boutons visibles Annuler/Rétablir et par le sélecteur d'outil.
- Poignées de manipulation nommées par leur position (« Poignée de redimensionnement, coin haut-gauche »), via un `HandleSpot` partagé entre `SelectionHandle` et l'enum du `CropOverlay` — les deux couvrent les mêmes huit positions et ne peuvent plus diverger. Les extrémités d'une flèche ont leur propre nom (départ / pointe).
- La couche de dessin des formes porte les libellés ; les bandes de préhension invisibles sont masquées, sinon chaque annotation serait annoncée deux fois.
- Panneau latéral : en-têtes marqués `isHeader`, champ de note nommé par son repère (le placeholder faisait que toutes les lignes s'annonçaient à l'identique), boutons de suppression étiquetés, sélection de ligne atteignable via une action accessible (le `onTapGesture` est une affordance souris).
- Le champ Instructions expose enfin un nom.

## Dynamic Type

- Panneau latéral : le badge numéroté suit la taille du texte (`@ScaledMetric`).
- Étagère : toutes les tailles fixes (`.system(size: 13/15/16/18)`) passent en styles système.
- Le canvas et le rendu des repères sont **laissés intacts** : ils doivent correspondre à l'image exportée (objet de #48, traité en parallèle).

## reduce-motion

Les six `withAnimation` de l'éditeur passent par un helper `withMotion`, qui retire l'animation quand « Réduire les animations » est actif. Les transitions elles-mêmes ne sont pas supprimées.

## Étagère

- Réglages, actualisation, recherche, effacement de recherche et toute la barre de sélection sont nommés ; les menus de filtre et de tri exposent aussi leur valeur active (« Filtre par date : Tout »).
- Cartes : libellé = titre, miniature « Aperçu de … », état de sélection annoncé, et les clics simple / double ont leur équivalent en actions accessibles.
- En-têtes de section lus « Aujourd'hui, 3 captures » et marqués `isHeader`, ce qui rend le rotor VoiceOver utilisable pour sauter d'un groupe de dates à l'autre.
- États vides nommés par leur cause (dossier illisible / filtres / étagère vide).
- Le bouton de glisser multi-fichiers expose un libellé en mode compact, où il n'a pas de titre.

## Contraste

- Ligne sélectionnée du panneau latéral : teinte 12 % → 20 %, plus un contour, pour ne plus faire porter l'information par la seule couleur.
- Sélection de région : pastille de dimensions 75 % → 88 % de noir en fond, pastille d'indice 55 % → 82 % avec du blanc pur. Blanc sur noir 55 % restait illisible au-dessus d'une fenêtre claire.

## Sélection de région

La vue AppKit expose son rôle, son libellé, les dimensions courantes en valeur et l'aide clavier, et poste une notification `valueChanged` **en fin de geste** — pas à chaque frame, sinon VoiceOver relirait un chiffre par image.

## i18n

37 clés `a11y.*` ajoutées avec `en` **et** `fr`, insérées en un seul bloc contigu et trié entre `10 seconds` et `Add to favorites`, pour limiter la surface de conflit avec les autres branches en cours. Rien d'autre n'a été touché dans le catalogue.

## Vérification

- `xcodegen generate` + `xcodebuild -scheme Pinpoint -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED**.
- Vérifié en lisant l'**arbre d'accessibilité réel** de l'app construite (celui que lit VoiceOver) pour l'étagère et l'éditeur. C'est ce test qui a révélé un doublon : le `Picker` conservait son titre malgré `labelsHidden()`, et mon libellé s'y ajoutait au lieu de le remplacer — VoiceOver annonçait « Outil, Outil d'annotation ». Le libellé surnuméraire et sa clé ont été retirés.
- La superposition de sélection de région n'a pas pu être observée : le build Debug n'a pas la permission d'enregistrement d'écran. Ses surcharges AppKit compilent, mais leur comportement à l'exécution n'est pas vérifié de bout en bout.

## Périmètre

Aucune formule de géométrie ni de dimensionnement du rendu n'a été touchée (`PinMarker`, `markupView`, `ArrowShape`, `PinShape`, rayons, épaisseurs, clamp de pastille, `fittedRect`), et `Exporter.swift` n'est pas modifié — c'est le périmètre de #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)