### PR TITLE
Capture de fenêtre précise : barre d'espace, survol, un clic

### DIFF
--- a/Pinpoint/AXSnapshotCollector.swift
+++ b/Pinpoint/AXSnapshotCollector.swift
@@ -91,6 +91,12 @@ enum AXSnapshotCollector {
     ///
     /// Call it *alongside* the screenshot rather than after it: the two then
     /// describe the same instant, which is the whole contract of the snapshot.
+    ///
+    /// A window capture (#51) is the favourable case, and it is treated as one:
+    /// the owning process is already known, so the search over "which
+    /// applications might be under this rectangle" is skipped entirely and the
+    /// walk starts at that application's windows — cheaper, and free of the
+    /// neighbours that happen to sit under the same coordinates.
     static func capture(region: CaptureRegion, includeFieldValues: Bool) async -> AXSnapshot? {
         guard AXPermission.isTrusted else { return nil }
 
@@ -104,8 +110,9 @@ enum AXSnapshotCollector {
         // lets whichever finishes first resume, and lets the loser be ignored.
         return await withCheckedContinuation { continuation in
             let box = SingleResume(continuation)
+            let target = region.window
             Task.detached(priority: .userInitiated) {
-                box.resume(walk(screenRect: screenRect, display: display,
+                box.resume(walk(screenRect: screenRect, display: display, target: target,
                                 includeFieldValues: includeFieldValues))
             }
             DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + hardCeiling) {
@@ -129,12 +136,19 @@ enum AXSnapshotCollector {
 
     // MARK: - The walk
 
-    private static func walk(screenRect: CGRect, display: CGRect, includeFieldValues: Bool) -> AXSnapshot? {
+    private static func walk(screenRect: CGRect, display: CGRect,
+                             target: CaptureRegion.WindowTarget?,
+                             includeFieldValues: Bool) -> AXSnapshot? {
         var state = State(region: screenRect,
                           includeFieldValues: includeFieldValues,
                           deadline: CACurrentMediaTime() + walkBudget)
 
-        for (order, pid) in owningProcesses(over: screenRect, on: display).enumerated() {
+        // One known process for a window capture, the window-list search
+        // otherwise.
+        let processes = target.map { [$0.processIdentifier] }
+            ?? owningProcesses(over: screenRect, on: display)
+
+        for (order, pid) in processes.enumerated() {
             guard !state.reachedElementLimit() else { break }
 
             let application = AXUIElementCreateApplication(pid)
@@ -152,10 +166,15 @@ enum AXSnapshotCollector {
             // an open menu or a popover — exactly what the capture timer exists
             // to let people photograph — is walked like any other top-level
             // container.
-            let roots = children(of: application) ?? []
-            for root in roots {
+            let roots = prioritised(children(of: application) ?? [], matching: target?.screenFrame)
+            for (rootIndex, root) in roots.enumerated() {
+                // Ranking by root rather than by application is what makes the
+                // targeted case precise: an app with two overlapping windows
+                // would otherwise give both the same rank, and a marker could
+                // resolve against the one *behind* the window that was
+                // photographed.
                 descend(root, parent: nil, depth: 0, application: appIndex,
-                        windowOrder: order, into: &state)
+                        windowOrder: target == nil ? order : rootIndex, into: &state)
             }
         }
 
@@ -168,6 +187,36 @@ enum AXSnapshotCollector {
             capturedAt: Date(),
             includesFieldValues: includeFieldValues
         )
+    }
+
+    /// Moves the captured window to the front of an application's top-level
+    /// elements, so it outranks its siblings.
+    ///
+    /// `SCWindow` and `AXFrame` report the same rectangle in the same space
+    /// (points, global top-left), which is the whole reason a `CGWindowID` can
+    /// be tied to an accessibility element without reaching for a private API:
+    /// the frames simply match. When nothing matches — the window moved between
+    /// the pick and the shutter, or the app doesn't answer `AXFrame` — the
+    /// order is left alone and the region pruning does its usual work.
+    private static func prioritised(_ roots: [AXUIElement], matching target: CGRect?) -> [AXUIElement] {
+        guard let target,
+              let match = roots.firstIndex(where: { matches(frame(of: $0), target) }) else {
+            return roots
+        }
+        var ordered = roots
+        ordered.insert(ordered.remove(at: match), at: 0)
+        return ordered
+    }
+
+    /// Frame equality with a point of slack: accessibility and window-server
+    /// geometry agree, but not always to the last fraction of a point.
+    private static func matches(_ frame: CGRect?, _ target: CGRect) -> Bool {
+        guard let frame else { return false }
+        let tolerance: CGFloat = 2
+        return abs(frame.minX - target.minX) <= tolerance
+            && abs(frame.minY - target.minY) <= tolerance
+            && abs(frame.width - target.width) <= tolerance
+            && abs(frame.height - target.height) <= tolerance
     }
 
     /// Depth-first, parents recorded before their children so `parent` indices

--- a/Pinpoint/CaptureRegion.swift
+++ b/Pinpoint/CaptureRegion.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import ScreenCaptureKit
 
 /// A resolved screen region to capture.
 ///
@@ -12,4 +13,42 @@ struct CaptureRegion: Equatable {
     let rect: CGRect
     /// Backing scale factor of the target display.
     let scale: CGFloat
+    /// Set when the capture targets one window rather than a screen rectangle
+    /// (#51). It changes *how* the pixels are read — a window filter instead of
+    /// a source rect — while `rect` keeps describing the same thing: the piece
+    /// of screen the resulting image covers. Everything downstream (the
+    /// accessibility snapshot, the marker → screen-point mapping of #55) reads
+    /// `rect` and needs no special case.
+    let window: WindowTarget?
+
+    init(displayID: CGDirectDisplayID, rect: CGRect, scale: CGFloat, window: WindowTarget? = nil) {
+        self.displayID = displayID
+        self.rect = rect
+        self.scale = scale
+        self.window = window
+    }
+
+    /// The same region cut down to what `display` can actually answer for, with
+    /// the window target dropped — the result no longer describes that window.
+    /// A degenerate intersection leaves the region untouched: there is nothing
+    /// better to offer, and the caller's own failure path is the honest one.
+    func clampedToDisplay(_ display: SCDisplay) -> CaptureRegion {
+        let bounds = CGRect(x: 0, y: 0, width: CGFloat(display.width), height: CGFloat(display.height))
+        let clamped = rect.intersection(bounds)
+        guard clamped.width >= 1, clamped.height >= 1 else { return self }
+        return CaptureRegion(displayID: displayID, rect: clamped, scale: scale)
+    }
+
+    /// The window a capture is aimed at, identified well enough to be found
+    /// again at capture time and to be matched against the accessibility tree.
+    struct WindowTarget: Equatable {
+        let id: CGWindowID
+        let processIdentifier: pid_t
+        let applicationName: String?
+        let title: String?
+        /// The window's frame in points, global **top-left** origin — the space
+        /// `AXFrame` also reports in, which is what lets the accessibility walk
+        /// pick the matching `AXWindow` out of an application that has several.
+        let screenFrame: CGRect
+    }
 }

--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -274,6 +274,18 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Ordre de tri" } }
       }
     },
+    "a11y.window.empty" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "No window under the pointer" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Aucune fenêtre sous le pointeur" } }
+      }
+    },
+    "a11y.window.selection" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Window selection" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Sélection de fenêtre" } }
+      }
+    },
     "Add to favorites" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Ajouter aux favoris" } }
@@ -537,9 +549,9 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Terminé" } }
       }
     },
