### PR TITLE
Tier 3 — Contexte d'accessibilité sous chaque repère

### DIFF
--- a/Pinpoint/AXPermission.swift
+++ b/Pinpoint/AXPermission.swift
@@ -1,0 +1,103 @@
+import ApplicationServices
+import AppKit
+
+/// The Accessibility (a.k.a. "control your computer") permission, which is what
+/// lets Pinpoint read the accessibility tree of *other* apps and turn a visual
+/// marker into a named UI element (#55).
+///
+/// Deliberately a separate grant from Screen Recording: a user who only wants
+/// screenshots never has to hand this one over. Everything here therefore
+/// follows one rule — **nothing prompts on its own**. The capture path only ever
+/// reads `isTrusted`, which is free and silent; the system prompt and the
+/// explanatory alert are reachable only from an explicit click in Settings.
+///
+/// The alert itself mirrors `ScreenCapture.presentPermissionAlert()`: same
+/// shape, same deep link into the matching System Settings pane, so the two
+/// permissions read as one idea rather than two inventions.
+enum AXPermission {
+
+    /// System Settings ▸ Privacy & Security ▸ Accessibility.
+    private static let settingsURL = URL(
+        string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+    )
+
+    /// Whether macOS currently lets Pinpoint read other apps' accessibility
+    /// trees. Cheap, side-effect free, and — unlike
+    /// `AXIsProcessTrustedWithOptions(prompt: true)` — never puts anything on
+    /// screen. This is the only entry point the capture flow is allowed to use.
+    static var isTrusted: Bool { AXIsProcessTrusted() }
+
+    /// Asks macOS for the grant, then explains where to finish the job.
+    ///
+    /// The system dialog raised by `kAXTrustedCheckOptionPrompt` only *offers* a
+    /// shortcut to System Settings and always returns the current (still false)
+    /// state, so a "granted / not granted" return value would be a lie. Instead
+    /// we open the pane ourselves after a short beat, which is the step users
+    /// actually have to perform.
+    ///
+    /// Only ever called from the Settings toggle — see the type comment.
+    @MainActor
+    static func request() {
+        let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
+        if AXIsProcessTrustedWithOptions(options) { return }
+        presentPermissionAlert()
+    }
+
+    /// States what the feature needs and offers a one-click jump to the right
+    /// pane. Kept in the same voice as the Screen Recording alert.
+    @MainActor
+    static func presentPermissionAlert() {
+        let alert = NSAlert()
+        alert.messageText = String(localized: "permission.accessibility.title",
+                                   defaultValue: "Pinpoint can’t read the interface")
+        alert.informativeText = String(
+            localized: "permission.accessibility.body",
+            defaultValue: "To name the element under each marker, Pinpoint needs the Accessibility permission. Open System Settings ▸ Privacy & Security ▸ Accessibility, turn Pinpoint on, then relaunch the app. Captures keep working without it — they just carry no interface details."
+        )
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: String(localized: "permission.accessibility.openSettings",
+                                          defaultValue: "Open System Settings"))
+        alert.addButton(withTitle: String(localized: "Cancel"))
+        NSApp.activate(ignoringOtherApps: true)
+        if alert.runModal() == .alertFirstButtonReturn {
+            openSettings()
+        }
+    }
+
+    /// Deep-links into System Settings ▸ Privacy & Security ▸ Accessibility.
+    static func openSettings() {
+        guard let settingsURL else { return }
+        NSWorkspace.shared.open(settingsURL)
+    }
+}
+
+/// User-facing switches for the accessibility context, and the single place the
+/// capture path reads them from.
+///
+/// `@AppStorage` can't be used off a SwiftUI view, and the capture runs long
+/// before any view exists, so the defaults are spelled out here once and the
+/// Settings screen binds to the very same keys.
+enum AXContextSettings {
+    /// Whether to describe the element under each marker at all.
+    static let enabledKey = "axContextEnabled"
+    /// Whether the text a user typed into ordinary fields may leave the machine.
+    static let fieldValuesKey = "axContextIncludesFieldValues"
+
+    /// On by default: with no Accessibility grant this changes nothing at all
+    /// (the walk is skipped, silently), so the switch only starts to matter for
+    /// someone who has already, explicitly, allowed it.
+    static var isEnabled: Bool {
+        UserDefaults.standard.object(forKey: enabledKey) as? Bool ?? true
+    }
+
+    /// Off by default, on purpose. A capture is handed to an outside agent, and
+    /// the accessibility tree hands out the *full* contents of a field — including
+    /// the part scrolled out of view, which the pixels never showed. Secure
+    /// fields are never read whatever this says; see `AXSnapshotCollector`.
+    static var includesFieldValues: Bool {
+        UserDefaults.standard.bool(forKey: fieldValuesKey)
+    }
+
+    /// Whether a capture should actually walk the tree: asked for, and allowed.
+    static var shouldCapture: Bool { isEnabled && AXPermission.isTrusted }
+}

--- a/Pinpoint/AXSnapshot.swift
+++ b/Pinpoint/AXSnapshot.swift
@@ -1,0 +1,279 @@
+import CoreGraphics
+import Foundation
+
+/// A frozen slice of the macOS accessibility tree, read at the instant a
+/// capture was taken and kept next to it (#55).
+///
+/// ## Why a snapshot, and not a live query
+///
+/// Markers are placed in the editor, *after* the capture — by then the app that
+/// was photographed may have scrolled, closed a sheet, or quit. Asking
+/// `AXUIElementCopyElementAtPosition` at the moment a marker is dropped would
+/// therefore answer about a screen that no longer exists. So the tree is walked
+/// once, while the pixels are being read, and every element that overlaps the
+/// captured region is stored with its frame. Resolving a marker afterwards is
+/// then pure geometry against that frozen list.
+///
+/// ## Coordinate spaces
+///
+/// Element frames are kept in the space the accessibility APIs speak: points,
+/// **global, top-left origin** — the same one `CGDisplayBounds` returns, which
+/// is what makes multi-display setups and negative screen origins fall out for
+/// free instead of needing a special case (#26).
+///
+/// `captureRect` is the piece of that space the image shows. Nothing else ties
+/// the elements to the image, which is what makes cropping (#21) trivial:
+/// `cropped(to:)` shrinks this one rect and leaves all 800 frames alone.
+struct AXSnapshot: Codable, Sendable, Equatable {
+
+    /// The screen area the image covers: points, global top-left origin.
+    var captureRect: CGRect
+
+    /// Every application whose windows were walked, referenced by index from
+    /// `Element.application`. Stored once rather than per element — a capture of
+    /// a single window would otherwise repeat the same bundle id 800 times.
+    var applications: [Application]
+
+    /// The flattened tree, parents always before their children (so `parent`
+    /// indices only ever point backwards).
+    var elements: [Element]
+
+    /// `true` when the walk stopped on one of its own limits (time, node count)
+    /// rather than because it had seen everything. Exported, so a reader knows
+    /// a missing element may mean "not looked at" and not "not there".
+    var truncated: Bool
+
+    /// When the tree was read (the capture instant, near enough).
+    var capturedAt: Date
+
+    /// Whether the walk was allowed to keep the contents of ordinary text
+    /// fields. Recorded per snapshot because it's decided at capture time — the
+    /// value is simply never read when the switch is off, so a later flip of the
+    /// setting can't retroactively expose an old capture.
+    var includesFieldValues: Bool
+
+    struct Application: Codable, Sendable, Equatable {
+        var name: String?
+        var bundleIdentifier: String?
+        var processIdentifier: Int32
+    }
+
+    /// Why an element's value isn't in the snapshot.
+    enum Redaction: String, Codable, Sendable {
+        /// A password field. Never read, at any setting.
+        case secureField
+        /// An ordinary text field, withheld by the default privacy policy.
+        case textFieldPolicy
+    }
+
+    struct Element: Codable, Sendable, Equatable {
+        /// `AXButton`, `AXTextField`… The raw accessibility role, deliberately
+        /// not translated into prose: it's the stable vocabulary an agent (and
+        /// every accessibility inspector) already shares.
+        var role: String
+        var subrole: String?
+        /// `AXTitle` — the visible label of a control.
+        var title: String?
+        /// `AXDescription` — what a screen reader would announce.
+        var label: String?
+        /// `AXIdentifier`. Gold for the issue's actual goal: it is usually the
+        /// very `accessibilityIdentifier` string written in the app's source.
+        var identifier: String?
+        /// `AXHelp` (tooltip). Only collected when nothing else names the
+        /// element, where it's often the only human-readable clue.
+        var help: String?
+        /// `AXPlaceholderValue`, for text inputs. Names an empty field.
+        var placeholder: String?
+        /// The element's value, when the privacy policy allows it.
+        var value: String?
+        /// Set instead of `value` when the value was withheld.
+        var redaction: Redaction?
+        /// Frame in points, global top-left origin.
+        var frame: CGRect
+        var enabled: Bool?
+        /// Index into `applications`.
+        var application: Int
+        /// Front-to-back rank of the owning window (0 = frontmost). Used to
+        /// break ties: two overlapping apps both "contain" the same point, and
+        /// only the one on top is what the user actually pointed at.
+        var windowOrder: Int
+        /// Depth below the application element (a window is 0).
+        var depth: Int
+        /// Index of the parent in `elements`, or nil for a window.
+        var parent: Int?
+
+        /// The best single name for this element, or nil when it has none.
+        var name: String? { title ?? label ?? identifier ?? placeholder ?? help }
+
+        var area: CGFloat { max(frame.width, 0) * max(frame.height, 0) }
+    }
+
+    /// An element together with what it took to find it: its owning app and the
+    /// chain of containers above it. Everything a caller needs to render the
+    /// element without walking the flat array itself.
+    struct Resolved: Sendable {
+        var element: Element
+        var application: Application
+        /// Ancestors, outermost first (window → … → the element's parent).
+        var ancestors: [Element]
+    }
+}
+
+// MARK: - Geometry
+
+extension AXSnapshot {
+
+    /// Maps a normalized image point (0…1, top-left) to the screen point it was
+    /// captured from.
+    func screenPoint(for normalized: CGPoint) -> CGPoint {
+        CGPoint(
+            x: captureRect.minX + normalized.x * captureRect.width,
+            y: captureRect.minY + normalized.y * captureRect.height
+        )
+    }
+
+    /// The inverse: a screen rect expressed in the image's normalized space.
+    /// Not clamped — an element wider than the capture keeps coordinates outside
+    /// 0…1, which is honest information (it sticks out of the frame).
+    func normalizedRect(for screenRect: CGRect) -> CGRect {
+        guard captureRect.width > 0, captureRect.height > 0 else { return .zero }
+        return CGRect(
+            x: (screenRect.minX - captureRect.minX) / captureRect.width,
+            y: (screenRect.minY - captureRect.minY) / captureRect.height,
+            width: screenRect.width / captureRect.width,
+            height: screenRect.height / captureRect.height
+        )
+    }
+
+    /// The same snapshot seen through a sub-rectangle of the image (normalized,
+    /// top-left) — what `EditorView.performCrop()` needs.
+    ///
+    /// Only `captureRect` moves: element frames are in screen space, so they
+    /// stay valid word for word. Elements are not dropped either, since a crop
+    /// can be undone (#44) and the ones outside simply stop matching.
+    func cropped(to rect: CGRect) -> AXSnapshot {
+        var copy = self
+        copy.captureRect = CGRect(
+            x: captureRect.minX + rect.minX * captureRect.width,
+            y: captureRect.minY + rect.minY * captureRect.height,
+            width: rect.width * captureRect.width,
+            height: rect.height * captureRect.height
+        )
+        return copy
+    }
+}
+
+// MARK: - Resolution
+
+extension AXSnapshot {
+
+    /// Roles that describe a *thing you can act on* — the answer an agent is
+    /// really after ("the Login button"), rather than the leaf that happens to
+    /// sit deepest under the pixel ("the label inside the Login button").
+    private static let actionableRoles: Set<String> = [
+        "AXButton", "AXPopUpButton", "AXMenuButton", "AXMenuItem", "AXCheckBox",
+        "AXRadioButton", "AXLink", "AXTextField", "AXTextArea", "AXSearchField",
+        "AXComboBox", "AXSlider", "AXStepper", "AXIncrementor", "AXDisclosureTriangle",
+        "AXTab", "AXRow", "AXCell", "AXColorWell", "AXSwitch", "AXToolbarButton"
+    ]
+
+    /// Roles that carry no meaning on their own: worth reporting only when
+    /// nothing better contains the point.
+    private static let passiveRoles: Set<String> = [
+        "AXStaticText", "AXImage", "AXUnknown", "AXGroup", "AXSplitGroup",
+        "AXScrollArea", "AXLayoutArea", "AXLayoutItem", "AXList", "AXTable",
+        "AXOutline", "AXToolbar", "AXSplitter", "AXScrollBar", "AXValueIndicator"
+    ]
+
+    /// The element a marker points at, or nil when the snapshot has nothing
+    /// under it (no permission, region outside any app, walk truncated…).
+    ///
+    /// Among everything whose frame contains the point, the winner is the one in
+    /// the frontmost window, then the **smallest**, then the deepest.
+    ///
+    /// Smallest and not deepest: depth reads like specificity and isn't. An
+    /// Electron window (Slack, VS Code…) nests generic `AXGroup` wrappers twenty
+    /// levels down while each of them still spans the whole window — rank by
+    /// depth and every marker anywhere in the app comes back as the same
+    /// anonymous group. Area is the honest measure of "this, not that", and
+    /// depth only breaks the tie between two elements sharing a frame, where the
+    /// inner one is the more precise answer.
+    ///
+    /// One correction is applied on top: when that leaf is decoration (the text
+    /// drawn *inside* a button, an icon inside a link), we hand back the nearest
+    /// actionable ancestor of roughly the same size instead. Naming the button
+    /// rather than its label is the whole point of the feature; the full chain is
+    /// reported either way, so nothing is lost.
+    func element(atNormalized point: CGPoint) -> Resolved? {
+        let screen = screenPoint(for: point)
+        let candidates = elements.indices.filter { elements[$0].frame.contains(screen) }
+        guard !candidates.isEmpty else { return nil }
+
+        let best = candidates.min { left, right in
+            let a = elements[left], b = elements[right]
+            if a.windowOrder != b.windowOrder { return a.windowOrder < b.windowOrder }
+            if a.area != b.area { return a.area < b.area }
+            return a.depth > b.depth
+        }
+        guard let best else { return nil }
+
+        let chosen = promoted(from: best)
+        let element = elements[chosen]
+        guard element.application < applications.count else { return nil }
+        return Resolved(element: element,
+                        application: applications[element.application],
+                        ancestors: ancestors(of: chosen))
+    }
+
+    /// Walks up from a decorative leaf to the control it belongs to. Stops as
+    /// soon as the ancestor grows much bigger than what was pointed at — a
+    /// button wrapping its own label is a promotion, a window wrapping a stray
+    /// icon is not.
+    private func promoted(from index: Int) -> Int {
+        guard Self.passiveRoles.contains(elements[index].role) else { return index }
+        let leafArea = max(elements[index].area, 1)
+
+        var current = elements[index].parent
+        var hops = 0
+        while let candidate = current, hops < 3 {
+            let element = elements[candidate]
+            guard element.area <= leafArea * 4 else { return index }
+            if Self.actionableRoles.contains(element.role) { return candidate }
+            current = element.parent
+            hops += 1
+        }
+        return index
+    }
+
+    /// The containers above `index`, outermost first, capped so a deeply nested
+    /// web view doesn't print a twenty-link path.
+    private func ancestors(of index: Int) -> [Element] {
+        var chain: [Element] = []
+        var current = elements[index].parent
+        while let parent = current, chain.count < 8 {
+            chain.append(elements[parent])
+            current = elements[parent].parent
+        }
+        return chain.reversed()
+    }
+}
+
+// MARK: - Description
+
+extension AXSnapshot.Element {
+    /// `AXButton “Login”`, or just `AXGroup` when the element has no name.
+    /// The role stays raw and the name is quoted, so the two can't blur into
+    /// each other when a label happens to look like a role.
+    var summary: String {
+        guard let name, !name.isEmpty else { return role }
+        return "\(role) “\(name)”"
+    }
+}
+
+extension AXSnapshot.Resolved {
+    /// `AXWindow “Sign in” › AXGroup › AXButton “Login”` — the element in its
+    /// context, one line, unambiguous to read either way round.
+    var path: String {
+        (ancestors.map(\.summary) + [element.summary]).joined(separator: " › ")
+    }
+}

