### PR TITLE
Handoff par fichier : capture.png / .md / .json à un chemin stable

### DIFF
--- a/Pinpoint/EditorView.swift
+++ b/Pinpoint/EditorView.swift
@@ -1078,6 +1078,23 @@ struct EditorView: View {
             return
         }
         onPersist(pins, shapes, context, image)
+
+        // The clipboard is only half of it. An agent that can’t render a pasted
+        // image — Claude Code being the case that started this — still reads the
+        // file triplet by path, so every copy also writes it to disk. Surfaced
+        // on failure rather than swallowed: announcing “Copied!” for a handoff
+        // that never landed is exactly what #38 stopped doing elsewhere.
+        do {
+            try FileHandoff.write(base: image, pins: pins, shapes: shapes,
+                                  context: context, style: pinStyle)
+        } catch {
+            exportError = String(
+                localized: "handoff.error.body",
+                defaultValue: "The capture was copied to the clipboard, but the files for the agent couldn’t be written to \(FileHandoff.latestDirectory.path): \(error.localizedDescription)"
+            )
+            return
+        }
+
         withMotion { didCopy = true }
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) {
             withMotion { didCopy = false }

--- a/Pinpoint/FileHandoff.swift
+++ b/Pinpoint/FileHandoff.swift
@@ -1,0 +1,249 @@
+import AppKit
+
+/// Writes the annotated capture to a stable, predictable place on disk so an
+/// agent can pick it up with its own file tools.
+///
+/// The clipboard alone is not a reliable channel. Claude Code doesn't render
+/// images returned inline by an MCP server — the base64 lands in the transcript
+/// as raw text (anthropics/claude-code#31208, closed "not planned") — so what
+/// actually reaches the model is a *file path* it reads itself. Every copy
+/// therefore also drops a triplet on disk:
+///
+///     ~/Library/Application Support/Pinpoint/last/capture.png   annotated image, native resolution
+///     ~/Library/Application Support/Pinpoint/last/capture.md    the agent-ready text
+///     ~/Library/Application Support/Pinpoint/last/capture.json  the same facts, machine-readable
+///
+/// plus a timestamped copy under `…/Pinpoint/archive/<stamp>/`.
+///
+/// Application Support rather than the user's screenshot folder: the path has
+/// to be hard-codable by an agent that never saw this machine, and the
+/// screenshot folder is neither fixed (see `ScreenshotLocationResolver`) nor
+/// ours to pollute — the Shelf watches it, so writing there would feed our own
+/// output back into the library. `CaptureHistory` already owns
+/// `Application Support/Pinpoint/Captures`, so we stay in the same root.
+enum FileHandoff {
+    // MARK: - Contract
+
+    /// Version of the JSON contract written to `capture.json`.
+    ///
+    /// Bumped only on a *breaking* change — a key removed, renamed, or given a
+    /// new meaning. Adding keys is not breaking: issue #55 will hang an
+    /// `accessibility` object off each marker, and a consumer written against
+    /// version 1 has to keep working. Read what you know, ignore the rest.
+    static let schemaVersion = 1
+
+    /// How many timestamped folders `archive/` keeps; the oldest are deleted on
+    /// every write. Kept deliberately low because each folder carries a
+    /// full-resolution copy of the PNG (a Retina capture runs to several MB),
+    /// and this directory is never surfaced in the UI — nobody would notice it
+    /// growing.
+    static let maxArchiveEntries = 10
+
+    /// `~/Library/Application Support/Pinpoint`.
+    static var rootDirectory: URL {
+        // No temp-directory fallback (unlike `CaptureHistory`): the whole point
+        // of this location is that an agent can hard-code it, so a random path
+        // would be worse than useless. If the lookup ever fails we rebuild the
+        // very path it would have returned.
+        let support = (try? FileManager.default.url(for: .applicationSupportDirectory,
+                                                    in: .userDomainMask,
+                                                    appropriateFor: nil, create: true))
+            ?? URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+                .appendingPathComponent("Library/Application Support", isDirectory: true)
+        return support.appendingPathComponent("Pinpoint", isDirectory: true)
+    }
+
+    /// The fixed location an agent reads: always the most recent handoff.
+    static var latestDirectory: URL {
+        rootDirectory.appendingPathComponent("last", isDirectory: true)
+    }
+
+    /// Timestamped copies of past handoffs, capped to `maxArchiveEntries`.
+    static var archiveDirectory: URL {
+        rootDirectory.appendingPathComponent("archive", isDirectory: true)
+    }
+
+    static let pngFileName = "capture.png"
+    static let markdownFileName = "capture.md"
+    static let jsonFileName = "capture.json"
+
+    /// Where a handoff landed. Returned so the callers that come next (the CLI
+    /// of #56, the MCP server of #57) can report the paths without rebuilding
+    /// them.
+    struct Output {
+        let directory: URL
+        let png: URL
+        let markdown: URL
+        let json: URL
+        /// The timestamped copy, or nil when the archive couldn't be written —
+        /// see `write(base:pins:shapes:context:style:)`.
+        let archive: URL?
+    }
+
+    enum Failure: LocalizedError {
+        /// The annotated PNG couldn't be produced, so there is nothing to hand
+        /// off. Write failures aren't listed here: `FileManager` already throws
+        /// localized errors, which we let through untouched.
+        case renderFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .renderFailed:
+                return String(localized: "The annotated image couldn’t be rendered.")
+            }
+        }
+    }
+
+    // MARK: - Writing
+
+    /// Renders the capture and writes the triplet to `last/`, then archives a
+    /// timestamped copy.
+    ///
+    /// Throws when the `last/` triplet couldn't be written — that failure has to
+    /// reach the user rather than be swallowed behind a "Copied!" (#38). The
+    /// archive is best effort: it's a convenience, not the contract, so a
+    /// failure there only leaves `Output.archive` nil.
+    @discardableResult
+    static func write(base: NSImage, pins: [Pin], shapes: [Markup],
+                      context: String, style: PinStyle) throws -> Output {
+        // No legend strip, whatever the editor's `includeLegend` setting says.
+        // The legend grows the image downwards, which would shift every pixel
+        // coordinate in the .md and .json off the pixels they describe — and
+        // the point of the triplet is that the text travels with the image, so
+        // baking it in buys nothing here. Native resolution, no clipboard cap:
+        // this file is read, not pasted.
+        guard let png = Exporter.pngData(base: base, pins: pins, shapes: shapes, context: context,
+                                         style: style, includeLegend: false, maxDimension: nil),
+              let rep = NSBitmapImageRep(data: png) else {
+            throw Failure.renderFailed
+        }
+        // Measured off the PNG we just produced, not taken from `base.size`.
+        // `annotatedImage` draws through `lockFocus()`, whose backing store
+        // follows the deepest screen: on a Retina Mac the file comes out at 2×
+        // the size in points (and at 1× on a machine with no display at all).
+        // The .md and .json quote pixel coordinates, so they have to be in the
+        // grid of the file sitting next to them — a factor-two mismatch would
+        // send an agent to the wrong half of the image.
+        let pixelSize = CGSize(width: rep.pixelsWide, height: rep.pixelsHigh)
+
+        // Always the full agent-ready text, again regardless of `includeLegend`
+        // — which is what keeps the enriched export (#41) reachable even in the
+        // default configuration, where the clipboard only carries the image
+        // (#69).
+        let markdown = Exporter.buildText(pins: pins, shapes: shapes,
+                                          context: context, imageSize: pixelSize)
+
+        let latest = latestDirectory
+        try replaceDirectory(latest, with: files(png: png, markdown: markdown,
+                                                 pins: pins, shapes: shapes, context: context,
+                                                 imageSize: pixelSize, directory: latest))
+
+        let archived = try? archive(png: png, markdown: markdown, pins: pins, shapes: shapes,
+                                    context: context, imageSize: pixelSize)
+
+        return Output(
+            directory: latest,
+            png: latest.appendingPathComponent(pngFileName),
+            markdown: latest.appendingPathComponent(markdownFileName),
+            json: latest.appendingPathComponent(jsonFileName),
+            archive: archived
+        )
+    }
+
+    /// The three files of a handoff, in the order they're written. `directory`
+    /// is where they will *end up*: the JSON quotes absolute paths, so it has to
+    /// be built for its final home, not for the staging folder.
+    private static func files(png: Data, markdown: String, pins: [Pin], shapes: [Markup],
+                              context: String, imageSize: CGSize,
+                              directory: URL) throws -> [(name: String, data: Data)] {
+        let document = Document(pins: pins, shapes: shapes, context: context,
+                                imageSize: imageSize, directory: directory)
+        let encoder = JSONEncoder()
+        // Pretty-printed, key-sorted and unescaped: a human debugging this reads
+        // it, `\/Users\/…` for every path is noise, and a fixed key order keeps
+        // two handoffs of the same annotations byte-identical.
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        return [
+            (pngFileName, png),
+            (markdownFileName, Data(markdown.utf8)),
+            (jsonFileName, try encoder.encode(document))
+        ]
+    }
+
+    /// Writes `files` into `directory`, replacing whatever was there.
+    ///
+    /// Staged in a sibling folder and swapped in with a single `replaceItemAt`,
+    /// so an agent reading `last/` gets either the previous handoff or the new
+    /// one — never a half-written PNG, and never a fresh `.md` describing the
+    /// previous `.png`.
+    private static func replaceDirectory(_ directory: URL,
+                                         with files: [(name: String, data: Data)]) throws {
+        let fileManager = FileManager.default
+        let parent = directory.deletingLastPathComponent()
+        try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
+
+        let staging = parent.appendingPathComponent(".staging-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: staging, withIntermediateDirectories: true)
+        // Only fires when something below threw; a successful swap consumes it.
+        defer { try? fileManager.removeItem(at: staging) }
+
+        for file in files {
+            try file.data.write(to: staging.appendingPathComponent(file.name), options: .atomic)
+        }
+
+        if fileManager.fileExists(atPath: directory.path) {
+            _ = try fileManager.replaceItemAt(directory, withItemAt: staging)
+        } else {
+            try fileManager.moveItem(at: staging, to: directory)
+        }
+    }
+
+    /// Writes a timestamped copy of the handoff and prunes the oldest ones.
+    private static func archive(png: Data, markdown: String, pins: [Pin], shapes: [Markup],
+                                context: String, imageSize: CGSize) throws -> URL {
+        let folder = archiveDirectory.appendingPathComponent(timestamp(), isDirectory: true)
+        try replaceDirectory(folder, with: files(png: png, markdown: markdown,
+                                                 pins: pins, shapes: shapes, context: context,
+                                                 imageSize: imageSize, directory: folder))
+        prune()
+        return folder
+    }
+
+    /// `2026-08-20-141203-482` — sorts chronologically as text, and carries
+    /// milliseconds so two copies in the same second don't collide.
+    private static func timestamp() -> String {
+        let formatter = DateFormatter()
+        // POSIX locale so the pattern isn't rewritten by the user's regional
+        // settings; local time because these folder names are read by a human
+        // browsing the archive.
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd-HHmmss-SSS"
+        return formatter.string(from: Date())
+    }
+
+    /// Keeps the `maxArchiveEntries` most recent folders. Without it the archive
+    /// grows one folder per copy for the life of the install.
+    private static func prune() {
+        let fileManager = FileManager.default
+        guard let entries = try? fileManager.contentsOfDirectory(
+            at: archiveDirectory,
+            includingPropertiesForKeys: [.creationDateKey, .isDirectoryKey],
+            options: [.skipsHiddenFiles]) else { return }
+
+        let folders = entries.filter {
+            (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+        }
+        guard folders.count > maxArchiveEntries else { return }
+
+        // By creation date rather than by name: the names carry local time, so
+        // a DST rollback would sort an hour's worth of them the wrong way round.
+        let newestFirst = folders.sorted { left, right in
+            let leftDate = (try? left.resourceValues(forKeys: [.creationDateKey]).creationDate) ?? .distantPast
+            let rightDate = (try? right.resourceValues(forKeys: [.creationDateKey]).creationDate) ?? .distantPast
+            return leftDate > rightDate
+        }
+        for folder in newestFirst.dropFirst(maxArchiveEntries) {
+            try? fileManager.removeItem(at: folder)
+        }
+    }
+}

--- a/Pinpoint/HandoffDocument.swift
+++ b/Pinpoint/HandoffDocument.swift
@@ -1,0 +1,197 @@
+import CoreGraphics
+import Foundation
+
+// The JSON contract written to `capture.json`.
+//
+// Spelled out here rather than encoding `Pin` and `Markup` straight to the
+// wire, even though both are already `Codable`: this file is read by things
+// that live outside the app — the CLI (#56), the MCP server (#57), whatever a
+// user scripts on top of it — and it must not shift the day the internal model
+// does. Renaming `Pin.note` should break a compile in here, not somebody's
+// script.
+//
+// Everything is derived, nothing is a reference to a live object, and the
+// coordinate convention matches `capture.md`: pixels from the top-left corner
+// first, then the same point as a percentage of the image size.
+extension FileHandoff {
+    struct Document: Encodable {
+        let schemaVersion: Int
+        let generator: Generator
+        /// When this handoff was written (ISO 8601, with offset).
+        let generatedAt: String
+        let image: Image
+        /// Absolute path of the Markdown twin sitting next to this file — the
+        /// same content in prose, for an agent that would rather read that.
+        let markdownPath: String
+        /// The user's instructions, verbatim. Empty string when they wrote none
+        /// (the key is always present, so a consumer never has to branch on its
+        /// absence).
+        let context: String
+        let markers: [Marker]
+        let shapes: [Shape]
+
+        struct Generator: Encodable {
+            let name: String
+            let version: String
+        }
+
+        struct Image: Encodable {
+            /// Absolute path of the annotated PNG next to this file.
+            let path: String
+            /// Pixel dimensions of that PNG — the grid every `x`/`y` below is
+            /// expressed in.
+            let width: Int
+            let height: Int
+        }
+
+        /// A point in the image, given twice: pixels for an agent working on
+        /// the file, percentages for one reasoning about a resized copy.
+        struct Point: Encodable {
+            let x: Int
+            let y: Int
+            /// 0…100, two decimals.
+            let xPercent: Double
+            let yPercent: Double
+        }
+
+        /// Axis-aligned box, same dual units as `Point`.
+        struct Box: Encodable {
+            let x: Int
+            let y: Int
+            let width: Int
+            let height: Int
+            let xPercent: Double
+            let yPercent: Double
+            let widthPercent: Double
+            let heightPercent: Double
+        }
+
+        /// A numbered marker.
+        ///
+        /// Issue #55 will add an `accessibility` object here (the element under
+        /// the marker, read from the accessibility tree at capture time). That's
+        /// an addition, so `schemaVersion` stays at 1 — consumers must tolerate
+        /// keys they don't know.
+        struct Marker: Encodable {
+            /// Stable identifier, the same code `capture.md` prints in brackets.
+            /// Survives the renumbering that follows a deletion, so two handoffs
+            /// of one session refer to the same marker by the same id.
+            let id: String
+            /// What is actually drawn on the image: "M1", "M2"… Unlike `id` it
+            /// changes when earlier markers are deleted.
+            let label: String
+            let number: Int
+            /// The user's description. Empty when they left it blank.
+            let note: String
+            let position: Point
+        }
+
+        /// An unnumbered outline: arrow or rectangle.
+        struct Shape: Encodable {
+            let id: String
+            /// "S1", "S2"… matching `capture.md`.
+            let label: String
+            /// "arrow" or "rectangle". Deliberately a plain string mapped by
+            /// hand, so renaming the internal enum can't silently change the
+            /// contract.
+            let kind: String
+            /// Arrow: the tail. Rectangle: its top-left corner.
+            let from: Point
+            /// Arrow: the tip, where the head is drawn. Rectangle: its
+            /// bottom-right corner.
+            let to: Point
+            let boundingBox: Box
+        }
+    }
+}
+
+extension FileHandoff.Document {
+    /// Builds the document for a set of annotations. `directory` is where the
+    /// triplet will live, since the absolute paths below point at its siblings.
+    init(pins: [Pin], shapes: [Markup], context: String, imageSize: CGSize, directory: URL) {
+        self.schemaVersion = FileHandoff.schemaVersion
+        self.generator = Generator(
+            name: "Pinpoint",
+            version: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0"
+        )
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        self.generatedAt = formatter.string(from: Date())
+        self.image = Image(
+            path: directory.appendingPathComponent(FileHandoff.pngFileName).path,
+            width: Int(imageSize.width.rounded()),
+            height: Int(imageSize.height.rounded())
+        )
+        self.markdownPath = directory.appendingPathComponent(FileHandoff.markdownFileName).path
+        self.context = context.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        self.markers = pins.sorted { $0.number < $1.number }.map { pin in
+            Marker(
+                id: pin.id.shortToken,
+                label: "M\(pin.number)",
+                number: pin.number,
+                note: pin.note.trimmingCharacters(in: .whitespacesAndNewlines),
+                position: Point(pin.position, in: imageSize)
+            )
+        }
+
+        self.shapes = shapes.enumerated().map { index, shape in
+            let kind: String
+            let from: CGPoint
+            let to: CGPoint
+            switch shape.kind {
+            case .arrow:
+                kind = "arrow"
+                from = shape.start
+                to = shape.end
+            case .rectangle:
+                kind = "rectangle"
+                from = CGPoint(x: shape.rect.minX, y: shape.rect.minY)
+                to = CGPoint(x: shape.rect.maxX, y: shape.rect.maxY)
+            }
+            return Shape(
+                id: shape.id.shortToken,
+                label: "S\(index + 1)",
+                kind: kind,
+                from: Point(from, in: imageSize),
+                to: Point(to, in: imageSize),
+                boundingBox: Box(shape.rect, in: imageSize)
+            )
+        }
+    }
+}
+
+extension FileHandoff.Document.Point {
+    init(_ point: CGPoint, in size: CGSize) {
+        self.init(
+            x: Int((point.x * size.width).rounded()),
+            y: Int((point.y * size.height).rounded()),
+            xPercent: FileHandoff.percent(point.x),
+            yPercent: FileHandoff.percent(point.y)
+        )
+    }
+}
+
+extension FileHandoff.Document.Box {
+    init(_ rect: CGRect, in size: CGSize) {
+        self.init(
+            x: Int((rect.minX * size.width).rounded()),
+            y: Int((rect.minY * size.height).rounded()),
+            width: Int((rect.width * size.width).rounded()),
+            height: Int((rect.height * size.height).rounded()),
+            xPercent: FileHandoff.percent(rect.minX),
+            yPercent: FileHandoff.percent(rect.minY),
+            widthPercent: FileHandoff.percent(rect.width),
+            heightPercent: FileHandoff.percent(rect.height)
+        )
+    }
+}
+
+extension FileHandoff {
+    /// A normalized 0…1 coordinate as a percentage with two decimals. Finer
+    /// than the whole percents `capture.md` prints — the text is for reading,
+    /// this is for computing against.
+    static func percent(_ value: CGFloat) -> Double {
+        (Double(value) * 10_000).rounded() / 100
+    }
+}

--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -621,6 +621,12 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Suivre l’emplacement des captures de macOS" } }
       }
     },