-    "Drag a rectangle · Esc to cancel" : {
+    "Drag a rectangle · Space to pick a window · Esc to cancel" : {
       "localizations" : {
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Trace un rectangle · Échap pour annuler" } }
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Trace un rectangle · Espace pour choisir une fenêtre · Échap pour annuler" } }
       }
     },
     "Drag file" : {
@@ -667,6 +679,11 @@
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "The capture was copied to the clipboard, but the files for the agent couldn’t be written to %@: %@" } },
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "La capture a été copiée dans le presse-papier, mais les fichiers destinés à l’agent n’ont pas pu être écrits dans %@ : %@" } }
+      }
+    },
+    "Hover a window · click to capture · Space for a rectangle · Esc to cancel" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Survole une fenêtre · clique pour capturer · Espace pour un rectangle · Échap pour annuler" } }
       }
     },
     "Instructions for the agent" : {
@@ -1117,6 +1134,12 @@
     "White ring + drop shadow." : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Anneau blanc + ombre portée." } }
+      }
+    },
+    "window.untitled" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Untitled window" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Fenêtre sans titre" } }
       }
     },
     "Yesterday" : {

--- a/Pinpoint/RegionSelectionController.swift
+++ b/Pinpoint/RegionSelectionController.swift
@@ -13,6 +13,15 @@ import AppKit
 final class RegionSelectionController {
     private var windows: [OverlayWindow] = []
     private var continuation: CheckedContinuation<CaptureRegion?, Never>?
+    /// Whether the space bar has switched the whole selection over to picking
+    /// windows (#51). It belongs here rather than in one view: with one overlay
+    /// per screen, the mode has to be the same on all of them or moving the
+    /// pointer to another display would silently leave it.
+    private var isWindowMode = false
+    /// Discovering the windows takes a round trip to the window server, so it
+    /// runs *after* the overlay is up and feeds the views when it lands. The
+    /// shortcut therefore stays as immediate as it was.
+    private var discovery: Task<Void, Never>?
 
     /// Shows the overlay and resolves with the chosen region, or `nil` if the
     /// user cancelled (Esc, or a click without a meaningful drag) — or if screen
@@ -65,10 +74,18 @@ final class RegionSelectionController {
             view.onComplete = { [weak self] globalRect, anchor in
                 self?.finish(Self.resolve(globalRect: globalRect, anchor: anchor))
             }
+            view.onCompleteWindow = { [weak self] window in
+                self?.finish(Self.resolve(window: window))
+            }
             view.onCancel = { [weak self] in self?.finish(nil) }
             view.onBeginSelection = { [weak self, weak view] in
                 guard let view else { return }
                 self?.focus(view)
+            }
+            view.onToggleWindowMode = { [weak self] in self?.toggleWindowMode() }
+            view.onHoverWindow = { [weak self, weak view] hovered in
+                guard let view else { return }
+                self?.highlight(hovered, from: view)
             }
             window.contentView = view
 
@@ -83,6 +100,42 @@ final class RegionSelectionController {
         }
 
         NSCursor.crosshair.push()
+        discoverWindows()
+    }
+
+    // MARK: - Window mode
+
+    /// Loads the pickable windows and hands them to every view.
+    ///
+    /// Best-effort by design: if it fails or hasn't landed yet, space still
+    /// switches the mode and simply has nothing to highlight until it does.
+    private func discoverWindows() {
+        discovery = Task { [weak self] in
+            let candidates = await WindowPicker.candidates()
+            guard let self, !Task.isCancelled else { return }
+            for window in self.windows {
+                (window.contentView as? RegionSelectionView)?.setCandidates(candidates)
+            }
+        }
+    }
+
+    /// Flips every screen's overlay between rectangle and window mode.
+    private func toggleWindowMode() {
+        isWindowMode.toggle()
+        for window in windows {
+            (window.contentView as? RegionSelectionView)?.setWindowMode(isWindowMode)
+        }
+    }
+
+    /// Mirrors the highlight decided by the view under the pointer onto the
+    /// others, so a window spanning two displays is outlined on both, and hands
+    /// that view the keyboard (Return, Esc, space) at the same time.
+    private func highlight(_ window: PickableWindow?, from view: RegionSelectionView) {
+        for other in windows {
+            guard let candidate = other.contentView as? RegionSelectionView, candidate !== view else { continue }
+            candidate.setHighlight(window)
+        }
+        focus(view)
     }
 
     /// Hands the hint, the keyboard focus and the sole selection to the screen
@@ -95,7 +148,9 @@ final class RegionSelectionController {
             guard let other = window.contentView as? RegionSelectionView else { continue }
             let isActive = (other === view)
             other.showsHint = isActive
-            if !isActive { other.clearSelection() }
+            // In window mode the other views are showing a mirror of this one's
+            // highlight, so clearing them would undo what `highlight` just did.
+            if !isActive, !isWindowMode { other.clearSelection() }
         }
         guard let window = view.window, !window.isKeyWindow else { return }
         window.makeKeyAndOrderFront(nil)
@@ -105,6 +160,8 @@ final class RegionSelectionController {
     private func finish(_ region: CaptureRegion?) {
         guard let continuation else { return }
         self.continuation = nil
+        discovery?.cancel()
+        discovery = nil
         NSCursor.pop()
         for window in windows { window.orderOut(nil) }
         windows.removeAll()
@@ -136,6 +193,42 @@ final class RegionSelectionController {
             height: clamped.height
         )
         return CaptureRegion(displayID: displayID, rect: rect, scale: screen.backingScaleFactor)
+    }
+
+    /// Turns a picked window into a capture region.
+    ///
+    /// `rect` still describes the piece of screen the image will cover, exactly
+    /// as it does for a dragged rectangle — that is what keeps the accessibility
+    /// mapping of #55 working with no special case. It is allowed to run past
+    /// the display's own bounds: a window half off-screen, or straddling two
+    /// displays, stays one rectangle expressed relative to one origin, and
+    /// `ScreenCapture` re-reads the authoritative geometry at shutter time
+    /// anyway.
+    ///
+    /// The display picked is the one showing most of the window, which is what
+    /// decides the countdown's screen and the fallback scale.
+    private static func resolve(window: PickableWindow) -> CaptureRegion? {
+        let screens = NSScreen.screens
+        let screen = screens.max { area($0.frame.intersection(window.overlayFrame))
+                                 < area($1.frame.intersection(window.overlayFrame)) }
+            ?? NSScreen.main
+        guard let screen, let displayID = screen.displayID else { return nil }
+
+        // Both rectangles are in the same space (points, global top-left), so
+        // going display-relative is a plain subtraction.
+        let origin = CGDisplayBounds(displayID).origin
+        return CaptureRegion(
+            displayID: displayID,
+            rect: window.screenFrame.offsetBy(dx: -origin.x, dy: -origin.y),
+            scale: screen.backingScaleFactor,
+            window: CaptureRegion.WindowTarget(
+                id: window.id,
+                processIdentifier: window.processIdentifier,
+                applicationName: window.applicationName,
+                title: window.title,
+                screenFrame: window.screenFrame
+            )
+        )
     }
 
     private static func area(_ rect: CGRect) -> CGFloat {

--- a/Pinpoint/RegionSelectionView.swift
+++ b/Pinpoint/RegionSelectionView.swift
@@ -9,12 +9,20 @@ import AppKit
 /// captures, Esc cancels the whole selection, and a drag starting outside it
 /// rubber-bands a fresh one.
 ///
+/// The space bar switches to *window mode* (#51), the same key macOS itself
+/// uses: the rectangle gives way to whichever window is under the pointer,
+/// highlighted whole, and a click captures it with its real edges and rounded
+/// corners. Space switches back, and a rectangle already drawn survives the
+/// round trip.
+///
 /// Everything is tracked in view-local coordinates and handed back to
 /// `RegionSelectionController` in global (screen) coordinates.
 final class RegionSelectionView: NSView {
     /// Called when the user validates the selection, with the rect in global
     /// AppKit coordinates (bottom-left origin) and the drag's anchor point.
     var onComplete: ((CGRect, CGPoint) -> Void)?
+    /// Called when the user picks a whole window in window mode.
+    var onCompleteWindow: ((PickableWindow) -> Void)?
     /// Called when the user cancels (Esc, or a click without a real drag).
     var onCancel: (() -> Void)?
     /// Called on every mouse-down, before anything else. The controller uses it
@@ -22,6 +30,14 @@ final class RegionSelectionView: NSView {
     /// selecting on — otherwise a selection started on a secondary display would
     /// leave Esc/Return/arrows going to another window.
     var onBeginSelection: (() -> Void)?
+    /// Called when the space bar is pressed. Window mode is a state of the whole
+    /// selection, not of one screen, so the controller mirrors it everywhere.
+    var onToggleWindowMode: (() -> Void)?
+    /// Called when the pointer settles over a window (or over nothing) in window
+    /// mode. The controller uses it both to move the keyboard focus to this
+    /// screen and to mirror the highlight onto the other screens, so a window
+    /// straddling two displays lights up on both.
+    var onHoverWindow: ((PickableWindow?) -> Void)?
     /// Whether to draw the hint. With one view per screen, only the view the
     /// user is working on sets this, so the hint shows just once.
     var showsHint: Bool = true { didSet { needsDisplay = true } }
@@ -60,6 +76,19 @@ final class RegionSelectionView: NSView {
     private var pressPoint: CGPoint?
     private var trackingArea: NSTrackingArea?
 
+    /// Whether the space bar has switched this selection over to picking whole
+    /// windows. Mirrored across every screen's view by the controller.
+    private var isWindowMode = false
+    /// Every window a capture could target, frontmost first. Loaded in the
+    /// background while the overlay is already up, so the shortcut stays as
+    /// immediate as it was (#39's preflight runs before any of this).
+    private var candidates: [PickableWindow] = []
+    /// The window currently highlighted, whichever screen the pointer is on.
+    private var highlighted: PickableWindow?
+    /// Whether the pointer is on *this* screen. Only the view under it may
+    /// capture; the others merely echo the highlight.
+    private var ownsPointer = false
+
     override var isFlipped: Bool { false }
     override var acceptsFirstResponder: Bool { true }
     override var mouseDownCanMoveWindow: Bool { false }
@@ -75,15 +104,17 @@ final class RegionSelectionView: NSView {
         )
     }
 
-    /// The rect to draw: the live rubber band while drawing, the settled
-    /// selection otherwise.
+    /// The rect to draw: the highlighted window in window mode, the live rubber
+    /// band while drawing, the settled selection otherwise.
     private var displayRect: CGRect? {
+        if isWindowMode { return highlighted.flatMap { viewRect(for: $0.overlayFrame) } }
         if case .drawing = gesture { return rubberBandRect }
         return selection
     }
 
     /// Whether a settled selection is up and waiting to be adjusted.
     private var isAdjusting: Bool {
+        if isWindowMode { return false }
         if case .drawing = gesture { return false }
         return selection != nil
     }
@@ -101,13 +132,92 @@ final class RegionSelectionView: NSView {
         needsDisplay = true
     }
 
+    // MARK: - Window mode
+
+    /// Hands over the list of windows a capture could target. Arrives after the
+    /// overlay is already on screen, so the highlight is recomputed in case the
+    /// user is waiting in window mode with the pointer still.
+    func setCandidates(_ windows: [PickableWindow]) {
+        candidates = windows
+        guard isWindowMode else { return }
+        updateHighlight()
+    }
+
+    /// Switches this screen's view into (or out of) window mode.
+    func setWindowMode(_ enabled: Bool) {
+        guard isWindowMode != enabled else { return }
+        isWindowMode = enabled
+        // A gesture in flight belongs to the mode being left.
+        gesture = .none
+        pressPoint = nil
+        lastDragPoint = nil
+        anchor = nil
+        current = nil
+        if enabled {
+            updateHighlight()
+        } else {
+            highlighted = nil
+            ownsPointer = false
+        }
+        needsDisplay = true
+        announceSelection()
+        cursorForPointer()?.set()
+    }
+
+    /// Echoes a highlight decided by the view under the pointer, so a window
+    /// spanning two displays is outlined on both.
+    func setHighlight(_ window: PickableWindow?) {
+        ownsPointer = false
+        guard highlighted != window else { return }
+        highlighted = window
+        needsDisplay = true
+    }
+
+    /// Recomputes what the pointer is over and tells the controller, which
+    /// mirrors it onto the other screens.
+    ///
+    /// The pointer position is read from `NSEvent` rather than taken from an
+    /// event, so this also works when nothing moved — pressing space with a
+    /// still mouse has to light a window up immediately.
+    private func updateHighlight() {
+        let point = NSEvent.mouseLocation
+        guard let window, window.frame.contains(point) else {
+            // The pointer is on another screen: that view owns the decision.
+            ownsPointer = false
+            return
+        }
+        // Notify on taking the pointer over as well as on a change of window: a
+        // window spanning two displays is already highlighted on both, so
+        // "nothing changed" would otherwise leave the keyboard on the screen
+        // the pointer just left.
+        let takingOver = !ownsPointer
+        ownsPointer = true
+        let next = WindowPicker.window(at: point, in: candidates)
+        guard next != highlighted || takingOver else { return }
+        highlighted = next
+        needsDisplay = true
+        announceSelection()
+        onHoverWindow?(next)
+    }
+
+    /// A global AppKit rect in this view's own coordinates.
+    private func viewRect(for globalRect: CGRect) -> CGRect? {
+        guard let window else { return nil }
+        return convert(window.convertFromScreen(globalRect), from: nil)
+    }
+
     // MARK: - Mouse
 
     override func mouseDown(with event: NSEvent) {
-        onBeginSelection?()
         let point = convert(event.locationInWindow, from: nil)
         pressPoint = point
         lastDragPoint = point
+
+        // Window mode has nothing to rubber-band: the press only has to be
+        // remembered long enough to tell a click from a stray drag.
+        guard !isWindowMode else { return }
+
+        onBeginSelection?()
 
         if let selection {
             if let handle = SelectionHandle.hit(point, in: selection, tolerance: Self.handleTolerance) {
@@ -132,6 +242,11 @@ final class RegionSelectionView: NSView {
 
     override func mouseDragged(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
+        guard !isWindowMode else {
+            // Dragging in window mode just moves the highlight along.
+            updateHighlight()
+            return
+        }
         defer { lastDragPoint = point; needsDisplay = true }
 
         switch gesture {
@@ -160,6 +275,13 @@ final class RegionSelectionView: NSView {
         gesture = .none
         pressPoint = nil
         lastDragPoint = nil
+
+        guard !isWindowMode else {
+            // A click captures the highlighted window; a drag that wandered off
+            // it does nothing, so a slip of the hand can't fire the shutter.
+            if travel < Self.clickSlop { commitWindow() }
+            return
+        }
         defer { announceSelection() }
 
         switch finished {
@@ -196,7 +318,8 @@ final class RegionSelectionView: NSView {
         let step: CGFloat = event.modifierFlags.contains(.shift) ? 10 : 1
         switch event.keyCode {
         case 53:            onCancel?()                 // Esc — cancels everything
-        case 36, 76:        commit()                    // Return / keypad Enter
+        case 49:            onToggleWindowMode?()       // Space — rectangle ⇄ window
+        case 36, 76:        isWindowMode ? commitWindow() : commit()  // Return / keypad Enter
         case 123:           nudge(dx: -step, dy: 0)     // ←
         case 124:           nudge(dx: step, dy: 0)      // →
         case 125:           nudge(dx: 0, dy: -step)     // ↓ (unflipped view)
@@ -225,6 +348,13 @@ final class RegionSelectionView: NSView {
         onComplete?(globalRect, anchor)
     }
 
+    /// Hands over the highlighted window. Only the view the pointer is on may
+    /// do this: the others are showing an echo of its decision.
+    private func commitWindow() {
+        guard isWindowMode, ownsPointer, let highlighted else { return }
+        onCompleteWindow?(highlighted)
+    }
+
     // MARK: - Accessibility
 
     /// The overlay is one element as far as VoiceOver is concerned: it has no
@@ -235,10 +365,19 @@ final class RegionSelectionView: NSView {
     override func accessibilityRole() -> NSAccessibility.Role? { .group }
 
     override func accessibilityLabel() -> String? {
-        String(localized: "a11y.region.selection", defaultValue: "Region selection")
+        isWindowMode
+            ? String(localized: "a11y.window.selection", defaultValue: "Window selection")
+            : String(localized: "a11y.region.selection", defaultValue: "Region selection")
     }
 
     override func accessibilityValue() -> Any? {
+        if isWindowMode {
+            guard let highlighted else {
+                return String(localized: "a11y.window.empty",
+                              defaultValue: "No window under the pointer")
+            }
+            return highlighted.displayName
+        }
         guard let selection else {
             return String(localized: "a11y.region.empty", defaultValue: "No region selected yet")
         }
@@ -250,11 +389,7 @@ final class RegionSelectionView: NSView {
 
     /// The same sentence the on-screen hint carries, so the keyboard steps are
     /// reachable without reading the badge.
-    override func accessibilityHelp() -> String? {
-        isAdjusting
-            ? String(localized: "Drag or nudge with arrows · ↵ to capture · Esc to cancel")
-            : String(localized: "Drag a rectangle · Esc to cancel")
-    }
+    override func accessibilityHelp() -> String? { hintText }
 
     /// Announces the new size once a gesture settles. Deliberately not called
     /// per drag event: VoiceOver would read a new figure every frame.
@@ -281,14 +416,18 @@ final class RegionSelectionView: NSView {
     }
 
     override func mouseMoved(with event: NSEvent) {
+        if isWindowMode { updateHighlight() }
         cursor(at: convert(event.locationInWindow, from: nil)).set()
     }
 
     /// Crosshair everywhere, except over an adjustable selection: its handles
     /// get the matching resize cursor and its interior an open hand, so the rect
-    /// reads as draggable. The controller pushes the crosshair; setting a cursor
-    /// here only changes what's displayed, so its `pop()` still restores.
+    /// reads as draggable. Window mode uses the plain arrow — there is nothing
+    /// to aim precisely, only a window to point at. The controller pushes the
+    /// crosshair; setting a cursor here only changes what's displayed, so its
+    /// `pop()` still restores.
     private func cursor(at point: CGPoint) -> NSCursor {
+        if isWindowMode { return .arrow }
         guard isAdjusting, let selection else { return .crosshair }
         if let handle = SelectionHandle.hit(point, in: selection, tolerance: Self.handleTolerance) {
             return handle.cursor
@@ -296,7 +435,29 @@ final class RegionSelectionView: NSView {
         return selection.contains(point) ? .openHand : .crosshair
     }
 
+    /// The cursor for wherever the pointer happens to be right now — used when
+    /// the mode changes under a still mouse, which sends no event. `nil` when
+    /// the pointer is on another screen: every view is told about the mode
+    /// change, and only the one under the pointer gets to say what it looks
+    /// like.
+    private func cursorForPointer() -> NSCursor? {
+        guard let window, window.frame.contains(NSEvent.mouseLocation) else { return nil }
+        let inWindow = window.convertPoint(fromScreen: NSEvent.mouseLocation)
+        return cursor(at: convert(inWindow, from: nil))
+    }
+
     // MARK: - Drawing
+
+    /// What the badge at the bottom (or centre) of the screen says. Also read
+    /// out as the accessibility help, so the two never drift apart.
+    private var hintText: String {
+        if isWindowMode {
+            return String(localized: "Hover a window · click to capture · Space for a rectangle · Esc to cancel")
+        }
+        return isAdjusting
+            ? String(localized: "Drag or nudge with arrows · ↵ to capture · Esc to cancel")
+            : String(localized: "Drag a rectangle · Space to pick a window · Esc to cancel")
+    }
 
     override func draw(_ dirtyRect: NSRect) {
         let dim = NSColor.black.withAlphaComponent(0.45)
@@ -304,7 +465,7 @@ final class RegionSelectionView: NSView {
 
         guard let sel = displayRect?.intersection(bounds), sel.width > 0, sel.height > 0 else {
             bounds.fill()
-            if showsHint { drawHint(String(localized: "Drag a rectangle · Esc to cancel"), at: bounds.center) }
+            if showsHint { drawHint(hintText, at: bounds.center) }
             return
         }
 
@@ -321,17 +482,21 @@ final class RegionSelectionView: NSView {
         border.lineWidth = 1.5
         border.stroke()
 
-        drawHandles(sel)
-        drawDimensions(sel)
-        if showsHint, isAdjusting {
+        if isWindowMode {
+            drawWindowName(in: sel)
+            // The window's own size, not the part that fits on this screen —
+            // otherwise a window spanning two displays reports two wrong figures.
+            drawDimensions(sel, size: highlighted?.overlayFrame.size)
+        } else {
+            drawHandles(sel)
+            drawDimensions(sel, size: nil)
+        }
+        if showsHint, isWindowMode || isAdjusting {
             // Below the selection by default, above it when the rect reaches
             // that low — the hint must not sit on top of what's being framed.
             let low = CGPoint(x: bounds.midX, y: bounds.minY + 56)
             let high = CGPoint(x: bounds.midX, y: bounds.maxY - 56)
-            drawHint(
-                String(localized: "Drag or nudge with arrows · ↵ to capture · Esc to cancel"),
-                at: sel.minY < low.y + 24 ? high : low
-            )
+            drawHint(hintText, at: sel.minY < low.y + 24 ? high : low)
         }
     }
 
@@ -353,8 +518,9 @@ final class RegionSelectionView: NSView {
         }
     }
 
-    private func drawDimensions(_ sel: CGRect) {
-        let text = "\(Int(sel.width.rounded())) × \(Int(sel.height.rounded()))" as NSString
+    private func drawDimensions(_ sel: CGRect, size: CGSize?) {
+        let reported = size ?? sel.size
+        let text = "\(Int(reported.width.rounded())) × \(Int(reported.height.rounded()))" as NSString
         let attrs: [NSAttributedString.Key: Any] = [
             .font: NSFont.monospacedSystemFont(ofSize: 12, weight: .semibold),
             .foregroundColor: NSColor.white
@@ -372,6 +538,38 @@ final class RegionSelectionView: NSView {
         NSColor.black.withAlphaComponent(0.88).setFill()
         NSBezierPath(roundedRect: rect, xRadius: 6, yRadius: 6).fill()
         text.draw(at: CGPoint(x: rect.minX + padX, y: rect.minY + padY), withAttributes: attrs)
+    }
+
+    /// Names the highlighted window in its middle. Two windows of the same app
+    /// look alike from the outside, and the title is what tells them apart —
+    /// but only when there is room, so a small palette isn't covered by its own
+    /// label.
+    private func drawWindowName(in sel: CGRect) {
+        guard let highlighted, sel.width >= 160, sel.height >= 72 else { return }
+        let style = NSMutableParagraphStyle()
+        style.lineBreakMode = .byTruncatingMiddle
+        style.alignment = .center
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 13, weight: .semibold),
+            .foregroundColor: NSColor.white,
+            .paragraphStyle: style
+        ]
+        let text = highlighted.displayName as NSString
+        let measured = text.size(withAttributes: attrs)
+        let padX: CGFloat = 14, padY: CGFloat = 8
+        let width = min(measured.width, min(sel.width - 48, 520))
+        let badge = CGSize(width: width + padX * 2, height: measured.height + padY * 2)
+        let rect = CGRect(
+            x: sel.midX - badge.width / 2,
+            y: sel.midY - badge.height / 2,
+            width: badge.width,
+            height: badge.height
+        )
+        NSColor.black.withAlphaComponent(0.82).setFill()
+        NSBezierPath(roundedRect: rect, xRadius: 10, yRadius: 10).fill()
+        text.draw(in: CGRect(x: rect.minX + padX, y: rect.minY + padY,
+                             width: width, height: measured.height),
+                  withAttributes: attrs)
     }
 
     private func drawHint(_ string: String, at center: CGPoint) {

--- a/Pinpoint/ScreenCapture.swift
+++ b/Pinpoint/ScreenCapture.swift
@@ -162,10 +162,28 @@ enum ScreenCapture {
 
         let content = try await SCShareableContent.current
 
+        // Window mode (#51). The window is looked up again *now* rather than
+        // trusted from selection time: the capture delay gives it every chance
+        // to have moved, resized, or gone. If it's gone, the rect it occupied is
+        // still known, so the capture quietly degrades to the region below
+        // instead of failing.
+        if let target = region.window,
+           let window = content.windows.first(where: { $0.windowID == target.id }) {
+            return try await capture(window: window, target: target, on: region.displayID)
+        }
+
         guard let display = content.displays.first(where: { $0.displayID == region.displayID })
                 ?? content.displays.first else {
             throw ScreenCaptureError.noDisplay
         }
+
+        // A window capture only reaches this line when its window vanished
+        // between the pick and the shutter. Such a rect is the window's own
+        // frame, which — unlike a dragged rectangle — is free to run past the
+        // display it was resolved against, and a `sourceRect` that does comes
+        // back stretched. Clamping it keeps the fallback honest: a smaller
+        // picture of the right place, at the right scale.
+        let region = region.window == nil ? region : region.clampedToDisplay(display)
 
         let filter = SCContentFilter(display: display,
                                      excludingApplications: ownApplications(in: content),
@@ -185,6 +203,67 @@ enum ScreenCapture {
         // it — and if `captureImage` throws first, the child task is cancelled
         // with the scope.
         async let snapshot = accessibilitySnapshot(for: region)
+        let cgImage = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
+        return Capture(
+            image: NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height)),
+            accessibility: await snapshot
+        )
+    }
+
+    /// Captures one window on its own: no desktop behind it, no neighbouring
+    /// windows in front of it, transparent rounded corners.
+    ///
+    /// ## Why shadows are dropped
+    ///
+    /// `SCContentFilter(desktopIndependentWindow:)` reports a `contentRect`
+    /// equal to the window's own frame, and asking for it at
+    /// `pointPixelScale` yields an image aligned to that frame pixel for pixel.
+    /// Keeping the drop shadow does *not* enlarge the image: ScreenCaptureKit
+    /// fits "window + shadow" into the size that was asked for, which shrinks
+    /// the window itself and shifts it (measured on a 1798×1041 pt window: the
+    /// opaque content landed at 3247×1881 px offset by 101, 68 instead of
+    /// filling 3596×2082). That resamples the pixels *and* breaks the one
+    /// invariant this whole feature rests on — that `CaptureRegion.rect` is
+    /// exactly the piece of screen the image shows, which is what maps a marker
+    /// back to an accessibility element (#55). Dropping the shadow keeps the
+    /// mapping exact and still gives clean edges: the corners come back
+    /// genuinely transparent, so the PNG carries the window's real silhouette.
+    @MainActor
+    private static func capture(window: SCWindow,
+                                target: CaptureRegion.WindowTarget,
+                                on displayID: CGDirectDisplayID) async throws -> Capture {
+        let filter = SCContentFilter(desktopIndependentWindow: window)
+        let scale = CGFloat(filter.pointPixelScale)
+        let contentRect = filter.contentRect
+
+        let config = SCStreamConfiguration()
+        config.width = Int((contentRect.width * scale).rounded())
+        config.height = Int((contentRect.height * scale).rounded())
+        config.showsCursor = false
+        config.scalesToFit = false
+        config.captureResolution = .best
+        config.ignoreShadowsSingleWindow = true
+
+        // The region the image actually covers, rebuilt from the filter rather
+        // than from what the overlay resolved: those can differ by the time the
+        // shutter fires. `contentRect` is global and top-left, the display's
+        // bounds are in the same space, so the subtraction is all it takes to
+        // get back to the display-relative rect the rest of the app expects.
+        let displayOrigin = CGDisplayBounds(displayID).origin
+        let effective = CaptureRegion(
+            displayID: displayID,
+            rect: contentRect.offsetBy(dx: -displayOrigin.x, dy: -displayOrigin.y),
+            scale: scale,
+            window: CaptureRegion.WindowTarget(
+                id: target.id,
+                processIdentifier: target.processIdentifier,
+                applicationName: target.applicationName,
+                title: target.title,
+                screenFrame: contentRect
+            )
+        )
+
+        async let snapshot = accessibilitySnapshot(for: effective)
         let cgImage = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
         return Capture(
             image: NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height)),

--- a/Pinpoint/WindowPicker.swift
+++ b/Pinpoint/WindowPicker.swift
@@ -1,0 +1,143 @@
+import AppKit
+import CoreGraphics
+import ScreenCaptureKit
+
+/// One window the user can point at while choosing what to capture (#51).
+///
+/// It carries the same rectangle twice, because two coordinate spaces are
+/// unavoidable here: ScreenCaptureKit and the accessibility APIs both speak
+/// points with a **global top-left** origin, while the selection overlay draws
+/// in AppKit's **global bottom-left** one. Converting once, at discovery, keeps
+/// every call site from having to remember which is which.
+struct PickableWindow: Equatable, Sendable {
+    let id: CGWindowID
+    let processIdentifier: pid_t
+    let applicationName: String?
+    let title: String?
+    /// Points, global top-left origin — the space `SCWindow.frame` is in.
+    let screenFrame: CGRect
+    /// The same rectangle in global AppKit coordinates (bottom-left origin).
+    let overlayFrame: CGRect
+
+    /// `Safari — Apple`, or just the application when the window is untitled.
+    /// Shown on the overlay badge and announced to VoiceOver.
+    var displayName: String {
+        let title = (self.title?.isEmpty == false) ? self.title : nil
+        switch (applicationName, title) {
+        case let (app?, title?): return "\(app) — \(title)"
+        case let (app?, nil):    return app
+        case let (nil, title?):  return title
+        case (nil, nil):
+            return String(localized: "window.untitled", defaultValue: "Untitled window")
+        }
+    }
+}
+
+/// Lists the windows a capture can target, front-to-back.
+///
+/// Everything here is best-effort: a failure to enumerate simply means window
+/// mode has nothing to highlight, never that a capture fails.
+@MainActor
+enum WindowPicker {
+
+    /// Smallest window worth offering. System processes keep one- and
+    /// zero-pixel windows around that nobody could ever point at.
+    private static let minSide: CGFloat = 8
+
+    /// The windows a capture can target, frontmost first.
+    static func candidates() async -> [PickableWindow] {
+        // `excludingDesktopWindows: true` drops the wallpaper and the desktop
+        // icon layer; `onScreenWindowsOnly: true` drops minimised windows and
+        // everything living on another Space.
+        guard let content = try? await SCShareableContent.excludingDesktopWindows(
+            true, onScreenWindowsOnly: true
+        ) else { return [] }
+
+        let ownPID = ProcessInfo.processInfo.processIdentifier
+        let order = frontToBackOrder()
+        let flipAxis = flipAxis()
+        let screens = NSScreen.screens.map(\.frame)
+
+        return content.windows
+            .filter { isPickable($0, ownPID: ownPID) }
+            .sorted { (order[$0.windowID] ?? .max) < (order[$1.windowID] ?? .max) }
+            .compactMap { window -> PickableWindow? in
+                guard let app = window.owningApplication else { return nil }
+                let overlay = overlayFrame(for: window.frame, flippingAbout: flipAxis)
+                // A window parked entirely off the visible desktop can't be
+                // pointed at, so it isn't offered.
+                guard screens.contains(where: { $0.intersects(overlay) }) else { return nil }
+                return PickableWindow(
+                    id: window.windowID,
+                    processIdentifier: app.processID,
+                    applicationName: app.applicationName,
+                    title: window.title,
+                    screenFrame: window.frame,
+                    overlayFrame: overlay
+                )
+            }
+    }
+
+    /// The frontmost candidate under `point` (global AppKit coordinates), or nil
+    /// over bare desktop. `candidates` is already front-to-back, so the first
+    /// hit is the one the user can actually see.
+    static func window(at point: CGPoint, in candidates: [PickableWindow]) -> PickableWindow? {
+        candidates.first { $0.overlayFrame.contains(point) }
+    }
+
+    // MARK: - Filtering
+
+    /// Only ordinary application windows are offered.
+    ///
+    /// `windowLayer == 0` is doing most of the work, and it is deliberate rather
+    /// than incidental: everything that floats above the normal level is either
+    /// not a window the user thinks of as one (the menu bar, Control Center's
+    /// one-window-per-icon menu extras, the orange recording indicator) or is
+    /// actively harmful to offer. Notification Center's host window is the case
+    /// that bites — layer 21, full-screen, alpha 1, permanently "on screen"
+    /// whether or not the panel is open, and ranked in front of every real
+    /// window (#55 hit the same thing while walking the accessibility tree).
+    /// Highlighting it would put an invisible full-screen rectangle over the
+    /// app the user is actually pointing at.
+    private static func isPickable(_ window: SCWindow, ownPID: pid_t) -> Bool {
+        guard window.isOnScreen, window.windowLayer == 0 else { return false }
+        guard let app = window.owningApplication, app.processID != ownPID else { return false }
+        return window.frame.width >= minSide && window.frame.height >= minSide
+    }
+
+    // MARK: - Ordering
+
+    /// Window numbers mapped to their front-to-back rank.
+    ///
+    /// `SCShareableContent.windows` makes no promise about ordering, and the
+    /// whole point of hovering is to highlight the window on top. The Core
+    /// Graphics window list does guarantee it, so it is used purely as the
+    /// ranking and joined back by window number.
+    private static func frontToBackOrder() -> [CGWindowID: Int] {
+        let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+        guard let raw = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
+            return [:]
+        }
+        var order: [CGWindowID: Int] = [:]
+        for (rank, window) in raw.enumerated() {
+            guard let number = window[kCGWindowNumber as String] as? CGWindowID else { continue }
+            if order[number] == nil { order[number] = rank }
+        }
+        return order
+    }
+
+    // MARK: - Coordinate conversion
+
+    /// The horizontal line both spaces are mirrored about: the top edge of the
+    /// screen whose AppKit origin is (0, 0), which is also Core Graphics' own
+    /// origin. Every other display — including one sitting at a negative AppKit
+    /// origin (#26) — falls out of the same single flip.
+    private static func flipAxis() -> CGFloat {
+        let zeroScreen = NSScreen.screens.first { $0.frame.origin == .zero } ?? NSScreen.screens.first
+        return zeroScreen?.frame.maxY ?? 0
+    }
+
+    private static func overlayFrame(for cgFrame: CGRect, flippingAbout axis: CGFloat) -> CGRect {
+        CGRect(x: cgFrame.minX, y: axis - cgFrame.maxY, width: cgFrame.width, height: cgFrame.height)
+    }
+}


### PR DESCRIPTION
Closes #51

Capturer proprement **la bonne fenêtre** était le cas d'usage n°1 et demandait
jusqu'ici de tracer un rectangle à la main autour. La barre d'espace — la même
touche que macOS — bascule désormais la sélection vers un mode où la fenêtre
sous le pointeur est surlignée entière, nommée, et capturée d'un clic.

## Ce que ça donne

Assombrissement partout sauf la fenêtre visée, bordure, badge `App — Titre` au
centre, dimensions réelles dessous, et l'aide qui rappelle qu'Espace ramène au
rectangle. Espace fait l'aller-retour sans perdre un rectangle déjà tracé.

## L'ombre portée : mesurée, puis écartée

`SCContentFilter(desktopIndependentWindow:)` rapporte un `contentRect` égal au
cadre de la fenêtre, et le demander à `pointPixelScale` donne une image alignée
au pixel près sur ce cadre. Garder l'ombre **n'agrandit pas l'image** :
ScreenCaptureKit fait tenir « fenêtre + ombre » dans la taille demandée, ce qui
rétrécit la fenêtre et la décale.

| `ignoreShadowsSingleWindow` | image demandée | contenu opaque réel |
|---|---|---|
| `false` (ombre gardée) | 3596×2082 | **3247×1881 à +101,+68** |
| `true` | 3596×2082 | **3596×2082 à +0,+0** |

Mesuré sur une fenêtre de 1798×1041 pt. Garder l'ombre rééchantillonne les
pixels *et* casse l'invariant dont tout dépend : que `CaptureRegion.rect` soit
exactement la portion d'écran montrée par l'image — c'est ce qui relie un
repère à un élément d'accessibilité (#55). L'ombre est donc écartée, et les
bords restent propres : les quatre coins reviennent réellement transparents,
donc le PNG porte la vraie silhouette de la fenêtre.

## L'instantané d'accessibilité (#55) — branché, et plus précis

Une capture de fenêtre est le cas **le plus favorable**, et il est traité comme
tel : le processus propriétaire est connu, donc la recherche « quelles
applications sont sous ce rectangle » est sautée entièrement, et la fenêtre
visée passe en tête de ses sœurs.

`SCWindow.frame` et `AXFrame` décrivent le même rectangle dans le même espace
(points, global haut-gauche) — c'est ce qui permet de relier un `CGWindowID` à
un élément d'accessibilité **sans API privée** : les cadres coïncident,
simplement. Ranger par fenêtre plutôt que par application est ce qui rend le
cas ciblé précis : une app à deux fenêtres superposées leur donnerait sinon le
même rang, et un repère pourrait se résoudre sur celle de *derrière*.

Mesuré sur une fenêtre du Finder : **1 seule application parcourue, 160
éléments, non tronqué**, `captureRect` égal au pixel près au cadre de la
fenêtre, et les repères résolvent en `AXOutline "présentation par liste" ›
AXColumn "name"` ou `AXToolbar`.

## Ce qui n'est pas cassé

- **#39** — `ScreenCapture.ensurePermission()` reste la première ligne de
  `selectRegion()`, avant tout affichage. Le mode fenêtre passe par le même
  chemin, sans en ouvrir un second.
- **#47** — le glisser, les 8 poignées, les flèches, Entrée et Échap sont
  intacts ; le transfert de fenêtre clé / infobulle / sélection unique vers
  l'écran travaillé est conservé et étendu au survol, de sorte que le clavier
  suit le pointeur d'un écran à l'autre.
- **#26** — validé de bout en bout sur un second écran à origine AppKit
  négative : la conversion aller-retour CG ↔ AppKit ne dévie sur aucun candidat.

## Fenêtres écartées

`windowLayer == 0` fait l'essentiel du travail, et c'est délibéré : tout ce qui
flotte au-dessus du niveau normal est soit une chose que l'utilisateur ne
considère pas comme une fenêtre (barre des menus, les fenêtres du Centre de
contrôle — une par icône —, l'indicateur d'enregistrement), soit franchement
nuisible à proposer. La fenêtre hôte du Centre de notifications est celle qui
mord : couche 21, plein écran, alpha 1, en permanence « à l'écran » que le
panneau soit ouvert ou non — c'est exactement ce que le worker de #55 avait
rencontré en parcourant l'arbre d'accessibilité. Sont aussi écartés : nos
propres fenêtres, le bureau, les fenêtres minimisées ou sur un autre Space, et
tout ce qui mesure moins de 8 pt de côté.

## Vérification

Build CI local vert (`xcodegen generate` + `xcodebuild`). Au-delà, un harnais
compilé sur les sources réelles a exercé :

- géométrie exacte (image = cadre × échelle) sur Chrome, Finder, Aperçu, et une
  fenêtre témoin ouverte par un autre processus sur l'écran secondaire ;
- coins arrondis transparents et absence de tout arrière-plan (sonde de pixels) ;
- le flux complet piloté par événements : Espace → survol → clic → `CaptureRegion`
  portant la bonne fenêtre → capture ;
- non-régression du rectangle : glisser, aller-retour par Espace, décalage aux
  flèches, Entrée — le rectangle survit au détour et `region.window` reste nil.

## i18n

5 clés ajoutées (`en` + `fr`), insérées à leur place sans toucher au reste du
fichier : 25 insertions, 2 suppressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