--- a/Pinpoint/AXSnapshotCollector.swift
+++ b/Pinpoint/AXSnapshotCollector.swift
@@ -1,0 +1,455 @@
+import ApplicationServices
+import AppKit
+import CoreGraphics
+import QuartzCore
+
+/// Walks the accessibility tree over a captured region and freezes it into an
+/// `AXSnapshot`.
+///
+/// Three rules shape everything below, in this order:
+///
+/// 1. **A capture must never fail because of this.** Every path returns an
+///    optional and swallows its own errors; the caller treats `nil` as "no
+///    context", not as a failure.
+/// 2. **It must never block the UI.** The whole walk runs off the main actor,
+///    behind a hard wall-clock ceiling, and each individual accessibility call
+///    is bounded by `AXUIElementSetMessagingTimeout` so one unresponsive app
+///    can't stall the rest.
+/// 3. **It must never read a password.** Secure fields are recognised before
+///    their value is fetched, so the contents never enter the process at all —
+///    not "fetched then dropped".
+enum AXSnapshotCollector {
+
+    // MARK: - Limits
+    //
+    // A full tree walk of a browser is unbounded work: a content-heavy page can
+    // hold tens of thousands of nodes. These caps are what turn it into a fixed
+    // cost. Whichever is hit first, the walk stops and reports `truncated`.
+
+    /// Elements kept. Beyond this the snapshot stops growing — it also caps the
+    /// size of the sidecar written next to every capture in the history.
+    private static let maxElements = 900
+    /// Nodes looked at, kept or not. Guards against a deep tree that lies almost
+    /// entirely outside the region (each miss still costs two AX round trips).
+    private static let maxVisited = 20_000
+    /// How deep to descend. A web view can nest far past anything useful.
+    private static let maxDepth = 40
+    /// Applications whose windows are walked, frontmost first. Sized to absorb
+    /// the system processes that crowd the top of the window list (Control
+    /// Center alone owns one window per menu-bar icon) without pushing the
+    /// user's actual apps out of range.
+    private static let maxApplications = 8
+    /// Soft budget: checked inside the walk, which then returns what it has.
+    private static let walkBudget: CFTimeInterval = 1.5
+    /// Hard ceiling: if the walk hasn't answered by then, the capture goes on
+    /// without it. Only reachable if an accessibility call wedges past its own
+    /// timeout — the walk is otherwise self-limiting.
+    private static let hardCeiling: TimeInterval = 3.0
+    /// Per-message timeout for one app. Deliberately short: a hung app costs a
+    /// third of a second here, not the whole budget.
+    private static let messagingTimeout: Float = 0.35
+
+    // MARK: - Roles
+
+    /// Roles whose value is a password. Never read.
+    private static let secureRoles: Set<String> = ["AXSecureTextField", "AXSecureTextArea"]
+
+    /// Roles whose value is text the user typed. Withheld unless the user opted
+    /// in — see `AXContextSettings.includesFieldValues`.
+    private static let typedTextRoles: Set<String> = [
+        "AXTextField", "AXTextArea", "AXSearchField", "AXComboBox"
+    ]
+
+    /// Roles whose value is state rather than content (a checkbox's 0/1, a
+    /// slider's number, a static label's own text). Always safe to report: for
+    /// `AXStaticText` in particular the value *is* what the screenshot already
+    /// shows, so quoting it adds no exposure.
+    private static let statefulValueRoles: Set<String> = [
+        "AXStaticText", "AXCheckBox", "AXRadioButton", "AXSlider", "AXPopUpButton",
+        "AXMenuItem", "AXDisclosureTriangle", "AXStepper", "AXIncrementor",
+        "AXProgressIndicator", "AXLevelIndicator", "AXSwitch", "AXValueIndicator"
+    ]
+
+    /// Longest value string kept, in characters. A text area can hold a whole
+    /// document; the point here is to identify an element, not to mirror it.
+    private static let maxValueLength = 200
+
+    /// Longest name (title, label, help, placeholder) kept.
+    ///
+    /// Not a cosmetic cap. Real apps build labels by concatenation: a Slack
+    /// conversation row announces itself with the sender, the subject and the
+    /// last several messages, running to thousands of characters — text that is
+    /// partly scrolled out of the picture. Cutting at a length that still
+    /// identifies the element keeps the export readable *and* keeps it from
+    /// carrying more than the screenshot itself showed.
+    private static let maxNameLength = 120
+
+    // MARK: - Entry point
+
+    /// Reads the tree covering `region`, or returns nil when there's nothing to
+    /// report — no permission, no window, or the ceiling was hit.
+    ///
+    /// Call it *alongside* the screenshot rather than after it: the two then
+    /// describe the same instant, which is the whole contract of the snapshot.
+    static func capture(region: CaptureRegion, includeFieldValues: Bool) async -> AXSnapshot? {
+        guard AXPermission.isTrusted else { return nil }
+
+        let display = CGDisplayBounds(region.displayID)
+        let screenRect = screenRect(for: region, on: display)
+        guard screenRect.width >= 1, screenRect.height >= 1 else { return nil }
+
+        // Not `async let` over a detached task alone: cancelling a Swift task
+        // does nothing to an accessibility call already blocked in IPC, so the
+        // ceiling has to be able to answer *without* the walk. A one-shot box
+        // lets whichever finishes first resume, and lets the loser be ignored.
+        return await withCheckedContinuation { continuation in
+            let box = SingleResume(continuation)
+            Task.detached(priority: .userInitiated) {
+                box.resume(walk(screenRect: screenRect, display: display,
+                                includeFieldValues: includeFieldValues))
+            }
+            DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + hardCeiling) {
+                box.resume(nil)
+            }
+        }
+    }
+
+    /// The captured region in the accessibility APIs' own space: points, global
+    /// top-left origin. `CGDisplayBounds` already returns the display's origin
+    /// in exactly that space, so multiple displays and negative origins (#26)
+    /// need no special case — the sum simply works.
+    private static func screenRect(for region: CaptureRegion, on display: CGRect) -> CGRect {
+        CGRect(
+            x: display.minX + region.rect.minX,
+            y: display.minY + region.rect.minY,
+            width: region.rect.width,
+            height: region.rect.height
+        )
+    }
+
+    // MARK: - The walk
+
+    private static func walk(screenRect: CGRect, display: CGRect, includeFieldValues: Bool) -> AXSnapshot? {
+        var state = State(region: screenRect,
+                          includeFieldValues: includeFieldValues,
+                          deadline: CACurrentMediaTime() + walkBudget)
+
+        for (order, pid) in owningProcesses(over: screenRect, on: display).enumerated() {
+            guard !state.reachedElementLimit() else { break }
+
+            let application = AXUIElementCreateApplication(pid)
+            _ = AXUIElementSetMessagingTimeout(application, messagingTimeout)
+
+            let appIndex = state.applications.count
+            let running = NSRunningApplication(processIdentifier: pid)
+            state.applications.append(AXSnapshot.Application(
+                name: running?.localizedName,
+                bundleIdentifier: running?.bundleIdentifier,
+                processIdentifier: pid
+            ))
+
+            // The application element's children, not just `AXWindows`: that way
+            // an open menu or a popover — exactly what the capture timer exists
+            // to let people photograph — is walked like any other top-level
+            // container.
+            let roots = children(of: application) ?? []
+            for root in roots {
+                descend(root, parent: nil, depth: 0, application: appIndex,
+                        windowOrder: order, into: &state)
+            }
+        }
+
+        guard !state.elements.isEmpty else { return nil }
+        return AXSnapshot(
+            captureRect: screenRect,
+            applications: state.applications,
+            elements: state.elements,
+            truncated: state.truncated,
+            capturedAt: Date(),
+            includesFieldValues: includeFieldValues
+        )
+    }
+
+    /// Depth-first, parents recorded before their children so `parent` indices
+    /// always point backwards into the array.
+    ///
+    /// Pruning is by intersection with the captured region, not by containment
+    /// in the parent: an element whose box misses the region can't have anything
+    /// to say about it. (A child drawn outside its parent's frame — rare, and
+    /// only in clipped scroll content — is missed with it. The alternative is
+    /// walking every node of every window, which is the cost this exists to
+    /// avoid.)
+    private static func descend(_ element: AXUIElement, parent: Int?, depth: Int,
+                                application: Int, windowOrder: Int, into state: inout State) {
+        guard depth <= maxDepth, !state.reachedElementLimit() else { return }
+
+        state.visited += 1
+        if state.visited > maxVisited || CACurrentMediaTime() > state.deadline {
+            state.truncated = true
+            return
+        }
+
+        guard let frame = frame(of: element), frame.intersects(state.region) else { return }
+        guard let role = string(element, kAXRoleAttribute) else { return }
+
+        let index = state.elements.count
+        state.elements.append(describe(element, role: role, frame: frame, depth: depth,
+                                       parent: parent, application: application,
+                                       windowOrder: windowOrder,
+                                       includeFieldValues: state.includeFieldValues))
+
+        for child in children(of: element) ?? [] {
+            descend(child, parent: index, depth: depth + 1, application: application,
+                    windowOrder: windowOrder, into: &state)
+        }
+    }
+
+    /// Reads the attributes worth keeping. Two of them are conditional on
+    /// purpose: `AXHelp` only when nothing else names the element (it's usually
+    /// a whole sentence), `AXPlaceholderValue` only for inputs.
+    private static func describe(_ element: AXUIElement, role: String, frame: CGRect,
+                                 depth: Int, parent: Int?, application: Int, windowOrder: Int,
+                                 includeFieldValues: Bool) -> AXSnapshot.Element {
+        let title = string(element, kAXTitleAttribute)
+        let label = string(element, kAXDescriptionAttribute)
+        let identifier = string(element, kAXIdentifierAttribute)
+        let isInput = typedTextRoles.contains(role) || secureRoles.contains(role)
+
+        let (value, redaction) = readValue(element, role: role, includeFieldValues: includeFieldValues)
+
+        return AXSnapshot.Element(
+            role: role,
+            subrole: string(element, kAXSubroleAttribute),
+            title: title,
+            label: label,
+            identifier: identifier,
+            help: (title == nil && label == nil && identifier == nil)
+                ? string(element, kAXHelpAttribute) : nil,
+            placeholder: isInput ? string(element, kAXPlaceholderValueAttribute) : nil,
+            value: value,
+            redaction: redaction,
+            frame: frame,
+            enabled: bool(element, kAXEnabledAttribute),
+            application: application,
+            windowOrder: windowOrder,
+            depth: depth,
+            parent: parent
+        )
+    }
+
+    // MARK: - Values, and what is never read
+
+    /// The privacy gate. Returns the value to keep, or the reason there isn't
+    /// one.
+    ///
+    /// A capture leaves the machine — that's the point of the whole app — and the
+    /// accessibility tree is far more talkative than the pixels: it hands over
+    /// the *entire* contents of a field, including the part scrolled out of
+    /// sight, and it does so for the password field too. So:
+    ///
+    /// - secure fields are identified by role **or** subrole and never read;
+    /// - anything the user typed is withheld unless they explicitly opted in;
+    /// - state-like values (a checkbox, a slider, a label's own text) are kept,
+    ///   since they're already visible in the image;
+    /// - every other role's value is ignored, because "unknown role, unknown
+    ///   sensitivity" is not a bet worth taking.
+    private static func readValue(_ element: AXUIElement, role: String,
+                                  includeFieldValues: Bool) -> (String?, AXSnapshot.Redaction?) {
+        let subrole = string(element, kAXSubroleAttribute)
+        if secureRoles.contains(role) || isSecure(subrole) || isSecure(role) {
+            return (nil, .secureField)
+        }
+        if typedTextRoles.contains(role) {
+            guard includeFieldValues else { return (nil, .textFieldPolicy) }
+            return (text(of: element).map { truncate($0, to: maxValueLength) }, nil)
+        }
+        guard statefulValueRoles.contains(role) else { return (nil, nil) }
+        return (text(of: element).map { truncate($0, to: maxValueLength) }, nil)
+    }
+
+    /// Catches the roles and subroles Apple didn't name in a constant —
+    /// `AXSecureTextField` as a subrole, and anything a framework spells with
+    /// "password" in it.
+    private static func isSecure(_ token: String?) -> Bool {
+        guard let token = token?.lowercased() else { return false }
+        return token.contains("secure") || token.contains("password")
+    }
+
+    /// `AXValue` as a readable string. Numbers and booleans are formatted rather
+    /// than skipped: a checkbox's `1` is exactly the state an agent needs.
+    private static func text(of element: AXUIElement) -> String? {
+        guard let raw = copy(element, kAXValueAttribute) else { return nil }
+        let string: String?
+        switch raw {
+        case let value as String: string = value
+        case let value as NSNumber: string = value.stringValue
+        default: string = nil
+        }
+        guard let string else { return nil }
+        let flattened = string.components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        return flattened.isEmpty ? nil : flattened
+    }
+
+    private static func truncate(_ value: String, to limit: Int) -> String {
+        guard value.count > limit else { return value }
+        return String(value.prefix(limit)) + "…"
+    }
+
+    // MARK: - Which applications to walk
+
+    /// The processes owning on-screen windows over the region, frontmost first.
+    ///
+    /// Starting from the window list rather than from every running application
+    /// is what keeps this cheap: a machine with thirty apps open usually has two
+    /// or three of them showing anything inside a selection. The list's order is
+    /// front-to-back, which is also the tie-break used when two overlapping apps
+    /// both contain a marker's point.
+    ///
+    /// One correction is applied to that order, and it matters more than it
+    /// sounds. Some system processes keep a full-screen host window permanently
+    /// "on screen" above every app while showing nothing at all — Notification
+    /// Center's is the one you meet in practice: layer 21, 2880×1620, alpha 1,
+    /// present whether or not the panel is open. Ranked naively it sits in front
+    /// of every real window, and *every* marker on the screen resolves to
+    /// `AXWindow "Notification Center" › AXGroup`. Such windows are therefore
+    /// moved behind everything else rather than dropped, so a capture that
+    /// genuinely is of one still gets an answer — it just stops answering for
+    /// the app it was covering.
+    private static func owningProcesses(over rect: CGRect, on display: CGRect) -> [pid_t] {
+        let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+        guard let raw = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
+            return []
+        }
+
+        let ownPID = ProcessInfo.processInfo.processIdentifier
+        var ordered: [pid_t] = []
+        var deferred: [pid_t] = []
+        for window in raw {
+            guard let pid = window[kCGWindowOwnerPID as String] as? pid_t, pid != ownPID else { continue }
+            guard let bounds = window[kCGWindowBounds as String] as? [String: Any],
+                  let frame = CGRect(dictionaryRepresentation: bounds as CFDictionary),
+                  frame.intersects(rect) else { continue }
+
+            let layer = window[kCGWindowLayer as String] as? Int ?? 0
+            if isFullScreenOverlay(frame, layer: layer, display: display) {
+                if !deferred.contains(pid) { deferred.append(pid) }
+                continue
+            }
+            guard !ordered.contains(pid) else { continue }
+            ordered.append(pid)
+            if ordered.count == maxApplications { break }
+        }
+
+        // A process only reached through an overlay window still gets walked,
+        // last: its other windows (Notification Center's desktop widgets, say)
+        // are real, and it costs nothing to have an answer of last resort.
+        for pid in deferred where !ordered.contains(pid) && ordered.count < maxApplications {
+            ordered.append(pid)
+        }
+        return ordered
+    }
+
+    /// A window floating above the normal level (`layer > 0`) that covers
+    /// essentially a whole display. Menu-bar items, popovers and open menus all
+    /// float too, but they are small — the size is what separates a real overlay
+    /// the user can see from a host window parked over everything.
+    private static func isFullScreenOverlay(_ frame: CGRect, layer: Int, display: CGRect) -> Bool {
+        guard layer > 0 else { return false }
+        let covered = frame.intersection(display)
+        guard !covered.isNull, display.width > 0, display.height > 0 else { return false }
+        return (covered.width * covered.height) >= 0.9 * (display.width * display.height)
+    }
+
+    // MARK: - Accessibility plumbing
+
+    private static func copy(_ element: AXUIElement, _ attribute: String) -> AnyObject? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success else {
+            return nil
+        }
+        return value
+    }
+
+    private static func string(_ element: AXUIElement, _ attribute: String) -> String? {
+        guard let value = copy(element, attribute) as? String else { return nil }
+        // Newlines folded to spaces: these end up on a single line of the
+        // Markdown, where a raw \n would break the list item in two.
+        let flattened = value.components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        return flattened.isEmpty ? nil : truncate(flattened, to: maxNameLength)
+    }
+
+    private static func bool(_ element: AXUIElement, _ attribute: String) -> Bool? {
+        (copy(element, attribute) as? NSNumber)?.boolValue
+    }
+
+    private static func children(of element: AXUIElement) -> [AXUIElement]? {
+        copy(element, kAXChildrenAttribute) as? [AXUIElement]
+    }
+
+    /// `AXFrame` in one call — global, top-left, already flipped for us. It is
+    /// undocumented but universally implemented; `AXPosition` + `AXSize` is the
+    /// fallback for the handful of elements that don't answer it.
+    private static func frame(of element: AXUIElement) -> CGRect? {
+        if let value = copy(element, "AXFrame"), CFGetTypeID(value) == AXValueGetTypeID() {
+            var rect = CGRect.zero
+            if AXValueGetValue(value as! AXValue, .cgRect, &rect) { return rect }
+        }
+        guard let originValue = copy(element, kAXPositionAttribute),
+              let sizeValue = copy(element, kAXSizeAttribute),
+              CFGetTypeID(originValue) == AXValueGetTypeID(),
+              CFGetTypeID(sizeValue) == AXValueGetTypeID() else { return nil }
+        var origin = CGPoint.zero
+        var size = CGSize.zero
+        guard AXValueGetValue(originValue as! AXValue, .cgPoint, &origin),
+              AXValueGetValue(sizeValue as! AXValue, .cgSize, &size) else { return nil }
+        return CGRect(origin: origin, size: size)
+    }
+
+    // MARK: - Bookkeeping
+
+    private struct State {
+        let region: CGRect
+        let includeFieldValues: Bool
+        let deadline: CFTimeInterval
+        var applications: [AXSnapshot.Application] = []
+        var elements: [AXSnapshot.Element] = []
+        var visited = 0
+        var truncated = false
+
+        /// Stops the walk once the element budget is spent, marking the result
+        /// so a reader knows the snapshot is partial.
+        mutating func reachedElementLimit() -> Bool {
+            guard elements.count >= AXSnapshotCollector.maxElements else { return false }
+            truncated = true
+            return true
+        }
+    }
+}
+
+/// Resumes a continuation exactly once, whoever gets there first.
+///
+/// The walk and its wall-clock ceiling race each other and neither can cancel
+/// the other; this is what makes "first one wins, second one is dropped" safe
+/// rather than a double-resume crash.
+private final class SingleResume: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<AXSnapshot?, Never>?
+
+    init(_ continuation: CheckedContinuation<AXSnapshot?, Never>) {
+        self.continuation = continuation
+    }
+
+    func resume(_ value: AXSnapshot?) {
+        lock.lock()
+        let pending = continuation
+        continuation = nil
+        lock.unlock()
+        pending?.resume(returning: value)
+    }
+}