+    "handoff.error.body" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "The capture was copied to the clipboard, but the files for the agent couldn’t be written to %@: %@" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "La capture a été copiée dans le presse-papier, mais les fichiers destinés à l’agent n’ont pas pu être écrits dans %@ : %@" } }
+      }
+    },
     "Instructions for the agent" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Instructions pour l’agent" } }

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ Pinpoint/
   PinStyle.swift                  # marker styles (disc / pointer / outline)
   Theme.swift                     # vermillon palette
   Exporter.swift                  # annotated PNG render + structured text + clipboard
+  FileHandoff.swift               # writes capture.{png,md,json} where an agent can read them
+  HandoffDocument.swift           # the JSON contract for capture.json (schemaVersion 1)
   SettingsWindowController.swift  # AppKit settings window (works around the macOS 14+ SettingsLink bug)
   ShelfWindowController.swift     # the shelf window
   ScreenshotDetailWindowController.swift  # detail window for a shelf item
@@ -152,6 +154,35 @@ Pinpoint/
   Shelf/                          # the screenshot library (Models, Services, Stores, Views)
 landing/                          # the marketing site (Astro + Tailwind v4, bilingual)
 ```
+
+## Agent handoff (files on disk)
+
+Copying from the editor doesn't only fill the clipboard: it also writes the
+capture to a fixed path, because a clipboard image is not something every agent
+can read (Claude Code doesn't render images returned inline by an MCP server —
+[anthropics/claude-code#31208](https://github.com/anthropics/claude-code/issues/31208)).
+A file path is the channel that reliably works.
+
+```
+~/Library/Application Support/Pinpoint/last/capture.png    annotated image, native resolution, no legend strip
+~/Library/Application Support/Pinpoint/last/capture.md     the agent-ready text (markers, shapes, instructions)
+~/Library/Application Support/Pinpoint/last/capture.json   the same facts, machine-readable — see HandoffDocument.swift
+~/Library/Application Support/Pinpoint/archive/<stamp>/    a timestamped copy of each handoff
+```
+
+- The path is fixed on purpose: an agent has to be able to hard-code it rather
+  than discover it. Point one at `capture.md` and it has everything.
+- The triplet is staged in a sibling folder and swapped in atomically, so a
+  reader gets the previous handoff or the new one, never a mix of the two.
+- `capture.md` always carries the complete text, whatever the "legend in the
+  image" setting says — unlike the clipboard, which drops it when the legend is
+  baked into the PNG.
+- Pixel coordinates in `.md`/`.json` are in the grid of `capture.png` itself, so
+  on a Retina capture they read 2× the size in points.
+- **The archive keeps the 10 most recent handoffs**, oldest deleted first. Each
+  folder holds a full-resolution PNG, so the cap is deliberately low.
+- `capture.json` carries a `schemaVersion`. New keys can appear without bumping
+  it — consumers must ignore what they don't know.
 
 ## Dependencies
 


### PR DESCRIPTION
Closes #54

Le presse-papier n'est pas un canal fiable vers un agent : Claude Code n'affiche pas les images renvoyées inline par un serveur MCP — le base64 arrive dans la transcription en texte brut ([anthropics/claude-code#31208](https://github.com/anthropics/claude-code/issues/31208), fermée « not planned »). Ce qui atteint réellement le modèle, c'est **un chemin de fichier qu'il lit avec son propre outil `Read`**. C'est la fondation dont dépendent #56 (CLI), #57 (MCP) et #58 (URL scheme).

Chaque copie depuis l'éditeur écrit donc aussi un triplet sur disque.

## Où, et pourquoi là

```
~/Library/Application Support/Pinpoint/last/capture.png    image annotée, résolution native, sans bandeau de légende
~/Library/Application Support/Pinpoint/last/capture.md     le texte agent-ready
~/Library/Application Support/Pinpoint/last/capture.json   les mêmes faits, exploitables par une machine
~/Library/Application Support/Pinpoint/archive/<stamp>/    copie horodatée de chaque handoff
```

- **Application Support, pas le dossier de captures.** `ScreenshotLocationResolver` résout un dossier qui n'est ni fixe (l'utilisateur le déplace) ni le nôtre — et la Shelf le surveille, donc y écrire réinjecterait notre propre sortie dans la bibliothèque. `CaptureHistory` possède déjà `Application Support/Pinpoint/Captures` : on reste dans la même racine.
- **Le chemin est en dur, volontairement.** Un agent doit pouvoir l'écrire dans son prompt sans avoir à le découvrir. L'app n'est pas sandboxée, donc c'est bien ce chemin-là et pas un container.

## Le `.json` — et le recouvrement avec #52

Contrat déclaré explicitement dans `HandoffDocument.swift` plutôt qu'en encodant `Pin`/`Markup` tels quels, bien que les deux soient déjà `Codable` : ce fichier est lu par des choses extérieures à l'app, il ne doit pas bouger le jour où le modèle interne bouge. Renommer `Pin.note` doit casser une compilation ici, pas le script de quelqu'un.

```json
{
  "schemaVersion": 1,
  "generator": { "name": "Pinpoint", "version": "0.6.0" },
  "generatedAt": "2026-08-20T09:28:54Z",
  "image": { "path": "/Users/…/last/capture.png", "width": 2400, "height": 1600 },
  "markdownPath": "/Users/…/last/capture.md",
  "context": "Corrige l'alignement du bouton principal.",
  "markers": [
    { "id": "589846", "label": "M1", "number": 1, "note": "Le bouton est mal aligné",
      "position": { "x": 480, "y": 240, "xPercent": 20, "yPercent": 15 } }
  ],
  "shapes": [
    { "id": "734a55", "label": "S1", "kind": "arrow",
      "from": { "x": 240, "y": 1440, "xPercent": 10, "yPercent": 90 },
      "to":   { "x": 960, "y": 880,  "xPercent": 40, "yPercent": 55 },
      "boundingBox": { "x": 240, "y": 880, "width": 720, "height": 560,
                       "xPercent": 10, "yPercent": 55, "widthPercent": 30, "heightPercent": 35 } }
  ]
}
```

`id` est le jeton stable (le même que le `.md` affiche entre crochets), `label` est ce qui est **dessiné** sur l'image et change quand un repère antérieur est supprimé. Les deux sont là parce qu'un agent a besoin des deux : l'un pour parler à l'utilisateur (« le repère 2 »), l'autre pour recouper deux exports de la même session.

**⚠️ Recouvrement avec #52 (« [Export] Structured JSON output », Tier 2).** Ce schéma en couvre déjà l'essentiel, mais il a été taillé pour le handoff, pas pour être un format d'export général :

| Couvert ici | Resterait à faire pour #52 |
| --- | --- |
| Dimensions image + chemin absolu du PNG | Exposer le JSON comme cible d'export explicite (bouton / `Save as…`), pas seulement en effet de bord de la copie |
| Repères : id stable, numéro, label, note, position px **et** % | Le style de repère, la couleur, l'horodatage de la capture d'origine |
| Formes : type, extrémités, boîte englobante (px et %) | Les métadonnées de la capture (écran source, région, échelle) que porte `CaptureRegion` |
| `schemaVersion`, `generator`, `generatedAt` | Un schéma publié/versionné hors du code (JSON Schema), si #52 vise l'interopérabilité |
| Contexte / instructions utilisateur | Import : ici tout est `Encodable` seulement, il n'y a pas de chemin de relecture |

À l'arbitrage du propriétaire du repo de décider si #52 devient redondante ou se réduit à « exposer ce JSON via l'UI d'export ».

**Extensibilité pour #55.** `schemaVersion` ne bouge que sur un changement cassant — clé retirée, renommée, ou dont le sens change. Ajouter des clés n'est pas cassant : le bloc d'accessibilité de #55 se logera dans un objet `accessibility` sous chaque `marker`, et un consommateur écrit contre la version 1 continuera de fonctionner. C'est dit dans le code, à côté du champ.

## Points d'attention traités

**Écriture atomique — de groupe, pas seulement par fichier.** Le triplet est monté dans un dossier de staging voisin puis basculé d'un seul `replaceItemAt`. Un agent qui lit `last/` obtient l'ancien handoff ou le nouveau : jamais un PNG à moitié écrit, et jamais un `.md` tout frais décrivant le `.png` précédent — ce que trois `write(options: .atomic)` indépendants n'auraient pas empêché. Bonus : le dossier remplacé ne garde aucun résidu d'une version antérieure.

**Les échecs se voient.** `FileHandoff.write` lève ; `EditorView.copy()` remonte l'erreur par l'alerte existante, avec le chemin visé et la raison. Même exigence que #38 : pas de « Copié ! » pour un handoff qui n'a pas eu lieu. L'archive, elle, est explicitement best effort — c'est une commodité, pas le contrat — et son échec laisse seulement `Output.archive` à `nil`.

**Purge de l'archive : les 10 handoffs les plus récents**, les plus anciens supprimés à chaque écriture. Plafond volontairement bas : chaque dossier porte une copie pleine résolution du PNG (plusieurs Mo sur une capture Retina) et ce dossier n'apparaît nulle part dans l'UI — personne ne le verrait grossir. Le tri se fait sur la date de création et non sur le nom, parce que les noms portent l'heure locale et qu'un retour à l'heure d'hiver classerait une heure de dossiers à l'envers. Documenté dans le README.

**Lien avec #69 — réglé pour le fichier.** `includeLegend` vaut `true` par défaut, ce qui fait que le texte enrichi de #41 n'atteint jamais le presse-papier dans la configuration par défaut. Le `.md` n'a pas cette contrainte : il contient **toujours** le texte complet, quel que soit le réglage. Le handoff par fichier rend donc l'export enrichi atteignable par défaut. #69 reste ouverte pour le presse-papier lui-même.

**Pas de bandeau de légende dans le PNG du handoff**, quel que soit le réglage : la légende agrandit l'image vers le bas, ce qui décalerait toutes les coordonnées pixels du `.md` et du `.json` par rapport aux pixels qu'elles décrivent. Et elle n'apporte rien ici puisque le texte voyage à côté, dans son propre fichier.

## Un bug de cohérence trouvé au passage

`Exporter.annotatedImage` dessine via `lockFocus()`, dont le backing store suit l'écran le plus profond : sur un Mac Retina le PNG produit fait **2× la taille en points**, alors que `.size` reste en points (et 1× sur une machine sans écran). Le handoff mesure donc les dimensions sur le PNG réellement écrit, pas sur `base.size` — sans quoi le `.json` aurait annoncé 1200×800 pour un fichier de 2400×1600 et envoyé l'agent dans le mauvais quart de l'image.

Vérifié : `capture.png` fait exactement ce que `capture.json` annonce, et le `.md` du handoff annonce la même chose.

À noter que **le même décalage existe dans le texte du presse-papier** (`buildText` y reçoit `base.size` alors que l'image collée est en plus plafonnée à 2000 px) : c'est un bug distinct, hors du périmètre de cette PR, qui mériterait sa propre issue du côté #41/#52. Rien n'a été touché dans le chemin du presse-papier.

## Vérification

- `xcodegen generate` + `xcodebuild -scheme Pinpoint -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED**, aucun warning Swift.
- Harnais compilé sur les sources réelles (`FileHandoff` + `HandoffDocument` + `Exporter`) et exécuté : triplet écrit, `.md` et `.json` cohérents entre eux et avec les pixels du PNG, chemin absolu du JSON pointant sur un fichier existant, encodage déterministe (deux écritures des mêmes annotations donnent des octets identiques hors horodatage), archive stabilisée à 10 dossiers après 15 écritures, aucun dossier de staging résiduel.
- Nouvelle clé i18n `handoff.error.body` (`en` + `fr`), insérée dans l'ordre alphabétique existant du catalogue.
