### PR TITLE
Tier 2 — Masquer une zone sensible avant de partager

### DIFF
--- a/Pinpoint/AXSnapshot.swift
+++ b/Pinpoint/AXSnapshot.swift
@@ -64,6 +64,12 @@ struct AXSnapshot: Codable, Sendable, Equatable {
         case secureField
         /// An ordinary text field, withheld by the default privacy policy.
         case textFieldPolicy
+        /// The user painted over this element in the editor (#50), so its name
+        /// and its value were stripped on the way out. Unlike the two above,
+        /// this one is never stored: the snapshot keeps every element intact
+        /// and only the exported copy is stripped, which is what makes undoing
+        /// a redaction restore the context it took away.
+        case userRedaction
     }
 
     struct Element: Codable, Sendable, Equatable {

--- a/Pinpoint/EditorView.swift
+++ b/Pinpoint/EditorView.swift
@@ -4,7 +4,7 @@ import UniformTypeIdentifiers
 
 /// Annotation tools the user can switch between in the editor.
 enum EditorTool: String, CaseIterable, Identifiable {
-    case pin, arrow, rectangle
+    case pin, arrow, rectangle, redaction
 
     var id: String { rawValue }
 
@@ -13,6 +13,7 @@ enum EditorTool: String, CaseIterable, Identifiable {
         case .pin: return String(localized: "Marker")
         case .arrow: return String(localized: "Arrow")
         case .rectangle: return String(localized: "Rectangle")
+        case .redaction: return String(localized: "tool.redaction", defaultValue: "Hide")
         }
     }
 
@@ -21,6 +22,7 @@ enum EditorTool: String, CaseIterable, Identifiable {
         case .pin: return "mappin"
         case .arrow: return "arrow.up.right"
         case .rectangle: return "rectangle"
+        case .redaction: return "eye.slash"
         }
     }
 
@@ -31,6 +33,20 @@ enum EditorTool: String, CaseIterable, Identifiable {
         case .pin: return "1"
         case .arrow: return "2"
         case .rectangle: return "3"
+        case .redaction: return "4"
+        }
+    }
+
+    /// The shape this tool draws, or nil for the marker tool — which places a
+    /// numbered `Pin` instead. Read by the canvas gesture and by
+    /// `isManipulable`, so adding a shape kind never means remembering to widen
+    /// a `switch` in either.
+    var markupKind: Markup.Kind? {
+        switch self {
+        case .pin: return nil
+        case .arrow: return .arrow
+        case .rectangle: return .rectangle
+        case .redaction: return .redaction
         }
     }
 }
@@ -376,6 +392,10 @@ struct EditorView: View {
             return shapes.contains { $0.kind == .rectangle }
                 ? String(localized: "Drag to draw a rectangle · click one to move or resize it")
                 : String(localized: "Drag to draw a rectangle")
+        case .redaction:
+            return shapes.contains(where: \.isRedaction)
+                ? String(localized: "hint.redaction.some", defaultValue: "Drag over what to hide · click one to move or resize it")
+                : String(localized: "hint.redaction", defaultValue: "Drag over what should never leave your Mac")
         }
     }
 