--- a/Pinpoint/AppDelegate.swift
+++ b/Pinpoint/AppDelegate.swift
@@ -163,7 +163,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
               let record = CaptureHistory.shared.records.first(where: { $0.id == id }),
               let image = CaptureHistory.shared.image(for: record) else { return }
         presentEditor(image: image, recordID: record.id,
-                      pins: record.pins, shapes: record.shapes, context: record.context)
+                      pins: record.pins, shapes: record.shapes, context: record.context,
+                      accessibility: CaptureHistory.shared.accessibility(for: record))
     }
 
     @objc private func clearHistory() {
@@ -177,9 +178,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     @objc private func captureFullScreen() {
         Task { @MainActor in
             do {
-                let image = try await ScreenCapture.captureDisplayUnderCursor()
-                let record = CaptureHistory.shared.add(image: image)
-                presentEditor(image: image, recordID: record?.id)
+                let capture = try await ScreenCapture.captureDisplayUnderCursor()
+                let record = CaptureHistory.shared.add(image: capture.image,
+                                                       accessibility: capture.accessibility)
+                presentEditor(image: capture.image, recordID: record?.id,
+                              accessibility: capture.accessibility)
             } catch {
                 presentCaptureError(error)
             }
@@ -243,9 +246,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             }
 
             do {
-                let image = try await ScreenCapture.captureRegion(region)
-                let record = CaptureHistory.shared.add(image: image)
-                presentEditor(image: image, recordID: record?.id)
+                let capture = try await ScreenCapture.captureRegion(region)
+                let record = CaptureHistory.shared.add(image: capture.image,
+                                                       accessibility: capture.accessibility)
+                presentEditor(image: capture.image, recordID: record?.id,
+                              accessibility: capture.accessibility)
             } catch {
                 presentCaptureError(error)
             }
@@ -307,17 +312,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     @MainActor
     private func presentEditor(image: NSImage, recordID: UUID?, sourceURL: URL? = nil,
-                               pins: [Pin] = [], shapes: [Markup] = [], context: String = "") {
+                               pins: [Pin] = [], shapes: [Markup] = [], context: String = "",
+                               accessibility: AXSnapshot? = nil) {
         let controller = EditorWindowController(
             image: image,
             initialPins: pins,
             initialShapes: shapes,
             initialContext: context,
+            initialAccessibility: accessibility,
             sourceURL: sourceURL,
-            onPersist: { pins, shapes, context, image in
+            onPersist: { pins, shapes, context, image, accessibility in
                 guard let recordID else { return }
                 CaptureHistory.shared.update(id: recordID, pins: pins, shapes: shapes, context: context)
                 CaptureHistory.shared.replaceImage(id: recordID, image: image)
+                // Only the crop moves the snapshot, but it moves both at once,
+                // so they're re-persisted together — a stale sidecar would point
+                // at a region the image no longer shows.
+                CaptureHistory.shared.replaceAccessibility(id: recordID, snapshot: accessibility)
                 if let sourceURL {
                     Self.writeCroppedFile(from: image, nextTo: sourceURL)
                 }

--- a/Pinpoint/CaptureHistory.swift
+++ b/Pinpoint/CaptureHistory.swift
@@ -29,8 +29,14 @@ final class CaptureHistory {
 
     /// Saves the raw image and prepends a new record. Returns it (or nil if the
     /// PNG couldn't be written).
+    ///
+    /// `accessibility` is the tree read at the same instant as the pixels
+    /// (#55), stored beside the PNG so reopening a capture from "Recent
+    /// captures" can still name the element under a marker placed days later.
+    /// Best effort: if the sidecar can't be written the capture is still
+    /// recorded, it just carries no interface details.
     @discardableResult
-    func add(image: NSImage) -> CaptureRecord? {
+    func add(image: NSImage, accessibility: AXSnapshot? = nil) -> CaptureRecord? {
         guard let png = Self.pngData(from: image) else { return nil }
         let id = UUID()
         let fileName = "\(id.uuidString).png"
@@ -48,7 +54,8 @@ final class CaptureHistory {
             height: Int(image.size.height.rounded()),
             pins: [],
             shapes: [],
-            context: ""
+            context: "",
+            axFileName: writeSidecar(accessibility, for: id)
         )
         records.insert(record, at: 0)
         prune()
@@ -83,9 +90,22 @@ final class CaptureHistory {
         saveIndex()
     }
 
+    /// Replaces the accessibility snapshot of an existing record — what a crop
+    /// (#21) produces, since it narrows the region the snapshot describes.
+    ///
+    /// A nil snapshot deletes the sidecar rather than leaving a stale one: after
+    /// a crop, the old file would describe a region the image no longer shows.
+    func replaceAccessibility(id: UUID, snapshot: AXSnapshot?) {
+        guard let index = records.firstIndex(where: { $0.id == id }) else { return }
+        removeSidecar(records[index])
+        records[index].axFileName = writeSidecar(snapshot, for: id)
+        saveIndex()
+    }
+
     func clear() {
         for record in records {
             try? fileManager.removeItem(at: directory.appendingPathComponent(record.imageFileName))
+            removeSidecar(record)
         }
         records.removeAll()
         saveIndex()
@@ -104,14 +124,27 @@ final class CaptureHistory {
         return image
     }
 
+    /// The accessibility snapshot stored with a record, if any. Read lazily —
+    /// only the capture being edited needs it, and decoding all fifteen at
+    /// launch would be pure waste.
+    func accessibility(for record: CaptureRecord) -> AXSnapshot? {
+        guard let name = record.axFileName,
+              let data = try? Data(contentsOf: directory.appendingPathComponent(name)) else { return nil }
+        return try? JSONDecoder().decode(AXSnapshot.self, from: data)
+    }
+
     // MARK: - Persistence
 
     private func load() {
         guard let data = try? Data(contentsOf: indexURL),
               let decoded = try? JSONDecoder().decode([CaptureRecord].self, from: data) else { return }
-        // Keep only records whose image file still exists.
-        records = decoded.filter {
-            fileManager.fileExists(atPath: directory.appendingPathComponent($0.imageFileName).path)
+        // Keep only records whose image file still exists — and take their
+        // accessibility sidecars down with them, so a hand-deleted PNG doesn't
+        // leave an orphan JSON behind forever.
+        records = decoded.filter { record in
+            let alive = fileManager.fileExists(atPath: directory.appendingPathComponent(record.imageFileName).path)
+            if !alive { removeSidecar(record) }
+            return alive
         }
     }
 
@@ -124,8 +157,30 @@ final class CaptureHistory {
         guard records.count > maxEntries else { return }
         for record in records[maxEntries...] {
             try? fileManager.removeItem(at: directory.appendingPathComponent(record.imageFileName))
+            removeSidecar(record)
         }
         records.removeLast(records.count - maxEntries)
+    }
+
+    // MARK: - Accessibility sidecar
+
+    /// Writes `snapshot` as `<uuid>-ax.json` and returns its file name, or nil
+    /// when there was nothing to write or the write failed. Never throws: a
+    /// missing sidecar costs the interface details, nothing else.
+    private func writeSidecar(_ snapshot: AXSnapshot?, for id: UUID) -> String? {
+        guard let snapshot, let data = try? JSONEncoder().encode(snapshot) else { return nil }
+        let name = "\(id.uuidString)-ax.json"
+        do {
+            try data.write(to: directory.appendingPathComponent(name), options: .atomic)
+        } catch {
+            return nil
+        }
+        return name
+    }
+
+    private func removeSidecar(_ record: CaptureRecord) {
+        guard let name = record.axFileName else { return }
+        try? fileManager.removeItem(at: directory.appendingPathComponent(name))
     }
 
     /// Encodes an NSImage as PNG. Static so callers outside this type (e.g. the

--- a/Pinpoint/CaptureRecord.swift
+++ b/Pinpoint/CaptureRecord.swift
@@ -15,4 +15,13 @@ struct CaptureRecord: Codable, Identifiable, Equatable {
     var pins: [Pin]
     var shapes: [Markup]
     var context: String
+    /// Name of the accessibility sidecar (`<uuid>-ax.json`) in the same
+    /// directory, when one was written (#55).
+    ///
+    /// A sidecar rather than a field on this record: a snapshot runs to a few
+    /// hundred elements, and `index.json` is read in full at every launch. Nil
+    /// for captures taken before the feature existed, taken without the
+    /// Accessibility permission, or taken with it switched off — which is also
+    /// why decoding an older index still works: an absent key decodes to nil.
+    var axFileName: String?
 }

--- a/Pinpoint/EditorHistory.swift
+++ b/Pinpoint/EditorHistory.swift
@@ -20,6 +20,11 @@ struct EditorSnapshot {
     /// back, and undoing a placement restores whatever was selected before.
     var selectedPinID: Pin.ID?
     var selectedShapeID: Markup.ID?
+    /// The accessibility snapshot (#55). Only a crop changes it — it narrows
+    /// the screen region the snapshot describes — so undoing a crop has to put
+    /// the wide one back, or the markers would be read against a region the
+    /// restored image no longer matches.
+    var accessibility: AXSnapshot?
 }
 
 extension EditorSnapshot: Equatable {
@@ -30,6 +35,11 @@ extension EditorSnapshot: Equatable {
     /// Images compare by identity — pixel comparison would be pointless work,
     /// and every image change in the editor comes from a crop, which always
     /// produces a new instance.
+    ///
+    /// The accessibility snapshot is excluded for the same reason and for one
+    /// more: it only ever moves with the image, which is already compared here,
+    /// and comparing several hundred element frames on every edit would be real
+    /// work done to learn nothing.
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.image === rhs.image
             && lhs.pins == rhs.pins

--- a/Pinpoint/EditorView.swift
+++ b/Pinpoint/EditorView.swift
@@ -111,8 +111,11 @@ struct EditorView: View {
     private let sourceURL: URL?
     var onClose: () -> Void
     /// Called with the current annotation state and base image so they can be
-    /// persisted to history (on copy and when the editor closes).
-    var onPersist: ([Pin], [Markup], String, NSImage) -> Void
+    /// persisted to history (on copy and when the editor closes). The
+    /// accessibility snapshot rides along because a crop narrows it: the two
+    /// have to be written back together or they'd disagree about which region
+    /// the image shows.
+    var onPersist: ([Pin], [Markup], String, NSImage, AXSnapshot?) -> Void
 
     @AppStorage(PinStyle.storageKey) private var pinStyle: PinStyle = .disc
     @AppStorage("includeLegend") private var includeLegend = true
@@ -120,6 +123,11 @@ struct EditorView: View {
     @State private var pins: [Pin] = []
     @State private var shapes: [Markup] = []
     @State private var context: String = ""
+    /// The accessibility tree as it stood when the capture was taken (#55), or
+    /// nil when the feature was off, unauthorized, or found nothing. Used to
+    /// name the element under each marker at export time — never queried live,
+    /// since by now the photographed UI may be long gone.
+    @State private var axSnapshot: AXSnapshot?
     @State private var tool: EditorTool = .pin
     @State private var selectedPinID: Pin.ID?
     @State private var selectedShapeID: Markup.ID?
@@ -167,8 +175,9 @@ struct EditorView: View {
         initialPins: [Pin] = [],
         initialShapes: [Markup] = [],
         initialContext: String = "",
+        initialAccessibility: AXSnapshot? = nil,
         sourceURL: URL? = nil,
-        onPersist: @escaping ([Pin], [Markup], String, NSImage) -> Void = { _, _, _, _ in },
+        onPersist: @escaping ([Pin], [Markup], String, NSImage, AXSnapshot?) -> Void = { _, _, _, _, _ in },
         onClose: @escaping () -> Void
     ) {
         _image = State(initialValue: image)
@@ -178,6 +187,7 @@ struct EditorView: View {
         _pins = State(initialValue: initialPins)
         _shapes = State(initialValue: initialShapes)
         _context = State(initialValue: initialContext)
+        _axSnapshot = State(initialValue: initialAccessibility)
     }
 
     var body: some View {
@@ -194,7 +204,7 @@ struct EditorView: View {
                 .frame(minWidth: 260, idealWidth: 280, maxWidth: 360)
         }
         .frame(minWidth: 680, minHeight: 440)
-        .onDisappear { onPersist(pins, shapes, context, image) }
+        .onDisappear { onPersist(pins, shapes, context, image, axSnapshot) }
         // A text field changing hands closes one typing session and opens the
         // next. See `flushTextEdit()`.
         .onChange(of: focusedField) { _, newValue in
@@ -1073,11 +1083,12 @@ struct EditorView: View {
 
     private func copy() {
         guard Exporter.copyToPasteboard(base: image, pins: pins, shapes: shapes, context: context,
-                                        style: pinStyle, includeLegend: includeLegend) else {
+                                        style: pinStyle, includeLegend: includeLegend,
+                                        accessibility: axSnapshot) else {
             exportError = String(localized: "Nothing was written to the clipboard. The annotated image couldn’t be rendered.")
             return
         }
-        onPersist(pins, shapes, context, image)
+        onPersist(pins, shapes, context, image, axSnapshot)
 
         // The clipboard is only half of it. An agent that can’t render a pasted
         // image — Claude Code being the case that started this — still reads the
@@ -1086,7 +1097,7 @@ struct EditorView: View {
         // that never landed is exactly what #38 stopped doing elsewhere.
         do {
             try FileHandoff.write(base: image, pins: pins, shapes: shapes,
-                                  context: context, style: pinStyle)
+                                  context: context, style: pinStyle, accessibility: axSnapshot)
         } catch {
             exportError = String(
                 localized: "handoff.error.body",
@@ -1121,7 +1132,7 @@ struct EditorView: View {
             exportError = error.localizedDescription
             return
         }
-        onPersist(pins, shapes, context, image)
+        onPersist(pins, shapes, context, image, axSnapshot)
     }
 
     // MARK: - Undo / redo
@@ -1141,7 +1152,8 @@ struct EditorView: View {
             shapes: shapes,
             context: context,
             selectedPinID: selectedPinID,
-            selectedShapeID: selectedShapeID
+            selectedShapeID: selectedShapeID,
+            accessibility: axSnapshot
         )
     }
 
@@ -1209,6 +1221,7 @@ struct EditorView: View {
         pins = state.pins
         shapes = state.shapes
         context = state.context
+        axSnapshot = state.accessibility
         // Selection travels with the snapshot, but is re-validated against the
         // restored arrays: it must never point at something that isn't there.
         selectedPinID = state.pins.contains { $0.id == state.selectedPinID } ? state.selectedPinID : nil
@@ -1306,6 +1319,9 @@ struct EditorView: View {
         image = newImage
         pins = newPins
         shapes = newShapes
+        // The snapshot describes a screen region, not the image, so a crop only
+        // has to narrow that region — every element frame stays valid as it is.
+        axSnapshot = axSnapshot?.cropped(to: c)
         selectedPinID = nil
         selectedShapeID = nil
         withMotion(.easeInOut(duration: 0.15)) { isCropping = false }

--- a/Pinpoint/EditorWindowController.swift
+++ b/Pinpoint/EditorWindowController.swift
@@ -10,8 +10,9 @@ final class EditorWindowController: NSWindowController, NSWindowDelegate {
         initialPins: [Pin] = [],
         initialShapes: [Markup] = [],
         initialContext: String = "",
+        initialAccessibility: AXSnapshot? = nil,
         sourceURL: URL? = nil,
-        onPersist: @escaping ([Pin], [Markup], String, NSImage) -> Void = { _, _, _, _ in }
+        onPersist: @escaping ([Pin], [Markup], String, NSImage, AXSnapshot?) -> Void = { _, _, _, _, _ in }
     ) {
         // Size the window to the image, capped to a comfortable on-screen size.
         let maxSize = NSSize(width: 1100, height: 760)
@@ -39,6 +40,7 @@ final class EditorWindowController: NSWindowController, NSWindowDelegate {
             initialPins: initialPins,
             initialShapes: initialShapes,
             initialContext: initialContext,
+            initialAccessibility: initialAccessibility,
             sourceURL: sourceURL,
             onPersist: onPersist
         ) { [weak window] in

--- a/Pinpoint/Exporter.swift
+++ b/Pinpoint/Exporter.swift
@@ -189,7 +189,8 @@ enum Exporter {
     /// image (top-left origin), so the agent can locate every annotation
     /// without reading the pixels — then the user's instructions in their own
     /// section.
-    static func buildText(pins: [Pin], shapes: [Markup] = [], context: String, imageSize: CGSize) -> String {
+    static func buildText(pins: [Pin], shapes: [Markup] = [], context: String, imageSize: CGSize,
+                          accessibility: AXSnapshot? = nil) -> String {
         let width = Int(imageSize.width.rounded())
         let height = Int(imageSize.height.rounded())
         let orderedPins = pins.sorted { $0.number < $1.number }
@@ -211,16 +212,32 @@ enum Exporter {
             lines.append(String(localized: "export.coordinates", defaultValue: "Positions are given in pixels from the top-left corner (0, 0), then as a percentage of the image size."))
         }
 
+        // Kept only when at least one marker actually resolves to an element:
+        // an empty snapshot must not print a legend promising details that never
+        // come, and must leave the text byte-identical to what it was before.
+        let snapshot = accessibility.flatMap { candidate in
+            orderedPins.contains { candidate.element(atNormalized: $0.position) != nil } ? candidate : nil
+        }
+
         if !orderedPins.isEmpty {
             lines.append("")
             lines.append("## " + String(localized: "Markers"))
             lines.append(String(localized: "export.markers.legend", defaultValue: "M1, M2… are the numbers drawn on the image; the code in brackets is a stable ID for that marker."))
+            if snapshot != nil {
+                lines.append(String(localized: "export.markers.accessibility.legend", defaultValue: "“UI” lines name the interface element found under the marker in the macOS accessibility tree at capture time — its role, its label, the app owning it, and its box in this image. “Path” is the chain of containers around it."))
+            }
             lines.append("")
             for pin in orderedPins {
                 let note = pin.note.trimmingCharacters(in: .whitespacesAndNewlines)
                 let description = note.isEmpty ? String(localized: "(no description)") : note
                 lines.append("- M\(pin.number) [\(pin.id.shortToken)] · \(description) — "
                              + "\(pixels(pin.position, in: imageSize)) px · \(percent(pin.position))")
+                // The interface element the marker landed on, read from the
+                // accessibility tree while the capture was taken (#55). Indented
+                // under its marker so the association is positional and can't be
+                // misread, and left out entirely when there's nothing to say.
+                lines.append(contentsOf: accessibilityLines(for: pin.position,
+                                                            snapshot: snapshot, imageSize: imageSize))
             }
         }
 
@@ -255,6 +272,69 @@ enum Exporter {
             lines.append(ctx)
         }
         return lines.joined(separator: "\n")
+    }
+
+    /// The two-or-three indented lines describing what sits under a marker, or
+    /// nothing at all when the snapshot has no element there.
+    ///
+    /// Written for both readers at once: a human scanning the file sees a
+    /// sentence, an agent sees `key: value` fields it can lift verbatim. The
+    /// role stays in its raw accessibility spelling (`AXButton`) because that is
+    /// the vocabulary shared with every inspector, and with the code that
+    /// created the element in the first place.
+    private static func accessibilityLines(for position: CGPoint, snapshot: AXSnapshot?,
+                                           imageSize: CGSize) -> [String] {
+        guard let snapshot, let resolved = snapshot.element(atNormalized: position) else { return [] }
+        let element = resolved.element
+
+        var facts: [String] = [element.summary]
+        if let identifier = element.identifier, identifier != element.name {
+            facts.append("id=\(identifier)")
+        }
+        if let subrole = element.subrole { facts.append("subrole=\(subrole)") }
+        if let bundle = resolved.application.bundleIdentifier ?? resolved.application.name {
+            facts.append(bundle)
+        }
+        facts.append(box(element.frame, snapshot: snapshot, imageSize: imageSize))
+        if element.enabled == false { facts.append(String(localized: "export.ax.disabled", defaultValue: "disabled")) }
+
+        // `UI:`, `Value:` and `Path:` stay in English like `M1` and `px`: they
+        // are field names in a machine-read file, not prose. Only the sentences
+        // a human might read are localized.
+        var lines = ["  - UI: " + facts.joined(separator: " · ")]
+        if let value = element.value {
+            lines.append("  - Value: “\(value)”")
+        } else if let redaction = element.redaction {
+            lines.append("  - Value: " + redactionNote(redaction))
+        }
+        lines.append("  - Path: " + resolved.path)
+        return lines
+    }
+
+    /// An element's screen frame restated in the image's own pixel grid, so it
+    /// lines up with every other coordinate in this file. Not clamped: a box
+    /// reaching past the edges is an element that sticks out of the capture,
+    /// which is worth knowing rather than hiding.
+    private static func box(_ frame: CGRect, snapshot: AXSnapshot, imageSize: CGSize) -> String {
+        let rect = snapshot.normalizedRect(for: frame)
+        let x = Int((rect.minX * imageSize.width).rounded())
+        let y = Int((rect.minY * imageSize.height).rounded())
+        let width = Int((rect.width * imageSize.width).rounded())
+        let height = Int((rect.height * imageSize.height).rounded())
+        return "box (\(x), \(y)) \(width)×\(height) px"
+    }
+
+    /// Says plainly that a value exists and was withheld, rather than leaving a
+    /// silent gap an agent might read as "the field was empty".
+    private static func redactionNote(_ redaction: AXSnapshot.Redaction) -> String {
+        switch redaction {
+        case .secureField:
+            return String(localized: "export.ax.value.secure",
+                          defaultValue: "withheld (secure field — Pinpoint never reads it)")
+        case .textFieldPolicy:
+            return String(localized: "export.ax.value.policy",
+                          defaultValue: "withheld (text field — enable “Include what is typed in fields” in Pinpoint’s settings)")
+        }
     }
 
     /// `(1075, 259)` — a normalized point in the image's pixel grid, top-left origin.
@@ -399,7 +479,8 @@ enum Exporter {
     /// happened.
     @discardableResult
     static func copyToPasteboard(base: NSImage, pins: [Pin], shapes: [Markup], context: String,
-                                 style: PinStyle, includeLegend: Bool) -> Bool {
+                                 style: PinStyle, includeLegend: Bool,
+                                 accessibility: AXSnapshot? = nil) -> Bool {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
 
@@ -410,7 +491,8 @@ enum Exporter {
         }
 
         if !includeLegend {
-            let text = buildText(pins: pins, shapes: shapes, context: context, imageSize: base.size)
+            let text = buildText(pins: pins, shapes: shapes, context: context, imageSize: base.size,
+                                 accessibility: accessibility)
             wrote = pasteboard.setString(text, forType: .string) || wrote
         }
 

--- a/Pinpoint/FileHandoff.swift
+++ b/Pinpoint/FileHandoff.swift
@@ -27,9 +27,10 @@ enum FileHandoff {
     /// Version of the JSON contract written to `capture.json`.
     ///
     /// Bumped only on a *breaking* change — a key removed, renamed, or given a
-    /// new meaning. Adding keys is not breaking: issue #55 will hang an
-    /// `accessibility` object off each marker, and a consumer written against
-    /// version 1 has to keep working. Read what you know, ignore the rest.
+    /// new meaning. Adding keys is not breaking, which is why #55 hanging an
+    /// `accessibility` object off each marker (and one on the document) left
+    /// this at 1: a consumer written against version 1 reads exactly what it
+    /// read before. Read what you know, ignore the rest.
     static let schemaVersion = 1
 
     /// How many timestamped folders `archive/` keeps; the oldest are deleted on
@@ -105,7 +106,8 @@ enum FileHandoff {
     /// failure there only leaves `Output.archive` nil.
     @discardableResult
     static func write(base: NSImage, pins: [Pin], shapes: [Markup],
-                      context: String, style: PinStyle) throws -> Output {
+                      context: String, style: PinStyle,
+                      accessibility: AXSnapshot? = nil) throws -> Output {
         // No legend strip, whatever the editor's `includeLegend` setting says.
         // The legend grows the image downwards, which would shift every pixel
         // coordinate in the .md and .json off the pixels they describe — and
@@ -131,15 +133,18 @@ enum FileHandoff {
         // default configuration, where the clipboard only carries the image
         // (#69).
         let markdown = Exporter.buildText(pins: pins, shapes: shapes,
-                                          context: context, imageSize: pixelSize)
+                                          context: context, imageSize: pixelSize,
+                                          accessibility: accessibility)
 
         let latest = latestDirectory
         try replaceDirectory(latest, with: files(png: png, markdown: markdown,
                                                  pins: pins, shapes: shapes, context: context,
-                                                 imageSize: pixelSize, directory: latest))
+                                                 imageSize: pixelSize, directory: latest,
+                                                 accessibility: accessibility))
 
         let archived = try? archive(png: png, markdown: markdown, pins: pins, shapes: shapes,
-                                    context: context, imageSize: pixelSize)
+                                    context: context, imageSize: pixelSize,
+                                    accessibility: accessibility)
 
         return Output(
             directory: latest,
@@ -154,10 +159,11 @@ enum FileHandoff {
     /// is where they will *end up*: the JSON quotes absolute paths, so it has to
     /// be built for its final home, not for the staging folder.
     private static func files(png: Data, markdown: String, pins: [Pin], shapes: [Markup],
-                              context: String, imageSize: CGSize,
-                              directory: URL) throws -> [(name: String, data: Data)] {
+                              context: String, imageSize: CGSize, directory: URL,
+                              accessibility: AXSnapshot?) throws -> [(name: String, data: Data)] {
         let document = Document(pins: pins, shapes: shapes, context: context,
-                                imageSize: imageSize, directory: directory)
+                                imageSize: imageSize, directory: directory,
+                                accessibility: accessibility)
         let encoder = JSONEncoder()
         // Pretty-printed, key-sorted and unescaped: a human debugging this reads
         // it, `\/Users\/…` for every path is noise, and a fixed key order keeps
@@ -200,11 +206,13 @@ enum FileHandoff {
 
     /// Writes a timestamped copy of the handoff and prunes the oldest ones.
     private static func archive(png: Data, markdown: String, pins: [Pin], shapes: [Markup],
-                                context: String, imageSize: CGSize) throws -> URL {
+                                context: String, imageSize: CGSize,
+                                accessibility: AXSnapshot?) throws -> URL {
         let folder = archiveDirectory.appendingPathComponent(timestamp(), isDirectory: true)
         try replaceDirectory(folder, with: files(png: png, markdown: markdown,
                                                  pins: pins, shapes: shapes, context: context,
-                                                 imageSize: imageSize, directory: folder))
+                                                 imageSize: imageSize, directory: folder,
+                                                 accessibility: accessibility))
         prune()
         return folder
     }

--- a/Pinpoint/HandoffDocument.swift
+++ b/Pinpoint/HandoffDocument.swift
@@ -27,6 +27,12 @@ extension FileHandoff {
         /// (the key is always present, so a consumer never has to branch on its
         /// absence).
         let context: String
+        /// What the accessibility tree contributed, or absent when it
+        /// contributed nothing (feature off, permission not granted, no element
+        /// under any marker). Present with `available: false` only when a walk
+        /// happened and came back thin, so a consumer can tell "not looked at"
+        /// from "looked at, found nothing".
+        let accessibility: AccessibilityContext?
         let markers: [Marker]
         let shapes: [Shape]
 
@@ -66,12 +72,92 @@ extension FileHandoff {
             let heightPercent: Double
         }
 
-        /// A numbered marker.
+        /// Snapshot-wide facts about the accessibility pass (#55). Lets a
+        /// consumer reason about *why* a marker has no element attached.
+        struct AccessibilityContext: Encodable {
+            /// Whether at least one element was collected.
+            let available: Bool
+            /// ISO 8601 instant the tree was read — the capture instant.
+            let capturedAt: String
+            /// How many elements the snapshot holds, across every app walked.
+            let elementCount: Int
+            /// `true` when the walk stopped on one of its own limits (time,
+            /// node budget). A missing element may then mean "not looked at".
+            let truncated: Bool
+            /// What was deliberately left out, so nobody has to guess whether a
+            /// missing `value` means "empty" or "withheld".
+            let policy: Policy
+
+            struct Policy: Encodable {
+                /// Always true. Password fields are never read, at any setting.
+                let secureFieldValuesOmitted: Bool
+                /// True unless the user opted in: the text typed in ordinary
+                /// fields is withheld by default, because the accessibility
+                /// tree hands over the whole field — including the part that was
+                /// scrolled out of the picture.
+                let textFieldValuesOmitted: Bool
+            }
+        }
+
+        /// The interface element found under a marker.
         ///
-        /// Issue #55 will add an `accessibility` object here (the element under
-        /// the marker, read from the accessibility tree at capture time). That's
-        /// an addition, so `schemaVersion` stays at 1 — consumers must tolerate
-        /// keys they don't know.
+        /// This is the point of the whole file: a marker is a pixel, and a pixel
+        /// is not something you can go and edit. `role` + `identifier` + `path`
+        /// are what turn it into a thing with a name in somebody's source code.
+        struct AccessibilityElement: Encodable {
+            /// Raw accessibility role, e.g. "AXButton". Not translated into
+            /// prose on purpose — it's the vocabulary every inspector shares.
+            let role: String
+            let subrole: String?
+            /// `AXTitle` — the control's visible label.
+            let title: String?
+            /// `AXDescription` — what a screen reader announces.
+            let label: String?
+            /// `AXIdentifier`, usually the `accessibilityIdentifier` written in
+            /// the app's own source. The most directly actionable field here.
+            let identifier: String?
+            /// `AXHelp`, only collected when nothing else named the element.
+            let help: String?
+            /// `AXPlaceholderValue`, for inputs.
+            let placeholder: String?
+            /// The element's value — present only when the privacy policy allows
+            /// it (see `redacted`).
+            let value: String?
+            /// Why `value` is absent: "secureField" (never read) or
+            /// "textFieldPolicy" (withheld by default). Absent when the element
+            /// simply has no value worth reporting.
+            let redacted: String?
+            let enabled: Bool?
+            /// The element's box in *this image's* pixel grid, the same one
+            /// every other coordinate in this file uses. May fall outside the
+            /// image when the element extends past the captured region.
+            let box: Box
+            /// The same box in screen points, global top-left origin — the
+            /// space the macOS accessibility APIs speak, for a consumer that
+            /// wants to go back and drive the live UI.
+            let screenFrame: ScreenFrame
+            let application: Application
+            /// Containers around the element, outermost first, each rendered as
+            /// `AXRole “Name”`.
+            let path: [String]
+
+            struct Application: Encodable {
+                let name: String?
+                let bundleIdentifier: String?
+                let processIdentifier: Int32
+            }
+
+            /// Points, global top-left origin. Not percentages: this rect isn't
+            /// relative to the image.
+            struct ScreenFrame: Encodable {
+                let x: Double
+                let y: Double
+                let width: Double
+                let height: Double
+            }
+        }
+
+        /// A numbered marker.
         struct Marker: Encodable {
             /// Stable identifier, the same code `capture.md` prints in brackets.
             /// Survives the renumbering that follows a deletion, so two handoffs
@@ -84,6 +170,11 @@ extension FileHandoff {
             /// The user's description. Empty when they left it blank.
             let note: String
             let position: Point
+            /// The interface element under `position`, resolved against the
+            /// snapshot taken at capture time. Absent when there is none —
+            /// which is the normal case for a capture of something that isn't
+            /// an app window, or with the feature switched off.
+            let accessibility: AccessibilityElement?
         }
 
         /// An unnumbered outline: arrow or rectangle.
@@ -108,7 +199,8 @@ extension FileHandoff {
 extension FileHandoff.Document {
     /// Builds the document for a set of annotations. `directory` is where the
     /// triplet will live, since the absolute paths below point at its siblings.
-    init(pins: [Pin], shapes: [Markup], context: String, imageSize: CGSize, directory: URL) {
+    init(pins: [Pin], shapes: [Markup], context: String, imageSize: CGSize, directory: URL,
+         accessibility: AXSnapshot? = nil) {
         self.schemaVersion = FileHandoff.schemaVersion
         self.generator = Generator(
             name: "Pinpoint",
@@ -125,14 +217,16 @@ extension FileHandoff.Document {
         self.markdownPath = directory.appendingPathComponent(FileHandoff.markdownFileName).path
         self.context = context.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        self.markers = pins.sorted { $0.number < $1.number }.map { pin in
-            Marker(
-                id: pin.id.shortToken,
-                label: "M\(pin.number)",
-                number: pin.number,
-                note: pin.note.trimmingCharacters(in: .whitespacesAndNewlines),
-                position: Point(pin.position, in: imageSize)
-            )
+        let ordered = pins.sorted { $0.number < $1.number }
+        if let snapshot = accessibility {
+            self.markers = ordered.map { pin in
+                Marker(pin, in: imageSize, accessibility: snapshot.element(atNormalized: pin.position)
+                    .map { AccessibilityElement($0, in: snapshot, imageSize: imageSize) })
+            }
+            self.accessibility = AccessibilityContext(snapshot, formatter: formatter)
+        } else {
+            self.markers = ordered.map { Marker($0, in: imageSize, accessibility: nil) }
+            self.accessibility = nil
         }
 
         self.shapes = shapes.enumerated().map { index, shape in
@@ -193,5 +287,70 @@ extension FileHandoff {
     /// this is for computing against.
     static func percent(_ value: CGFloat) -> Double {
         (Double(value) * 10_000).rounded() / 100
+    }
+}
+
+extension FileHandoff.Document.Marker {
+    init(_ pin: Pin, in size: CGSize,
+         accessibility: FileHandoff.Document.AccessibilityElement?) {
+        self.init(
+            id: pin.id.shortToken,
+            label: "M\(pin.number)",
+            number: pin.number,
+            note: pin.note.trimmingCharacters(in: .whitespacesAndNewlines),
+            position: FileHandoff.Document.Point(pin.position, in: size),
+            accessibility: accessibility
+        )
+    }
+}
+
+extension FileHandoff.Document.AccessibilityContext {
+    init(_ snapshot: AXSnapshot, formatter: ISO8601DateFormatter) {
+        self.init(
+            available: !snapshot.elements.isEmpty,
+            capturedAt: formatter.string(from: snapshot.capturedAt),
+            elementCount: snapshot.elements.count,
+            truncated: snapshot.truncated,
+            policy: Policy(
+                // Not a setting: no code path reads the value of a secure field,
+                // so this is a statement of fact rather than a configuration.
+                secureFieldValuesOmitted: true,
+                textFieldValuesOmitted: !snapshot.includesFieldValues
+            )
+        )
+    }
+}
+
+extension FileHandoff.Document.AccessibilityElement {
+    /// Restates one resolved element in the handoff's own terms: screen points
+    /// become image pixels, the ancestor chain becomes a list of strings, and
+    /// the redaction reason becomes a plain token a script can switch on.
+    init(_ resolved: AXSnapshot.Resolved, in snapshot: AXSnapshot, imageSize: CGSize) {
+        let element = resolved.element
+        self.init(
+            role: element.role,
+            subrole: element.subrole,
+            title: element.title,
+            label: element.label,
+            identifier: element.identifier,
+            help: element.help,
+            placeholder: element.placeholder,
+            value: element.value,
+            redacted: element.redaction?.rawValue,
+            enabled: element.enabled,
+            box: FileHandoff.Document.Box(snapshot.normalizedRect(for: element.frame), in: imageSize),
+            screenFrame: ScreenFrame(
+                x: Double(element.frame.minX),
+                y: Double(element.frame.minY),
+                width: Double(element.frame.width),
+                height: Double(element.frame.height)
+            ),
+            application: Application(
+                name: resolved.application.name,
+                bundleIdentifier: resolved.application.bundleIdentifier,
+                processIdentifier: resolved.application.processIdentifier
+            ),
+            path: (resolved.ancestors.map(\.summary) + [element.summary])
+        )
     }
 }

--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -420,6 +420,48 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Copier pour l’agent" } }
       }
     },
+    "export.ax.disabled" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "disabled" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "désactivé" } }
+      }
+    },
+    "export.ax.value.policy" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "withheld (text field — enable “Include what is typed in fields” in Pinpoint’s settings)" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "masquée (champ texte — activez « Inclure ce qui est saisi dans les champs » dans les réglages de Pinpoint)" } }
+      }
+    },
+    "export.ax.value.secure" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "withheld (secure field — Pinpoint never reads it)" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "masquée (champ sécurisé — Pinpoint ne la lit jamais)" } }
+      }
+    },
+    "export.markers.accessibility.legend" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "“UI” lines name the interface element found under the marker in the macOS accessibility tree at capture time — its role, its label, the app owning it, and its box in this image. “Path” is the chain of containers around it." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Les lignes « UI » nomment l’élément d’interface trouvé sous le repère dans l’arbre d’accessibilité macOS au moment de la capture — son rôle, son libellé, l’app qui le possède et sa boîte dans cette image. « Path » est la chaîne de conteneurs qui l’entoure." } }
+      }
+    },
+    "permission.accessibility.body" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "To name the element under each marker, Pinpoint needs the Accessibility permission. Open System Settings ▸ Privacy & Security ▸ Accessibility, turn Pinpoint on, then relaunch the app. Captures keep working without it — they just carry no interface details." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Pour nommer l’élément sous chaque repère, Pinpoint a besoin de l’autorisation Accessibilité. Ouvrez Réglages Système ▸ Confidentialité et sécurité ▸ Accessibilité, activez Pinpoint, puis relancez l’application. Les captures continuent de fonctionner sans elle — elles ne portent simplement aucun détail d’interface." } }
+      }
+    },
+    "permission.accessibility.openSettings" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Open System Settings" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Ouvrir les Réglages Système" } }
+      }
+    },
+    "permission.accessibility.title" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Pinpoint can’t read the interface" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Pinpoint ne peut pas lire l’interface" } }
+      }
+    },
     "Save image…" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Enregistrer l’image…" } }
@@ -896,6 +938,48 @@
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "%lld selected" } },
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "%lld sélectionnées" } }
+      }
+    },
+    "settings.ax.explanation" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Adds a line under each marker naming the interface element it points at — its role, its label and the app owning it — read while the capture is taken. Needs the Accessibility permission, which is separate from Screen Recording." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Ajoute sous chaque repère une ligne nommant l’élément d’interface visé — son rôle, son libellé et l’app qui le possède — lu au moment de la capture. Nécessite l’autorisation Accessibilité, distincte de l’Enregistrement de l’écran." } }
+      }
+    },
+    "settings.ax.fieldValues" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Include what is typed in fields" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Inclure ce qui est saisi dans les champs" } }
+      }
+    },
+    "settings.ax.fieldValues.explanation" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Off by default: the accessibility tree returns the whole contents of a field, including the part scrolled out of the picture. Password fields are never read, whatever this says." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Désactivé par défaut : l’arbre d’accessibilité renvoie tout le contenu d’un champ, y compris la partie sortie du cadre. Les champs de mot de passe ne sont jamais lus, quel que soit ce réglage." } }
+      }
+    },
+    "settings.ax.permission.grant" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Allow access…" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Autoriser l’accès…" } }
+      }
+    },
+    "settings.ax.permission.missing" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Accessibility permission required. Without it, captures work exactly as before — they just carry no interface details." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Autorisation Accessibilité requise. Sans elle, les captures fonctionnent exactement comme avant — elles ne portent simplement aucun détail d’interface." } }
+      }
+    },
+    "settings.ax.section" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Interface context" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Contexte d’interface" } }
+      }
+    },
+    "settings.ax.toggle" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Describe the element under each marker" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Décrire l’élément sous chaque repère" } }
       }
     },
     "Settings…" : {

--- a/Pinpoint/PinpointApp.swift
+++ b/Pinpoint/PinpointApp.swift
@@ -42,7 +42,7 @@ struct SettingsView: View {
                 .textSelection(.enabled)
                 .padding(.vertical, 6)
         }
-        .frame(width: 460, height: 366)
+        .frame(width: 460, height: 470)
     }
 
     /// Marketing version + build read from the bundle, e.g. "Pinpoint 0.3.0 (3)".
@@ -59,6 +59,13 @@ struct CaptureSettingsView: View {
     @AppStorage(PinStyle.storageKey) private var pinStyle: PinStyle = .disc
     @AppStorage("includeLegend") private var includeLegend = true
     @AppStorage(CaptureDelay.storageKey) private var captureDelay: CaptureDelay = .off
+    @AppStorage(AXContextSettings.enabledKey) private var axContext = true
+    @AppStorage(AXContextSettings.fieldValuesKey) private var axFieldValues = false
+
+    /// Whether macOS grants Accessibility, re-read whenever the window comes
+    /// back — the switch is flipped in System Settings, in another process, so
+    /// there's nothing to observe here beyond "the user came back to us".
+    @State private var isTrusted = AXPermission.isTrusted
 
     var body: some View {
         Form {
@@ -92,7 +99,56 @@ struct CaptureSettingsView: View {
                     .foregroundStyle(.secondary)
                     .font(.callout)
             }
+            accessibilitySection
         }
         .formStyle(.grouped)
+        // Coming back from System Settings is the moment the answer can have
+        // changed; nothing else in this window can change it.
+        .onReceive(NotificationCenter.default.publisher(
+            for: NSApplication.didBecomeActiveNotification)) { _ in
+            isTrusted = AXPermission.isTrusted
+        }
+    }
+
+    /// The accessibility context (#55): what turns a marker from a pixel into a
+    /// named element an agent can go and edit.
+    ///
+    /// Its permission is a separate grant from Screen Recording, so the section
+    /// states where it stands rather than surprising anyone mid-capture — and
+    /// nothing here prompts unless the button is pressed.
+    private var accessibilitySection: some View {
+        Section(String(localized: "settings.ax.section", defaultValue: "Interface context")) {
+            Toggle(String(localized: "settings.ax.toggle",
+                          defaultValue: "Describe the element under each marker"),
+                   isOn: $axContext)
+            Text(String(localized: "settings.ax.explanation",
+                        defaultValue: "Adds a line under each marker naming the interface element it points at — its role, its label and the app owning it — read while the capture is taken. Needs the Accessibility permission, which is separate from Screen Recording."))
+                .foregroundStyle(.secondary)
+                .font(.callout)
+
+            if axContext && !isTrusted {
+                HStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                    Text(String(localized: "settings.ax.permission.missing",
+                                defaultValue: "Accessibility permission required. Without it, captures work exactly as before — they just carry no interface details."))
+                        .font(.callout)
+                }
+                Button(String(localized: "settings.ax.permission.grant",
+                              defaultValue: "Allow access…")) {
+                    AXPermission.request()
+                    isTrusted = AXPermission.isTrusted
+                }
+            }
+
+            Toggle(String(localized: "settings.ax.fieldValues",
+                          defaultValue: "Include what is typed in fields"),
+                   isOn: $axFieldValues)
+                .disabled(!axContext)
+            Text(String(localized: "settings.ax.fieldValues.explanation",
+                        defaultValue: "Off by default: the accessibility tree returns the whole contents of a field, including the part scrolled out of the picture. Password fields are never read, whatever this says."))
+                .foregroundStyle(.secondary)
+                .font(.callout)
+        }
     }
 }