@@ -399,11 +419,13 @@ struct EditorView: View {
                     .shadow(radius: 8, y: 2)
                     .accessibilityLabel(String(localized: "a11y.canvas.image", defaultValue: "Screenshot being annotated"))
 
-                // Committed markups. Drawing and interaction are two layers:
-                // every shape draws first and takes no clicks, then the
-                // manipulable ones take them on top, so a handle is never
-                // buried under the outline of a shape drawn after it.
-                ForEach(shapes) { shape in
+                // Committed markups, redactions first (`inDrawOrder`, the order
+                // the exporter draws in too, so the preview stacks them the way
+                // the file will). Drawing and interaction are two layers: every
+                // shape draws first and takes no clicks, then the manipulable
+                // ones take them on top, so a handle is never buried under the
+                // outline of a shape drawn after it.
+                ForEach(shapes.inDrawOrder) { shape in
                     // The drawing layer is what VoiceOver reads: it carries
                     // every shape, where the grab bands below only exist for
                     // the ones the active tool can manipulate.
@@ -498,6 +520,10 @@ struct EditorView: View {
         switch shape.kind {
         case .arrow: return String(localized: "a11y.shape.arrow", defaultValue: "Arrow annotation")
         case .rectangle: return String(localized: "a11y.shape.rectangle", defaultValue: "Rectangle annotation")
+        // Announces the bar, not what went under it: VoiceOver is a channel
+        // like any other, and the text it reads is the text a screen recording
+        // of this session would carry.
+        case .redaction: return String(localized: "a11y.shape.redaction", defaultValue: "Hidden area")
         }
     }
 
@@ -536,23 +562,16 @@ struct EditorView: View {
     private func canvasGesture(in fitted: CGRect) -> some Gesture {
         DragGesture(minimumDistance: 0)
             .onChanged { value in
-                guard !isCropping else { return }
-                switch tool {
-                case .pin:
-                    break
-                case .arrow, .rectangle:
-                    let kind: Markup.Kind = tool == .arrow ? .arrow : .rectangle
-                    updateDraft(kind: kind, value: value, in: fitted)
-                }
+                guard !isCropping, let kind = tool.markupKind else { return }
+                updateDraft(kind: kind, value: value, in: fitted)
             }
             .onEnded { value in
                 guard !isCropping else { return }
-                switch tool {
-                case .pin:
+                guard tool.markupKind != nil else {
                     addPin(at: value.location, in: fitted)
-                case .arrow, .rectangle:
-                    commitDraft(value: value, in: fitted)
+                    return
                 }
+                commitDraft(value: value, in: fitted)
             }
     }
 
@@ -578,6 +597,17 @@ struct EditorView: View {
             )
             .stroke(Color.pinpointVermillon, style: StrokeStyle(lineWidth: width, lineCap: .round, lineJoin: .round))
             .shadow(color: .black.opacity(0.25), radius: 1, y: 0.5)
+        case .redaction:
+            // Square corners and a border drawn inside, exactly like
+            // `Exporter.drawRedaction`: what the preview covers is what the
+            // file covers. The bar is opaque here too — a preview that let the
+            // secret show through would be telling the user it is still there.
+            let r = absoluteRect(shape.rect, in: fitted)
+            Rectangle()
+                .fill(Color.pinpointRedaction)
+                .overlay(Rectangle().strokeBorder(Color.pinpointVermillon, lineWidth: width))
+                .frame(width: r.width, height: r.height)
+                .position(x: r.midX, y: r.midY)
         }
     }
 
@@ -633,20 +663,26 @@ struct EditorView: View {
     /// overlay is modal and owns interaction.
     private func isManipulable(_ shape: Markup) -> Bool {
         guard !isCropping else { return false }
-        switch shape.kind {
-        case .arrow: return tool == .arrow
-        case .rectangle: return tool == .rectangle
-        }
+        return tool.markupKind == shape.kind
     }
 
     /// The clickable band along a shape's outline. Deliberately not its
     /// interior: a rectangle annotation is mostly hole, and clicking through it
     /// has to keep dropping markers and drawing new shapes.
+    ///
+    /// A redaction is the exception, and for the same reason: it is a solid
+    /// bar, not an outline around a hole, so its whole surface takes the click.
     @ViewBuilder
     private func shapeGrabBand(_ shape: Markup, in fitted: CGRect, metrics: MarkupMetrics) -> some View {
         let band = Self.grabBandWidth(metrics)
         Group {
             switch shape.kind {
+            case .redaction:
+                let r = absoluteRect(shape.rect, in: fitted)
+                Color.clear
+                    .frame(width: r.width, height: r.height)
+                    .contentShape(Rectangle())
+                    .position(x: r.midX, y: r.midY)
             case .rectangle:
                 let r = absoluteRect(shape.rect, in: fitted)
                 Color.clear
@@ -699,7 +735,7 @@ struct EditorView: View {
                           label: end.accessibilityLabel)
                     .gesture(arrowEndDrag(shape, end: end, in: fitted))
             }
-        case .rectangle:
+        case .rectangle, .redaction:
             let r = absoluteRect(shape.rect, in: fitted)
             ForEach(SelectionHandle.allCases, id: \.self) { handle in
                 handleDot(at: handle.point(in: r, orientation: .yDown),
@@ -770,7 +806,8 @@ struct EditorView: View {
             .onEnded { _ in endShapeDrag() }
     }
 
-    /// Drag one of a rectangle's eight handles to resize it.
+    /// Drag one of the eight handles of a rectangle — or of a redaction, which
+    /// is resized by the same geometry — to resize it.
     private func rectangleResizeDrag(_ shape: Markup, handle: SelectionHandle,
                                      in fitted: CGRect) -> some Gesture {
         DragGesture(minimumDistance: 0)
@@ -1308,6 +1345,19 @@ struct EditorView: View {
         for shape in shapes {
             let s = remap(shape.start)
             let e = remap(shape.end)
+            if shape.isRedaction {
+                // A redaction survives on overlap alone, and is clamped to what
+                // is left of it. The endpoint rule below would drop a bar wider
+                // than the crop — both its corners *and* its midpoint sit
+                // outside — and dropping it would uncover, in the cropped
+                // image, pixels the user had painted over. A crop must never be
+                // able to undo a redaction.
+                guard shape.rect.intersects(c) else { continue }
+                newShapes.append(
+                    Markup(id: shape.id, kind: shape.kind, start: clamp01(s), end: clamp01(e))
+                )
+                continue
+            }
             // Keep a markup iff at least one defining point survives the crop.
             // Midpoint-or-endpoint rule; straddlers keep what's inside.
             guard inside(s) || inside(e) || inside(CGPoint(x: (s.x+e.x)/2, y: (s.y+e.y)/2)) else { continue }

--- a/Pinpoint/Exporter.swift
+++ b/Pinpoint/Exporter.swift
@@ -1,9 +1,10 @@
 import AppKit
 
 enum Exporter {
-    /// Renders the base capture with markups (arrows/rectangles) and numbered
-    /// pins drawn on top, at full image resolution. Markups are drawn first so
-    /// numbered pins stay legible above them.
+    /// Renders the base capture with markups (redactions, arrows, rectangles)
+    /// and numbered pins drawn on top, at full image resolution. Markups are
+    /// drawn first so numbered pins stay legible above them, and redactions
+    /// first among those — `inDrawOrder`, the same order the editor previews.
     static func annotatedImage(base: NSImage, pins: [Pin], shapes: [Markup], style: PinStyle) -> NSImage {
         let size = base.size
         let result = NSImage(size: size)
@@ -16,7 +17,7 @@ enum Exporter {
         // no scaling here. `EditorView` builds the same metrics with the
         // canvas' scale factor, which is what makes the preview WYSIWYG.
         let metrics = MarkupMetrics(imageWidth: size.width)
-        for shape in shapes {
+        for shape in shapes.inDrawOrder {
             drawMarkup(shape, in: size, metrics: metrics)
         }
 
@@ -48,17 +49,14 @@ enum Exporter {
 
         switch shape.kind {
         case .rectangle:
-            let r = shape.rect
-            let rect = NSRect(
-                x: r.minX * size.width,
-                y: (1 - r.maxY) * size.height,
-                width: r.width * size.width,
-                height: r.height * size.height
-            )
+            let rect = imageRect(shape.rect, in: size)
             let path = NSBezierPath(roundedRect: rect,
                                     xRadius: metrics.cornerRadius, yRadius: metrics.cornerRadius)
             path.lineWidth = lineWidth
             path.stroke()
+
+        case .redaction:
+            drawRedaction(imageRect(shape.rect, in: size), lineWidth: lineWidth)
 
         case .arrow:
             let start = px(shape.start)
@@ -86,6 +84,56 @@ enum Exporter {
             path.line(to: right)
             path.stroke()
         }
+    }
+
+    /// A normalized rect (top-left origin) in the image's own drawing space
+    /// (bottom-left origin).
+    private static func imageRect(_ rect: CGRect, in size: CGSize) -> NSRect {
+        NSRect(
+            x: rect.minX * size.width,
+            y: (1 - rect.maxY) * size.height,
+            width: rect.width * size.width,
+            height: rect.height * size.height
+        )
+    }
+
+    /// Paints out a redacted region: an opaque bar, then a vermillon border
+    /// drawn *inside* it so the annotation reads as one of Pinpoint's own
+    /// without ever narrowing what it covers.
+    ///
+    /// Three details carry the guarantee, and none of them is cosmetic:
+    ///
+    /// - `.copy` rather than the default source-over, so the pixels underneath
+    ///   are **replaced** and not blended with. A colour that ever picked up an
+    ///   alpha below 1 would otherwise turn the bar into a tint.
+    /// - `integral`, which rounds the rect *outwards* to whole units. A bar on
+    ///   fractional bounds leaves a partially covered row of pixels along each
+    ///   edge — a sliver of the original image, and a sliver of a character is
+    ///   sometimes a whole character.
+    /// - antialiasing off while filling, for the same reason: a smoothed edge
+    ///   is a blended edge.
+    ///
+    /// Square corners, not the rounded ones a rectangle markup gets: a rounded
+    /// corner would leave the four corners of the region the user dragged
+    /// showing.
+    private static func drawRedaction(_ rect: NSRect, lineWidth: CGFloat) {
+        guard rect.width > 0, rect.height > 0 else { return }
+        let context = NSGraphicsContext.current
+        let wasAntialiasing = context?.shouldAntialias ?? true
+        context?.shouldAntialias = false
+        NSColor.pinpointRedaction.setFill()
+        rect.integral.fill(using: .copy)
+        context?.shouldAntialias = wasAntialiasing
+
+        // Inset by half the stroke width so the whole border sits inside the
+        // bar; a centred stroke would spill outside the area the user drew.
+        // Skipped on a bar too thin to hold one, where it would invert.
+        let inset = rect.insetBy(dx: lineWidth / 2, dy: lineWidth / 2)
+        guard inset.width > 0, inset.height > 0 else { return }
+        NSColor.pinpointVermillon.setStroke()
+        let border = NSBezierPath(rect: inset)
+        border.lineWidth = lineWidth
+        border.stroke()
     }
 
     /// Shifts `anchor` so the marker's badge stays fully within `size` (image
@@ -212,11 +260,20 @@ enum Exporter {
             lines.append(String(localized: "export.coordinates", defaultValue: "Positions are given in pixels from the top-left corner (0, 0), then as a percentage of the image size."))
         }
 
+        // What the user painted over (#50). Every accessibility lookup below
+        // goes through it: the bar hides the pixels, and this hides the text
+        // that describes the very same pixels — the leak this feature would
+        // otherwise open, since a marker dropped on a hidden token would carry
+        // the token's label and value into this file.
+        let mask = RedactionMask(shapes)
+
         // Kept only when at least one marker actually resolves to an element:
         // an empty snapshot must not print a legend promising details that never
         // come, and must leave the text byte-identical to what it was before.
         let snapshot = accessibility.flatMap { candidate in
-            orderedPins.contains { candidate.element(atNormalized: $0.position) != nil } ? candidate : nil
+            orderedPins.contains {
+                candidate.element(atNormalized: $0.position, hiddenBy: mask) != nil
+            } ? candidate : nil
         }
 
         if !orderedPins.isEmpty {
@@ -236,8 +293,8 @@ enum Exporter {
                 // accessibility tree while the capture was taken (#55). Indented
                 // under its marker so the association is positional and can't be
                 // misread, and left out entirely when there's nothing to say.
-                lines.append(contentsOf: accessibilityLines(for: pin.position,
-                                                            snapshot: snapshot, imageSize: imageSize))
+                lines.append(contentsOf: accessibilityLines(for: pin.position, snapshot: snapshot,
+                                                            mask: mask, imageSize: imageSize))
             }
         }
 
@@ -245,12 +302,19 @@ enum Exporter {
             lines.append("")
             lines.append("## " + String(localized: "export.shapes.heading", defaultValue: "Shapes"))
             lines.append(String(localized: "export.shapes.legend", defaultValue: "Unnumbered outlines drawn on the image: rectangles are listed top-left → bottom-right, arrows tail → tip, followed by the size of their bounding box."))
+            // Only when there is one, so a capture without redactions keeps the
+            // text it had before. Says what a hidden area *is* — never what it
+            // held — because an agent that doesn't know a region was painted
+            // out would read the bar as part of the interface.
+            if !mask.isEmpty {
+                lines.append(String(localized: "export.shapes.redaction.legend", defaultValue: "A hidden area is a region the user painted over before sharing: its pixels are not in the image, and nothing was collected about what sat under it. Ask the user rather than guessing."))
+            }
             lines.append("")
             for (index, shape) in shapes.enumerated() {
                 let box = shape.rect
                 let from: CGPoint, to: CGPoint
                 switch shape.kind {
-                case .rectangle:
+                case .rectangle, .redaction:
                     from = CGPoint(x: box.minX, y: box.minY)
                     to = CGPoint(x: box.maxX, y: box.maxY)
                 case .arrow:
@@ -283,8 +347,9 @@ enum Exporter {
     /// the vocabulary shared with every inspector, and with the code that
     /// created the element in the first place.
     private static func accessibilityLines(for position: CGPoint, snapshot: AXSnapshot?,
-                                           imageSize: CGSize) -> [String] {
-        guard let snapshot, let resolved = snapshot.element(atNormalized: position) else { return [] }
+                                           mask: RedactionMask, imageSize: CGSize) -> [String] {
+        guard let snapshot,
+              let resolved = snapshot.element(atNormalized: position, hiddenBy: mask) else { return [] }
         let element = resolved.element
 
         var facts: [String] = [element.summary]
@@ -334,6 +399,9 @@ enum Exporter {
         case .textFieldPolicy:
             return String(localized: "export.ax.value.policy",
                           defaultValue: "withheld (text field — enable “Include what is typed in fields” in Pinpoint’s settings)")
+        case .userRedaction:
+            return String(localized: "export.ax.value.redacted",
+                          defaultValue: "withheld (the user painted over this element — its name and its contents were left out)")
         }
     }
 

--- a/Pinpoint/HandoffDocument.swift
+++ b/Pinpoint/HandoffDocument.swift
@@ -123,9 +123,12 @@ extension FileHandoff {
             /// The element's value — present only when the privacy policy allows
             /// it (see `redacted`).
             let value: String?
-            /// Why `value` is absent: "secureField" (never read) or
-            /// "textFieldPolicy" (withheld by default). Absent when the element
-            /// simply has no value worth reporting.
+            /// Why `value` is absent: "secureField" (never read),
+            /// "textFieldPolicy" (withheld by default) or "userRedaction" (the
+            /// user painted over this element, so its name — `title`, `label`,
+            /// `identifier`, `help`, `placeholder` — was dropped along with its
+            /// value). Absent when the element simply has no value worth
+            /// reporting.
             let redacted: String?
             let enabled: Bool?
             /// The element's box in *this image's* pixel grid, the same one
@@ -173,23 +176,32 @@ extension FileHandoff {
             /// The interface element under `position`, resolved against the
             /// snapshot taken at capture time. Absent when there is none —
             /// which is the normal case for a capture of something that isn't
-            /// an app window, or with the feature switched off.
+            /// an app window, or with the feature switched off — and always
+            /// absent for a marker dropped on a redacted region, where naming
+            /// what sits under the bar would undo the redaction in text.
             let accessibility: AccessibilityElement?
         }
 
-        /// An unnumbered outline: arrow or rectangle.
+        /// An unnumbered shape: arrow, rectangle or redaction.
         struct Shape: Encodable {
             let id: String
             /// "S1", "S2"… matching `capture.md`.
             let label: String
-            /// "arrow" or "rectangle". Deliberately a plain string mapped by
-            /// hand, so renaming the internal enum can't silently change the
-            /// contract.
+            /// "arrow", "rectangle" or "redaction". Deliberately a plain string
+            /// mapped by hand, so renaming the internal enum can't silently
+            /// change the contract.
+            ///
+            /// A "redaction" is a region the user painted over before sharing:
+            /// its pixels are gone from the PNG, and no accessibility element
+            /// under it is described anywhere in this file. Its box is still
+            /// given — where something was hidden is not itself a secret, and a
+            /// consumer that knows a region is unreadable asks instead of
+            /// guessing.
             let kind: String
-            /// Arrow: the tail. Rectangle: its top-left corner.
+            /// Arrow: the tail. Rectangle/redaction: its top-left corner.
             let from: Point
-            /// Arrow: the tip, where the head is drawn. Rectangle: its
-            /// bottom-right corner.
+            /// Arrow: the tip, where the head is drawn. Rectangle/redaction:
+            /// its bottom-right corner.
             let to: Point
             let boundingBox: Box
         }
@@ -218,9 +230,16 @@ extension FileHandoff.Document {
         self.context = context.trimmingCharacters(in: .whitespacesAndNewlines)
 
         let ordered = pins.sorted { $0.number < $1.number }
+        // The regions the user painted over (#50). This file is the one that
+        // makes a redaction worth anything or worth nothing: the PNG next to it
+        // is already clean, and without the mask the accessibility block below
+        // would hand over the label — and the typed value — of whatever sits
+        // under the bar, in plain text, keys sorted, ready to grep.
+        let mask = RedactionMask(shapes)
         if let snapshot = accessibility {
             self.markers = ordered.map { pin in
-                Marker(pin, in: imageSize, accessibility: snapshot.element(atNormalized: pin.position)
+                Marker(pin, in: imageSize,
+                       accessibility: snapshot.element(atNormalized: pin.position, hiddenBy: mask)
                     .map { AccessibilityElement($0, in: snapshot, imageSize: imageSize) })
             }
             self.accessibility = AccessibilityContext(snapshot, formatter: formatter)
@@ -240,6 +259,10 @@ extension FileHandoff.Document {
                 to = shape.end
             case .rectangle:
                 kind = "rectangle"
+                from = CGPoint(x: shape.rect.minX, y: shape.rect.minY)
+                to = CGPoint(x: shape.rect.maxX, y: shape.rect.maxY)
+            case .redaction:
+                kind = "redaction"
                 from = CGPoint(x: shape.rect.minX, y: shape.rect.minY)
                 to = CGPoint(x: shape.rect.maxX, y: shape.rect.maxY)
             }

--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -244,6 +244,12 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Annotation rectangle" } }
       }
     },
+    "a11y.shape.redaction" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Hidden area" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Zone masquée" } }
+      }
+    },
     "a11y.shelf.dateFilter" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Date filter" } },
@@ -430,6 +436,12 @@
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "withheld (text field — enable “Include what is typed in fields” in Pinpoint’s settings)" } },
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "masquée (champ texte — activez « Inclure ce qui est saisi dans les champs » dans les réglages de Pinpoint)" } }
+      }
+    },
+    "export.ax.value.redacted" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "withheld (the user painted over this element — its name and its contents were left out)" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "retenue (l’utilisateur a masqué cet élément — son nom et son contenu ont été écartés)" } }
       }
     },
     "export.ax.value.secure" : {
@@ -633,6 +645,12 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Tracés non numérotés dessinés sur l’image : les rectangles sont donnés haut-gauche → bas-droite, les flèches base → pointe, suivis de la taille de leur boîte englobante." } }
       }
     },
+    "export.shapes.redaction.legend" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "A hidden area is a region the user painted over before sharing: its pixels are not in the image, and nothing was collected about what sat under it. Ask the user rather than guessing." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Une zone masquée est une région que l’utilisateur a recouverte avant de partager : ses pixels ne sont pas dans l’image, et rien n’a été collecté sur ce qui se trouvait dessous. Demandez à l’utilisateur plutôt que de deviner." } }
+      }
+    },
     "Favorites" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Favoris" } }
@@ -667,6 +685,18 @@
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "The capture was copied to the clipboard, but the files for the agent couldn’t be written to %@: %@" } },
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "La capture a été copiée dans le presse-papier, mais les fichiers destinés à l’agent n’ont pas pu être écrits dans %@ : %@" } }
+      }
+    },
+    "hint.redaction" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Drag over what should never leave your Mac" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Faites glisser sur ce qui ne doit jamais quitter votre Mac" } }
+      }
+    },
+    "hint.redaction.some" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Drag over what to hide · click one to move or resize it" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Faites glisser sur ce qu’il faut masquer · cliquez sur une zone pour la déplacer ou la redimensionner" } }
       }
     },
     "Instructions for the agent" : {
@@ -733,6 +763,12 @@
     "Markers (position in % of the image, top-left origin):" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Repères (position en % de l’image, origine haut-gauche) :" } }
+      }
+    },
+    "markup.redaction" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Hidden area" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Zone masquée" } }
       }
     },
     "More actions" : {
@@ -1087,6 +1123,12 @@
     "Tool" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Outil" } }
+      }
+    },
+    "tool.redaction" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Hide" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Masquer" } }
       }
     },
     "Undo" : {

--- a/Pinpoint/Markup.swift
+++ b/Pinpoint/Markup.swift
@@ -1,7 +1,8 @@
 import CoreGraphics
 import Foundation
 
-/// A non-numbered visual annotation (arrow or rectangle) drawn on the capture.
+/// A non-numbered visual annotation (arrow, rectangle or redaction) drawn on
+/// the capture.
 ///
 /// Unlike `Pin`, markups carry no number and no user description: they're
 /// visual emphasis. The agent-ready text still describes each of them (kind,
@@ -12,16 +13,24 @@ struct Markup: Identifiable, Equatable, Codable {
     enum Kind: String, Equatable, Codable {
         case arrow
         case rectangle
+        /// A region painted over before the capture leaves the app (#50).
+        ///
+        /// Deliberately a `Kind` and not a type of its own: a redaction is
+        /// drawn, selected, moved, resized, deleted and undone exactly like the
+        /// other shapes, and every one of those behaviours already exists for
+        /// them. What makes it different is not its geometry but what the
+        /// exporters do with it — see `RedactionMask`.
+        case redaction
     }
 
     var id = UUID()
     var kind: Kind
-    /// Arrow: tail. Rectangle: one corner.
+    /// Arrow: tail. Rectangle/redaction: one corner.
     var start: CGPoint
-    /// Arrow: tip (where the arrowhead is). Rectangle: opposite corner.
+    /// Arrow: tip (where the arrowhead is). Rectangle/redaction: opposite corner.
     var end: CGPoint
 
-    /// Order-independent normalized rect (for rectangle markups).
+    /// Order-independent normalized rect (for rectangle and redaction markups).
     var rect: CGRect {
         CGRect(
             x: min(start.x, end.x),
@@ -31,10 +40,17 @@ struct Markup: Identifiable, Equatable, Codable {
         )
     }
 
+    /// Whether this markup hides pixels rather than pointing at them.
+    var isRedaction: Bool { kind == .redaction }
+
     var label: String {
         switch kind {
         case .arrow: return String(localized: "Arrow")
         case .rectangle: return String(localized: "Rectangle")
+        // Names the shape, never its contents: this string is read by the agent
+        // and by VoiceOver, and "what was hidden" is precisely what must not
+        // travel with the capture.
+        case .redaction: return String(localized: "markup.redaction", defaultValue: "Hidden area")
         }
     }
 
@@ -42,6 +58,22 @@ struct Markup: Identifiable, Equatable, Codable {
         switch kind {
         case .arrow: return "arrow.up.right"
         case .rectangle: return "rectangle"
+        case .redaction: return "eye.slash"
         }
+    }
+}
+
+extension Array where Element == Markup {
+    /// The shapes in the order they must be drawn: redactions first, then
+    /// everything else.
+    ///
+    /// One definition for both surfaces — the editor canvas and `Exporter` —
+    /// so the preview and the exported image stack them identically. The order
+    /// matters twice over: an arrow or a rectangle drawn *before* a redaction
+    /// would otherwise be swallowed by the bar that came after it, and a
+    /// redaction dropped last over a numbered marker would hide the marker
+    /// itself. Markers are drawn last of all by both sides, above every shape.
+    var inDrawOrder: [Markup] {
+        filter(\.isRedaction) + filter { !$0.isRedaction }
     }
 }

--- a/Pinpoint/Redaction.swift
+++ b/Pinpoint/Redaction.swift
@@ -1,0 +1,119 @@
+import CoreGraphics
+
+/// The regions of a capture the user painted over, and the only questions the
+/// exporters ever ask about them (#50).
+///
+/// ## Why this type exists at all
+///
+/// Hiding pixels is the easy half. Pinpoint doesn't only hand over an image:
+/// every copy also writes `capture.md` and `capture.json` next to it (#54), and
+/// each numbered marker in those files carries the role, the label and
+/// sometimes the *value* of the interface element the accessibility tree found
+/// under it (#55). A redaction that only painted the picture would therefore
+/// blank out an API key on screen and ship the very same string, in plain text,
+/// two files over — the worst possible outcome, because the image *looks*
+/// clean. So the mask is threaded through both text exporters, not just the
+/// renderer.
+///
+/// Rects are normalized (0…1) in image space, top-left origin: the same
+/// convention `Markup`, `Pin` and `AXSnapshot.normalizedRect(for:)` speak, so
+/// nothing has to be converted at the call sites.
+struct RedactionMask {
+    /// The redacted regions, normalized. Empty for a capture with no redaction,
+    /// which is the case every check below short-circuits on.
+    let rects: [CGRect]
+
+    /// Reads the redactions out of a set of markups. Taking the whole array
+    /// rather than a pre-filtered one is deliberate: every exporter already has
+    /// `shapes` in hand, so there is no way to build the document and forget
+    /// the mask.
+    init(_ shapes: [Markup]) {
+        rects = shapes.filter(\.isRedaction).map(\.rect)
+    }
+
+    var isEmpty: Bool { rects.isEmpty }
+
+    /// Whether a normalized point falls inside a redacted region — a marker
+    /// dropped on something the user chose to hide.
+    func hides(_ point: CGPoint) -> Bool {
+        rects.contains { $0.contains(point) }
+    }
+
+    /// Whether a normalized rect touches a redacted region.
+    ///
+    /// Any overlap counts, however small, and that is the whole point. An
+    /// element's text is rendered inside its own frame, so a redaction covering
+    /// a tenth of a label covers a tenth of that label's characters — and those
+    /// characters are exactly what the user meant to hide. There is no safe
+    /// threshold above zero, so there isn't one.
+    ///
+    /// A degenerate (empty) frame counts as hidden whenever anything is
+    /// redacted at all: it can't be reasoned about geometrically, and erring
+    /// towards hiding costs nothing — such an element contains no point, so it
+    /// is never what a marker resolves to.
+    func hides(_ rect: CGRect) -> Bool {
+        guard !rects.isEmpty else { return false }
+        guard rect.width > 0, rect.height > 0 else { return true }
+        return rects.contains { $0.intersects(rect) }
+    }
+}
+
+// MARK: - Accessibility
+
+extension AXSnapshot {
+
+    /// The interface element under a marker, with everything a redaction covers
+    /// taken out of the answer — the only resolution the exporters are allowed
+    /// to use.
+    ///
+    /// Two rules, both deliberately blunt:
+    ///
+    /// 1. **A marker sitting on a redacted region resolves to nothing.** Not to
+    ///    a nameless element, not to its parent: nothing. The user pointed at
+    ///    something they had just decided to hide, and the honest answer is
+    ///    silence. Without this, `element(atNormalized:)`'s promotion step could
+    ///    hand back the *actionable ancestor* of the hidden leaf — a button
+    ///    whose own label was never covered — and quietly name what was under
+    ///    the bar.
+    ///
+    /// 2. **Any element whose frame a redaction touches loses its name and its
+    ///    value**, whether it is the resolved element or one of the ancestors
+    ///    printed in its path. Its role, its box and its position stay: they
+    ///    describe geometry the black bar already advertises, and they are what
+    ///    still lets an agent say "there is a text field here I can't read".
+    ///
+    /// Rule 2 is coarse on purpose, and it costs something: a redaction
+    /// anywhere in a window also strips that window's title from every path,
+    /// since the window's frame contains the redaction. That is the trade this
+    /// feature is *for* — a name kept by mistake is a leak, a name dropped by
+    /// mistake is a slightly duller export.
+    ///
+    /// The snapshot itself is never mutated: it stays whole in the editor's
+    /// state and in its sidecar, which is what lets undoing a redaction bring
+    /// the context back (#44). Only the copy that leaves the app is stripped.
+    func element(atNormalized point: CGPoint, hiddenBy mask: RedactionMask) -> Resolved? {
+        guard !mask.hides(point) else { return nil }
+        guard var resolved = element(atNormalized: point) else { return nil }
+        guard !mask.isEmpty else { return resolved }
+
+        resolved.element = redacting(resolved.element, under: mask)
+        resolved.ancestors = resolved.ancestors.map { redacting($0, under: mask) }
+        return resolved
+    }
+
+    /// Strips every human-readable field from an element a redaction covers,
+    /// and says so through `redaction` rather than leaving a silent gap a reader
+    /// could take for "this element had nothing to show".
+    private func redacting(_ element: Element, under mask: RedactionMask) -> Element {
+        guard mask.hides(normalizedRect(for: element.frame)) else { return element }
+        var stripped = element
+        stripped.title = nil
+        stripped.label = nil
+        stripped.identifier = nil
+        stripped.help = nil
+        stripped.placeholder = nil
+        stripped.value = nil
+        stripped.redaction = .userRedaction
+        return stripped
+    }
+}

--- a/Pinpoint/Theme.swift
+++ b/Pinpoint/Theme.swift
@@ -9,10 +9,21 @@ extension NSColor {
     static let pinpointVermillon = NSColor(srgbRed: 255.0 / 255, green: 77.0 / 255, blue: 46.0 / 255, alpha: 1)
     static let pinpointVermillonLight = NSColor(srgbRed: 255.0 / 255, green: 106.0 / 255, blue: 69.0 / 255, alpha: 1)
     static let pinpointVermillonDark = NSColor(srgbRed: 232.0 / 255, green: 53.0 / 255, blue: 15.0 / 255, alpha: 1)
+
+    /// The bar that hides a redacted region (#50) — the same near-black ink the
+    /// exported legend prints in, so a redaction reads as part of the design
+    /// rather than as a hole punched in the capture.
+    ///
+    /// Fully opaque, and it has to stay that way: the whole guarantee of the
+    /// feature is that nothing of what is underneath survives in the exported
+    /// pixels. An alpha below 1 here would silently turn every redaction into a
+    /// tint over readable text.
+    static let pinpointRedaction = NSColor(srgbRed: 0.114, green: 0.114, blue: 0.122, alpha: 1)
 }
 
 extension Color {
     static let pinpointVermillon = Color(nsColor: .pinpointVermillon)
     static let pinpointVermillonLight = Color(nsColor: .pinpointVermillonLight)
     static let pinpointVermillonDark = Color(nsColor: .pinpointVermillonDark)
+    static let pinpointRedaction = Color(nsColor: .pinpointRedaction)
 }


### PR DESCRIPTION
Closes #50

Partager un vrai écran avec un agent implique souvent de cacher un token, un e-mail ou une clé d'API. Jusqu'ici il fallait un autre outil, donc quitter le flux capture → prompt. Un quatrième outil (**⌘4**) recouvre désormais une région au glisser, avant l'export.

## Ce que ça donne

Une rédaction est un `Markup.Kind` de plus, pas un cas particulier : elle se trace au glisser comme un rectangle, se sélectionne, se déplace, se redimensionne par les huit poignées de `SelectionHandle` (#45/#47), se supprime avec ⌫, apparaît dans le panneau latéral, et **chaque geste vaut une entrée d'annulation** via `withUndo` (#44). Une seule différence de comportement, assumée : on l'attrape sur toute sa surface et pas seulement sur son contour, parce qu'une barre pleine n'est pas un rectangle creux.

Ses dimensions viennent de `MarkupMetrics` (#48) comme le reste — le liseré vermillon est `metrics.lineWidth` — donc l'aperçu et l'export masquent au même endroit et au même grain.

## Barre opaque, pas pixelisation

Choix assumé, un seul mode : **la barre opaque**. Une pixelisation reste une transformation déterministe des pixels qu'elle prétend cacher — encore lisible à l'œil quand le bloc est fin, récupérable statistiquement quand il ne l'est pas (une dépixelisation par recherche sur les rendus plausibles est un exercice connu). La barre, elle, ne transforme rien : elle remplace. Proposer les deux, ce serait offrir un réglage dont la mauvaise valeur ne se voit pas.

Trois détails d'implémentation portent la garantie, aucun n'est cosmétique :

- composition `.copy` plutôt que source-over : les pixels sont **remplacés**, jamais mélangés ;
- rect arrondi vers l'extérieur (`integral`) : une barre sur des bornes fractionnaires laisse une rangée de pixels partiellement couverts — et un fragment de caractère est parfois un caractère entier ;
- antialiasing coupé pendant le remplissage, pour la même raison ;
- coins vifs, contrairement au rectangle d'annotation : un coin arrondi laisserait voir les quatre coins de la région tracée.

Les rédactions sont dessinées **avant** les autres formes et avant les repères (`inDrawOrder`, une définition partagée par l'aperçu et par `Exporter`, donc les deux empilent pareil) : un repère posé sur une zone masquée reste visible au-dessus d'elle.

## Le vrai sujet : les deux canaux texte

Une rédaction qui masque à l'écran mais laisse fuir la donnée ailleurs est pire qu'absente. `develop` a reçu deux canaux qui exfiltrent du texte à chaque copie, et les deux sont traités.

**Le handoff par fichier (#54).** Le PNG écrit dans `last/` et dans `archive/` passe par `Exporter.pngData` → `annotatedImage` → `drawMarkup`, donc il porte la rédaction. Vérifié réellement, pas supposé (voir plus bas).

**Le contexte d'accessibilité (#55).** C'est le trou facile à manquer : l'image est propre et le token part en clair dans le `.md` et le `.json`. Un `RedactionMask`, construit depuis `shapes`, est donc traversé par les **deux** exporteurs — `Exporter.buildText` et `FileHandoff.Document.init`, les deux seuls endroits qui appellent `element(atNormalized:)`. Deux règles, volontairement franches :

1. **Un repère posé sur une zone masquée ne résout vers rien du tout.** Ni un élément anonyme, ni son parent : rien. Sans cette règle, l'étape de promotion de `element(atNormalized:)` aurait pu remonter à l'ancêtre actionnable de la feuille cachée — un bouton dont le label, lui, n'a jamais été couvert — et nommer ce qui était sous la barre.
2. **Tout élément dont la frame est touchée par une rédaction perd son nom et sa valeur** (`title`, `label`, `identifier`, `help`, `placeholder`, `value`), y compris dans la chaîne d'ancêtres imprimée dans `Path`. Restent le rôle, la box et la position, qui décrivent une géométrie que la barre noire annonce déjà.

Le seuil de la règle 2 est zéro, pas « la moitié » : le texte d'un élément est rendu **dans sa propre frame**, donc une rédaction qui couvre un dixième d'un libellé couvre un dixième de ses caractères — précisément ceux qu'on voulait cacher. Il n'existe pas de seuil sûr au-dessus de zéro.

Le prix est réel et je le note : une rédaction n'importe où dans une fenêtre retire aussi le **titre de cette fenêtre** de tous les chemins, puisque sa frame contient la rédaction. Un nom gardé par erreur est une fuite, un nom perdu par erreur est un export un peu plus terne — l'échange est le bon sens de cette feature.

Le `.md` gagne une phrase de légende (seulement s'il y a une rédaction, donc les captures sans rédaction gardent leur texte au bit près) qui dit à l'agent qu'une région a été recouverte et que rien n'a été collecté dessous — sans jamais dire ce qu'elle masquait. Côté JSON, aucun changement de format global : les formes gagnent `kind: "redaction"` et le champ `redacted` existant gagne la valeur `userRedaction`.

## Undo, et ce qui se passe après une copie

Le snapshot d'accessibilité **n'est jamais muté** : seul l'exemplaire qui sort de l'app est expurgé. Donc :

- **Annuler une rédaction ne restaure rien dans un export déjà écrit.** `last/` et `archive/<stamp>/` sont des instantanés figés au moment de la copie ; l'annulation ne les réécrit pas, et le presse-papier garde l'image masquée jusqu'à la copie suivante. Une rédaction ne peut pas être défaite rétroactivement.
- Une **nouvelle** copie après annulation écrase `last/` par une version non masquée — c'est un geste explicite de l'utilisateur, et c'est ce qui rend l'annulation utile (masquer par erreur ne doit pas condamner la capture).
- Limite connue, honnêtement : si on copie **avant** de masquer, la version non masquée reste dans `archive/` (dix entrées) et l'image de base non annotée reste dans l'historique local. La rédaction protège ce qui **sort** de l'app, pas l'historique local de la machine.

Un cas trouvé en chemin et corrigé : le recadrage abandonnait une forme dont aucun point de définition ne survivait, ce qui **supprimait une rédaction plus large que le cadre** — et découvrait dans l'image recadrée des pixels qui avaient été peints. Une rédaction survit désormais au simple chevauchement, clampée à ce qu'il en reste. Un recadrage ne peut plus défaire une rédaction.

## Vérification

Le build CI (`xcodegen generate` + `xcodebuild`) passe.

Au-delà, un harnais jetable a compilé les vraies sources (`Exporter`, `FileHandoff`, `HandoffDocument`, `Redaction`, `AXSnapshot`) et exécuté `FileHandoff.write` de bout en bout, avec `CFFIXED_USER_HOME` redirigé vers un dossier jetable (garde-fou dans le code du test : il refuse de tourner si le chemin d'écriture n'est pas dans le bac à sable, ce qui a d'ailleurs bloqué la première tentative). Scénario : une capture avec un bloc magenta « secret », une rédaction exactement dessus, un repère **dedans** et un repère **dehors**, et un `AXSnapshot` dont l'élément caché porte le token dans son `title` **et** dans sa `value`.

Résultats, sur `last/capture.png` **et** sur la copie d'archive :

- contrôle préalable : sans rédaction, le `.md` contient bien le secret — le test sait détecter une fuite ;
- 96 000 pixels échantillonnés dans la région : **aucun** pixel du bloc secret ne survit ;
- l'intérieur de la barre porte **exactement une couleur** : aucune structure de l'image d'origine ne subsiste, et chaque pixel est opaque ;
- le repère posé dans la zone est toujours dessiné **au-dessus** de la barre ;
- le reste de la capture est intact ;
- `capture.md` et `capture.json` ne contiennent ni le token, ni le label, ni l'`identifier` de l'élément caché ; le repère intérieur n'a **aucune** ligne `UI:`/`Path:` ; le repère extérieur garde tout son contexte (non-régression #55) ;
- le texte du presse-papier suit le même chemin et ne porte rien non plus ;
- retirer la rédaction rend le contexte aux **nouveaux** exports, tandis que le handoff déjà sur disque reste masqué.

L'export rendu, relu à l'œil : barre quasi noire à liseré vermillon, repère lisible dessus, le reste inchangé.

## i18n

Sept clés ajoutées avec `en` **et** `fr`, insérées à leur place alphabétique dans `Localizable.xcstrings`, rien d'autre touché dans le fichier.