--- a/Pinpoint/ScreenCapture.swift
+++ b/Pinpoint/ScreenCapture.swift
@@ -20,6 +20,19 @@ enum ScreenCaptureError: LocalizedError {
 
 enum ScreenCapture {
 
+    /// What one capture produced: the pixels, plus the accessibility tree that
+    /// covered them at that instant (#55).
+    ///
+    /// The two travel together on purpose. Markers are placed later, in the
+    /// editor, when the photographed UI may already be gone — so the only moment
+    /// the tree can be read is this one. `accessibility` is nil whenever the
+    /// feature is off, unauthorized, or simply found nothing: it is context, and
+    /// its absence never turns a successful capture into a failure.
+    struct Capture {
+        let image: NSImage
+        let accessibility: AXSnapshot?
+    }
+
     // MARK: - Screen recording permission
 
     /// System Settings ▸ Privacy & Security ▸ Screen Recording.
@@ -94,7 +107,7 @@ enum ScreenCapture {
     /// Captures the full display that currently contains the mouse cursor,
     /// at native (Retina) resolution, using ScreenCaptureKit.
     @MainActor
-    static func captureDisplayUnderCursor() async throws -> NSImage {
+    static func captureDisplayUnderCursor() async throws -> Capture {
         guard await ensurePermission() else { throw ScreenCaptureError.permissionDenied }
 
         let content = try await SCShareableContent.current
@@ -120,8 +133,21 @@ enum ScreenCapture {
         config.showsCursor = false
         config.scalesToFit = false
 
+        // A whole-display capture is a region capture whose region happens to be
+        // the display: expressing it that way lets the accessibility snapshot use
+        // one mapping rule instead of two.
+        let region = CaptureRegion(
+            displayID: display.displayID,
+            rect: CGRect(x: 0, y: 0, width: CGFloat(display.width), height: CGFloat(display.height)),
+            scale: scale
+        )
+
+        async let snapshot = accessibilitySnapshot(for: region)
         let cgImage = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
-        return NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+        return Capture(
+            image: NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height)),
+            accessibility: await snapshot
+        )
     }
 
     /// Captures a single region of one display, at native (Retina) resolution.
@@ -131,7 +157,7 @@ enum ScreenCapture {
     /// pixel dimensions are the region size multiplied by the display scale — so
     /// the result keeps native resolution without any rescaling.
     @MainActor
-    static func captureRegion(_ region: CaptureRegion) async throws -> NSImage {
+    static func captureRegion(_ region: CaptureRegion) async throws -> Capture {
         guard await ensurePermission() else { throw ScreenCaptureError.permissionDenied }
 
         let content = try await SCShareableContent.current
@@ -153,8 +179,31 @@ enum ScreenCapture {
         config.scalesToFit = false
         config.captureResolution = .best
 
+        // Started before the screenshot rather than after it, so both describe
+        // the same instant. It never throws and never blocks past its own
+        // ceiling, so awaiting it here can only delay the capture, never break
+        // it — and if `captureImage` throws first, the child task is cancelled
+        // with the scope.
+        async let snapshot = accessibilitySnapshot(for: region)
         let cgImage = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
-        return NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+        return Capture(
+            image: NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height)),
+            accessibility: await snapshot
+        )
+    }
+
+    /// Reads the accessibility tree over `region`, or nothing at all.
+    ///
+    /// The two gates are checked here, together, so no other call site has to
+    /// remember them: the feature has to be switched on, and macOS has to have
+    /// granted Accessibility. Neither ever prompts — a user who never asked for
+    /// this sees precisely the app they had before (#55).
+    private static func accessibilitySnapshot(for region: CaptureRegion) async -> AXSnapshot? {
+        guard AXContextSettings.shouldCapture else { return nil }
+        return await AXSnapshotCollector.capture(
+            region: region,
+            includeFieldValues: AXContextSettings.includesFieldValues
+        )
     }
 
     /// Pinpoint's own running application(s), so its windows (a leftover editor,

--- a/Pinpoint/SettingsWindowController.swift
+++ b/Pinpoint/SettingsWindowController.swift
@@ -15,7 +15,7 @@ import SwiftUI
 final class SettingsWindowController: NSWindowController {
     init() {
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 460, height: 340),
+            contentRect: NSRect(x: 0, y: 0, width: 460, height: 444),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false


### PR DESCRIPTION
Closes #55

Une capture ne connaissait que des pixels. Un repère devient maintenant un **élément d'interface nommé** :

```
- M1 [0414b2] · Ce bouton doit être désactivé tant que le formulaire est vide — (408, 372) px · (51 %, 62 %)
  - UI: AXButton “Login” · id=login-button · com.apple.Safari · box (312, 340) 192×64 px
  - Path: AXWindow “Sign in” › AXGroup › AXButton “Login”
```

C'est le chaînon que l'issue décrit : un agent qui lit ça sait quel composant modifier, là où « 51 %, 62 % » ne dit rien.

## La difficulté principale : quand lire l'arbre ?

Les repères sont posés **après** la capture, dans l'éditeur — quand l'UI photographiée a pu défiler, se fermer, ou passer à l'arrière-plan. Interroger `AXUIElementCopyElementAtPosition` à ce moment-là répondrait à propos d'un écran qui n'existe plus.

L'arbre est donc lu **pendant la capture**, en parallèle du screenshot (`async let` dans `ScreenCapture.captureRegion`, lancé avant `SCScreenshotManager.captureImage` pour que les deux décrivent le même instant), et conservé avec elle. Résoudre un repère n'est ensuite que de la géométrie contre cet instantané figé.

## Coordonnées : un seul espace, et le recadrage tombe juste

Les frames sont conservées telles que les API AX les rendent : **points, origine globale haut-gauche** — le même espace que `CGDisplayBounds`. Les écrans multiples et les origines négatives (#26) tombent juste sans cas particulier :

```swift
screenRect = CGDisplayBounds(displayID) + region.rect
```

Seul `captureRect` relie l'instantané à l'image. Le recadrage (#21) n'a donc qu'à rétrécir ce rect — aucune des centaines de frames ne bouge :

```swift
axSnapshot = axSnapshot?.cropped(to: c)
```

L'instantané fait aussi partie de `EditorSnapshot`, sinon annuler un recadrage remettrait la grande image en face d'une région rétrécie. Il est exclu de `==` (il ne bouge qu'avec l'image, déjà comparée par identité).

Vérifié par un harnais dédié : mapping avec origine d'écran négative, invariance du point écran à travers un recadrage, résolution après recadrage, aller-retour JSON.

## Coût borné

Hors du main actor, plafonné de bout en bout : 900 éléments, 20 000 nœuds visités, profondeur 40, 8 applications, 1,5 s de budget interne, `AXUIElementSetMessagingTimeout` à 0,35 s par app, et un plafond dur de 3 s (une course entre le parcours et une horloge, parce qu'annuler une tâche Swift n'interrompt pas un appel AX bloqué). L'élagage se fait par intersection avec la région capturée.

Mesuré sur cette machine (écran 2880×1620, huit apps ouvertes) :

| Sélection | Durée | Éléments | Sidecar |
|---|---|---|---|
| plein écran | 509 ms | 900 (tronqué) | 142 Ko |
| moitié centrale | 235 ms | 425 | 71 Ko |
| 600×400 | 130 ms | 235 | 40 Ko |
| 200×120 | 208 ms | 135 | 25 Ko |

Un échec, un dépassement ou une absence de permission rend `nil` : **jamais une capture ratée**.

## Deux pièges trouvés en sondant l'arbre réel

Les deux venaient d'hypothèses raisonnables et fausses ; sans essai sur un vrai bureau, la fonctionnalité aurait été inutilisable.

**1. Une fenêtre système invisible captait tous les repères.** Le Centre de notifications garde en permanence une fenêtre hôte plein écran « on screen » (layer 21, 2880×1620, alpha 1) qu'il soit ouvert ou non. Classée naïvement par ordre z, elle passe devant tout et *chaque* repère de l'écran résolvait vers `AXWindow "Notification Center" › AXGroup`. Ces fenêtres — layer > 0 couvrant ≥ 90 % d'un écran — sont maintenant repoussées derrière tout le reste plutôt que supprimées, pour qu'une capture qui en est vraiment une obtienne quand même une réponse.

**2. Le tri par profondeur était faux.** La profondeur ressemble à de la spécificité et n'en est pas : une fenêtre Electron (Slack, VS Code) empile vingt niveaux d'`AXGroup` génériques qui couvrent chacun toute la fenêtre. Sur une grille de 80 points dans Slack, **un seul** élément distinct remontait. Le critère honnête est l'**aire** ; la profondeur ne sert qu'à départager deux éléments de même frame. Même grille après correction : **12 éléments distincts**, avec de vrais `AXButton "Agents 6"`, `AXList "Worktrees"`.

Une correction s'ajoute par-dessus : quand la plus petite boîte est décorative (le texte *dans* un bouton), on remonte au contrôle actionnable de taille voisine. Nommer le bouton plutôt que son libellé est tout l'intérêt ; la chaîne complète est exportée dans tous les cas.

## Vie privée — ce qui sort, ce qui se tait

La capture part chez un agent externe, et l'arbre AX est bien plus bavard que les pixels : il rend le contenu **entier** d'un champ, y compris la partie sortie du cadre.

| | Comportement |
|---|---|
| Champ sécurisé (rôle **ou** sous-rôle, ou contenant « secure »/« password ») | **Jamais lu**, à aucun réglage. Le contenu n'entre pas dans le processus. |
| Champ texte ordinaire | **Masqué par défaut** — réglage pour l'inclure |
| Case à cocher, curseur, menu, texte statique | Exporté : c'est de l'état déjà visible sur l'image |
| Tout autre rôle | Valeur ignorée (rôle inconnu → sensibilité inconnue) |
| Noms (titre, libellé, aide) | Coupés à 120 caractères |

La coupe des noms n'est pas cosmétique : Slack annonce une conversation avec l'expéditeur, le sujet **et les derniers messages** concaténés — des milliers de caractères, en partie hors écran.

Une valeur masquée le dit explicitement (`Value: withheld (secure field — Pinpoint never reads it)`) plutôt que de laisser un blanc qu'un agent lirait comme « champ vide ». Le JSON porte `redacted: "secureField" | "textFieldPolicy"` et un bloc `policy` au niveau du document.

**Décision de PO signalée** : les champs texte ordinaires sont masqués par défaut, l'option prudente. Le réglage « Inclure ce qui est saisi dans les champs » est lu **au moment de la capture** — rien de sensible n'atterrit sur disque quand il est désactivé, et l'activer plus tard n'expose pas rétroactivement une capture ancienne.

## Permission — optionnelle, et silencieuse

Sur le modèle du Tier 0 (#39) : alerte explicite et lien profond vers `x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility`.

Différence assumée : **rien ne s'affiche jamais tout seul**. Le chemin de capture ne lit que `AXIsProcessTrusted()`, gratuit et muet. Le prompt système et l'alerte ne sont atteignables que depuis un clic explicite dans les Réglages. Sans la permission, Pinpoint se comporte **exactement** comme avant — aucune alerte à chaque capture.

Le réglage est activé par défaut, ce qui ne change rien tant que la permission n'est pas accordée : il ne commence à compter que pour quelqu'un qui l'a déjà explicitement autorisée. Les Réglages affichent l'état de la permission et un bouton « Autoriser l'accès… ».

## Contrat JSON

`HandoffDocument` avait prévu ce bloc. `accessibility` sous chaque repère (rôle, sous-rôle, titre, libellé, `identifier`, placeholder, valeur ou motif de masquage, boîte en pixels de l'image **et** en points écran, app propriétaire, chaîne d'ancêtres) plus un bloc de synthèse au niveau du document (`available`, `elementCount`, `truncated`, `policy`). Ce sont des **ajouts** : `schemaVersion` reste à **1**, un consommateur écrit contre la version 1 lit exactement ce qu'il lisait.

L'`identifier` est le champ le plus directement actionnable : c'est en général l'`accessibilityIdentifier` écrit dans le code source de l'app visée.

Coordonnées prises sur le PNG réel via le handoff par fichier, jamais sur le presse-papier (#76).

## Persistance

L'instantané est écrit en fichier compagnon `<uuid>-ax.json` à côté du PNG, pas dans `index.json` — celui-ci est relu en entier à chaque lancement et n'a pas à porter quelques centaines d'éléments par capture. Rouvrir une capture depuis « Captures récentes » retrouve donc le contexte. Les compagnons sont supprimés avec leur capture, par `clear()`, par l'élagage, et au chargement si le PNG a disparu à la main.

## Vérifications

- `xcodegen generate` + `xcodebuild -scheme Pinpoint -destination 'platform=macOS'` : **vert, sans avertissement**.
- Harnais de géométrie (8 groupes) : mapping écran négatif, promotion vers le contrôle, ordre z, recadrage, conversion en pixels image, aller-retour JSON — tout passe.
- Rendu réel du `.md` et du `.json` sur un instantané synthétique couvrant bouton, champ texte, champ sécurisé, case à cocher et bouton désactivé — y compris la vérification que `value` est **absent** du JSON pour le champ sécurisé.
- Sonde du collecteur sur le bureau réel : 0 fuite de champ sécurisé, mesures de coût ci-dessus, et les deux pièges décrits plus haut.
- i18n : 14 clés ajoutées avec `en` et `fr`, insérées à leur place alphabétique. Le diff de `Localizable.xcstrings` est en **insertions pures** (84 lignes, 0 suppression) pour ne pas gêner les branches parallèles.

**Reste à valider à la main** : je n'ai pas accordé la permission Accessibilité à un binaire de test — cela aurait modifié les réglages de confidentialité de la machine. Le collecteur a en revanche été sondé en conditions réelles depuis un processus qui l'avait déjà (mesures et pièges ci-dessus). Restent donc à voir en vrai : l'alerte de permission et son lien vers les Réglages, et le parcours complet capture → repère → `capture.md` depuis l'app installée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)