### PR TITLE
Formats d'export : JSON structuré, presets de tâche, et correctif de la grille Retina

### DIFF
--- a/Pinpoint/AgentTextFormat.swift
+++ b/Pinpoint/AgentTextFormat.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// What the *text* half of a copy carries (#52).
+///
+/// The image is always a PNG; the string next to it is a choice. Markdown reads
+/// well in a chat window and is what a model does best with unprompted; JSON is
+/// the same facts in the shape a script can index, for a flow that pipes the
+/// clipboard into something rather than pasting it into a conversation.
+///
+/// Only ever affects the clipboard. `FileHandoff` writes both `capture.md` and
+/// `capture.json` on every copy whatever this says, so choosing one here never
+/// costs the other.
+enum AgentTextFormat: String, CaseIterable, Identifiable {
+    /// The agent-ready Markdown of `Exporter.buildText` — the default, and what
+    /// every copy carried before this setting existed.
+    case markdown
+    /// The versioned `capture.json` contract, serialized to the clipboard.
+    case json
+
+    var id: String { rawValue }
+
+    static let storageKey = "agentTextFormat"
+
+    var label: String {
+        switch self {
+        case .markdown: return String(localized: "format.markdown.label", defaultValue: "Markdown")
+        case .json: return String(localized: "format.json.label", defaultValue: "JSON")
+        }
+    }
+}

--- a/Pinpoint/EditorView.swift
+++ b/Pinpoint/EditorView.swift
@@ -119,6 +119,10 @@ struct EditorView: View {
 
     @AppStorage(PinStyle.storageKey) private var pinStyle: PinStyle = .disc
     @AppStorage("includeLegend") private var includeLegend = true
+    /// The framing put above the user's instructions (#53). A preference rather
+    /// than per-capture state: it is a way of working, and the point of the
+    /// feature is not having to pick it again every time.
+    @AppStorage(TaskPreset.storageKey) private var taskPreset: TaskPreset = .raw
 
     @State private var pins: [Pin] = []
     @State private var shapes: [Markup] = []
@@ -849,6 +853,8 @@ struct EditorView: View {
 
             Divider()
 
+            taskPicker
+
             Text("Instructions for the agent")
                 .font(.headline)
                 .accessibilityAddTraits(.isHeader)
@@ -877,6 +883,22 @@ struct EditorView: View {
             .keyboardShortcut("s", modifiers: [.command])
         }
         .padding(14)
+    }
+
+    /// Picks the framing written above the instructions in the export.
+    ///
+    /// The guidance itself is the tooltip rather than a caption under the
+    /// picker: it runs to three sentences, this panel is already the tightest
+    /// part of the window, and the text is in the export a click away for anyone
+    /// who wants to read all of it.
+    private var taskPicker: some View {
+        Picker(String(localized: "task.picker.label", defaultValue: "Task:"), selection: $taskPreset) {
+            ForEach(TaskPreset.allCases) { preset in
+                Text(preset.label).tag(preset)
+            }
+        }
+        .help(taskPreset.guidance ?? String(localized: "task.raw.caption",
+                                            defaultValue: "No framing — the export carries only the markers and your instructions."))
     }
 
     private var pinsSection: some View {
@@ -1084,7 +1106,7 @@ struct EditorView: View {
     private func copy() {
         guard Exporter.copyToPasteboard(base: image, pins: pins, shapes: shapes, context: context,
                                         style: pinStyle, includeLegend: includeLegend,
-                                        accessibility: axSnapshot) else {
+                                        preset: taskPreset, accessibility: axSnapshot) else {
             exportError = String(localized: "Nothing was written to the clipboard. The annotated image couldn’t be rendered.")
             return
         }
@@ -1097,7 +1119,8 @@ struct EditorView: View {
         // that never landed is exactly what #38 stopped doing elsewhere.
         do {
             try FileHandoff.write(base: image, pins: pins, shapes: shapes,
-                                  context: context, style: pinStyle, accessibility: axSnapshot)
+                                  context: context, style: pinStyle, preset: taskPreset,
+                                  accessibility: axSnapshot)
         } catch {
             exportError = String(
                 localized: "handoff.error.body",
@@ -1122,7 +1145,8 @@ struct EditorView: View {
         // Full resolution here (no cap): the file is meant to be attached/kept,
         // unlike the pasteboard image which is downscaled to stay pasteable.
         guard let png = Exporter.pngData(base: image, pins: pins, shapes: shapes, context: context,
-                                         style: pinStyle, includeLegend: includeLegend, maxDimension: nil) else {
+                                         style: pinStyle, includeLegend: includeLegend,
+                                         preset: taskPreset, maxDimension: nil) else {
             exportError = String(localized: "The annotated image couldn’t be rendered.")
             return
         }

--- a/Pinpoint/EditorView.swift
+++ b/Pinpoint/EditorView.swift
@@ -123,6 +123,7 @@ struct EditorView: View {
     /// than per-capture state: it is a way of working, and the point of the
     /// feature is not having to pick it again every time.
     @AppStorage(TaskPreset.storageKey) private var taskPreset: TaskPreset = .raw
+    @AppStorage(AgentTextFormat.storageKey) private var textFormat: AgentTextFormat = .markdown
 
     @State private var pins: [Pin] = []
     @State private var shapes: [Markup] = []
@@ -881,6 +882,20 @@ struct EditorView: View {
             }
             .controlSize(.large)
             .keyboardShortcut("s", modifiers: [.command])
+
+            // The JSON as a target of its own, not a by-product of copying
+            // (#52): a script being written against the contract needs a file it
+            // chose the name of, and the clipboard is the wrong place to build
+            // that against. Full width like its neighbours rather than sharing a
+            // row with them — this panel is 260 pt at its narrowest, and two
+            // labelled buttons side by side truncate before the window does.
+            Button(action: exportJSON) {
+                Label(String(localized: "export.json.button", defaultValue: "Export JSON…"),
+                      systemImage: "curlybraces")
+                    .frame(maxWidth: .infinity)
+            }
+            .controlSize(.large)
+            .keyboardShortcut("s", modifiers: [.command, .shift])
         }
         .padding(14)
     }
@@ -1106,7 +1121,8 @@ struct EditorView: View {
     private func copy() {
         guard Exporter.copyToPasteboard(base: image, pins: pins, shapes: shapes, context: context,
                                         style: pinStyle, includeLegend: includeLegend,
-                                        preset: taskPreset, accessibility: axSnapshot) else {
+                                        preset: taskPreset, format: textFormat,
+                                        accessibility: axSnapshot) else {
             exportError = String(localized: "Nothing was written to the clipboard. The annotated image couldn’t be rendered.")
             return
         }
@@ -1152,6 +1168,38 @@ struct EditorView: View {
         }
         do {
             try png.write(to: url)
+        } catch {
+            exportError = error.localizedDescription
+            return
+        }
+        onPersist(pins, shapes, context, image, axSnapshot)
+    }
+
+    /// Writes the annotated capture as JSON alone, wherever the user asks.
+    ///
+    /// The coordinates describe the annotated image at native resolution — the
+    /// file "Save image…" writes without a legend, and `image.size` since the
+    /// renderer became 1:1 with its own pixel grid (#76). The legend strip is
+    /// left out of the reckoning on purpose: it only ever grows the image
+    /// downwards, so every marker keeps the pixel it had, and quoting a taller
+    /// image here would describe a picture nobody asked for.
+    private func exportJSON() {
+        guard let json = Exporter.buildJSON(pins: pins, shapes: shapes, context: context,
+                                            imageSize: image.size, style: pinStyle,
+                                            preset: taskPreset, accessibility: axSnapshot) else {
+            exportError = String(localized: "export.json.error",
+                                 defaultValue: "The capture couldn’t be written as JSON.")
+            return
+        }
+
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.json]
+        panel.nameFieldStringValue = "Pinpoint.json"
+        panel.canCreateDirectories = true
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        do {
+            try Data(json.utf8).write(to: url)
         } catch {
             exportError = error.localizedDescription
             return

--- a/Pinpoint/Exporter.swift
+++ b/Pinpoint/Exporter.swift
@@ -247,7 +247,7 @@ enum Exporter {
     /// without reading the pixels — then the user's instructions in their own
     /// section.
     static func buildText(pins: [Pin], shapes: [Markup] = [], context: String, imageSize: CGSize,
-                          accessibility: AXSnapshot? = nil) -> String {
+                          preset: TaskPreset = .raw, accessibility: AXSnapshot? = nil) -> String {
         let width = Int(imageSize.width.rounded())
         let height = Int(imageSize.height.rounded())
         let orderedPins = pins.sorted { $0.number < $1.number }
@@ -320,6 +320,17 @@ enum Exporter {
                              + "\(pixels(from, in: imageSize)) → \(pixels(to, in: imageSize)) px · "
                              + "\(percent(from)) → \(percent(to)) · \(boxWidth)×\(boxHeight) px")
             }
+        }
+
+        // The task framing (#53) sits directly above the user's own words: the
+        // two are read together, and an agent that has just been told how to
+        // work should meet the specifics of *this* capture next. `.raw` adds
+        // nothing, which is what keeps the default export byte-identical to
+        // what it was before presets existed.
+        if let guidance = preset.guidance {
+            lines.append("")
+            lines.append("## " + preset.heading)
+            lines.append(guidance)
         }
 
         let ctx = context.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -409,9 +420,10 @@ enum Exporter {
     /// single paste carries everything — most chat UIs paste only the image and
     /// drop the clipboard text.
     static func exportImage(base: NSImage, pins: [Pin], shapes: [Markup], context: String,
-                            style: PinStyle, includeLegend: Bool) -> NSImage {
+                            style: PinStyle, includeLegend: Bool, preset: TaskPreset = .raw) -> NSImage {
         let annotated = annotatedImage(base: base, pins: pins, shapes: shapes, style: style)
-        guard includeLegend, let legend = legendString(pins: pins, context: context, width: annotated.size.width) else {
+        guard includeLegend, let legend = legendString(pins: pins, context: context,
+                                                       preset: preset, width: annotated.size.width) else {
             return annotated
         }
 
@@ -420,7 +432,7 @@ enum Exporter {
         let textWidth = width - pad * 2
         let textHeight = ceil(legend.boundingRect(
             with: NSSize(width: textWidth, height: .greatestFiniteMagnitude),
-            options: [.usesLineFragmentOrigin, .usesFontLeading]).height)
+            options: legendDrawingOptions).height)
         // Rounded up to a whole pixel: the capture is laid on top of this strip,
         // and a fractional offset would resample it against the grid it is
         // already aligned to.
@@ -437,16 +449,27 @@ enum Exporter {
             NSRect(x: 0, y: panelHeight - 1, width: width, height: 1).fill()
             // .usesLineFragmentOrigin fills from the top edge of the rect downwards.
             legend.draw(with: NSRect(x: pad, y: pad, width: textWidth, height: textHeight),
-                        options: [.usesLineFragmentOrigin])
+                        options: legendDrawingOptions)
         }
     }
 
+    /// How the legend is laid out — used to measure it *and* to draw it.
+    ///
+    /// One constant for both on purpose. They used to disagree: the height was
+    /// measured with `.usesFontLeading` and the text drawn without it, which lays
+    /// out taller lines, so the panel came out a few points short of its own
+    /// contents and the last line of the user's instructions was cut off by the
+    /// bottom edge of the image. Whichever option is chosen, it has to be the
+    /// same one twice.
+    private static let legendDrawingOptions: NSString.DrawingOptions = [.usesLineFragmentOrigin]
+
     /// The legend rendered into the exported image, or nil if there's nothing to
-    /// show (no pins and no instructions).
-    private static func legendString(pins: [Pin], context: String, width: CGFloat) -> NSAttributedString? {
+    /// show (no pins, no instructions and no task framing).
+    private static func legendString(pins: [Pin], context: String, preset: TaskPreset,
+                                     width: CGFloat) -> NSAttributedString? {
         let trimmedContext = context.trimmingCharacters(in: .whitespacesAndNewlines)
         let orderedPins = pins.sorted { $0.number < $1.number }
-        guard !orderedPins.isEmpty || !trimmedContext.isEmpty else { return nil }
+        guard !orderedPins.isEmpty || !trimmedContext.isEmpty || preset.guidance != nil else { return nil }
 
         let bodySize = max(15, width * 0.016)
         let body = NSFont.systemFont(ofSize: bodySize)
@@ -474,8 +497,17 @@ enum Exporter {
                 add("   \(note.isEmpty ? String(localized: "(no description)") : note)\n", body, dark)
             }
         }
-        if !trimmedContext.isEmpty {
+        // The task framing belongs here for the same reason the legend exists at
+        // all (#41, #69): with it embedded, the clipboard carries the image and
+        // nothing else, so anything left out of the strip never reaches the
+        // agent. Same order as `buildText` — framing, then the user's own words.
+        if let guidance = preset.guidance {
             if !orderedPins.isEmpty { add("\n", body, dark) }
+            add(preset.heading.uppercased(with: .current) + "\n", heading, secondary)
+            add(guidance + "\n", body, dark)
+        }
+        if !trimmedContext.isEmpty {
+            if !orderedPins.isEmpty || preset.guidance != nil { add("\n", body, dark) }
             add(String(localized: "legend.instructions", defaultValue: "INSTRUCTIONS") + "\n", heading, secondary)
             add(trimmedContext, body, dark)
         }
@@ -507,9 +539,10 @@ enum Exporter {
     /// optionally downscaled so its longest edge is at most `maxDimension` pixels.
     /// Pass `nil` for full native resolution.
     static func renderPNG(base: NSImage, pins: [Pin], shapes: [Markup], context: String,
-                          style: PinStyle, includeLegend: Bool, maxDimension: CGFloat?) -> RenderedPNG? {
+                          style: PinStyle, includeLegend: Bool, preset: TaskPreset = .raw,
+                          maxDimension: CGFloat?) -> RenderedPNG? {
         let image = exportImage(base: base, pins: pins, shapes: shapes, context: context,
-                                style: style, includeLegend: includeLegend)
+                                style: style, includeLegend: includeLegend, preset: preset)
         guard let rep = bitmapRep(of: image) else { return nil }
         let output = maxDimension.flatMap { downscaled(rep, maxDimension: $0) } ?? rep
         guard let data = output.representation(using: .png, properties: [:]) else { return nil }
@@ -520,9 +553,11 @@ enum Exporter {
     /// The bytes alone, for callers that already know the grid (the full-res
     /// "Save image…", which writes the file and nothing else).
     static func pngData(base: NSImage, pins: [Pin], shapes: [Markup], context: String,
-                        style: PinStyle, includeLegend: Bool, maxDimension: CGFloat?) -> Data? {
+                        style: PinStyle, includeLegend: Bool, preset: TaskPreset = .raw,
+                        maxDimension: CGFloat?) -> Data? {
         renderPNG(base: base, pins: pins, shapes: shapes, context: context,
-                  style: style, includeLegend: includeLegend, maxDimension: maxDimension)?.data
+                  style: style, includeLegend: includeLegend, preset: preset,
+                  maxDimension: maxDimension)?.data
     }
 
     /// The bitmap behind a rendered export. `drawn(size:matching:)` builds the
@@ -571,7 +606,7 @@ enum Exporter {
     /// happened.
     @discardableResult
     static func copyToPasteboard(base: NSImage, pins: [Pin], shapes: [Markup], context: String,
-                                 style: PinStyle, includeLegend: Bool,
+                                 style: PinStyle, includeLegend: Bool, preset: TaskPreset = .raw,
                                  accessibility: AXSnapshot? = nil) -> Bool {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
@@ -581,7 +616,7 @@ enum Exporter {
         // so a failed render still produces coherent (if imageless) text.
         var pixelSize = base.size
         if let png = renderPNG(base: base, pins: pins, shapes: shapes, context: context,
-                               style: style, includeLegend: includeLegend,
+                               style: style, includeLegend: includeLegend, preset: preset,
                                maxDimension: clipboardMaxDimension) {
             pixelSize = png.pixelSize
             wrote = pasteboard.setData(png.data, forType: .png)
@@ -595,7 +630,7 @@ enum Exporter {
             // the capture's own dimensions there put every `px` in this text
             // 1.28× (or 2.56×) off the pixels it names.
             let text = buildText(pins: pins, shapes: shapes, context: context, imageSize: pixelSize,
-                                 accessibility: accessibility)
+                                 preset: preset, accessibility: accessibility)
             wrote = pasteboard.setString(text, forType: .string) || wrote
         }
 

--- a/Pinpoint/Exporter.swift
+++ b/Pinpoint/Exporter.swift
@@ -6,35 +6,92 @@ enum Exporter {
     /// numbered pins stay legible above them.
     static func annotatedImage(base: NSImage, pins: [Pin], shapes: [Markup], style: PinStyle) -> NSImage {
         let size = base.size
-        let result = NSImage(size: size)
-        result.lockFocus()
+        return drawn(size: size, matching: base) {
+            base.draw(in: NSRect(origin: .zero, size: size),
+                      from: .zero, operation: .copy, fraction: 1.0)
 
-        base.draw(in: NSRect(origin: .zero, size: size),
-                  from: .zero, operation: .copy, fraction: 1.0)
+            // Drawn at 1:1 into the image's own pixel grid, so the metrics need
+            // no scaling here. `EditorView` builds the same metrics with the
+            // canvas' scale factor, which is what makes the preview WYSIWYG.
+            let metrics = MarkupMetrics(imageWidth: size.width)
+            for shape in shapes {
+                drawMarkup(shape, in: size, metrics: metrics)
+            }
 
-        // Drawn at 1:1 into the image's own pixel grid, so the metrics need
-        // no scaling here. `EditorView` builds the same metrics with the
-        // canvas' scale factor, which is what makes the preview WYSIWYG.
-        let metrics = MarkupMetrics(imageWidth: size.width)
-        for shape in shapes {
-            drawMarkup(shape, in: size, metrics: metrics)
+            for pin in pins {
+                // Pin position is the marked point (top-left origin); NSImage
+                // drawing is bottom-left, so flip y.
+                let anchor = CGPoint(
+                    x: pin.position.x * size.width,
+                    y: (1 - pin.position.y) * size.height
+                )
+                // Keep the badge fully inside the image when the point is near an
+                // edge; the exact point is still carried by the % in the text.
+                let drawAnchor = clampedMarkerAnchor(anchor, metrics: metrics, style: style, in: size)
+                drawMarker(number: pin.number, anchor: drawAnchor, metrics: metrics, style: style)
+            }
+        }
+    }
+
+    /// Renders `body` into a bitmap of exactly `size` pixels — one drawing unit
+    /// per pixel — and hands it back as an `NSImage` whose `size` therefore
+    /// equals its own pixel dimensions.
+    ///
+    /// Deliberately not `NSImage.lockFocus()` (#76). That borrows the backing
+    /// scale of the deepest attached screen, so the very same annotations came
+    /// out at 2× the requested size on a Retina Mac and 1× on a headless build
+    /// machine — and nothing downstream was told. Captures are already stored at
+    /// native pixel resolution (`NSImage(cgImage:size:)` with the pixel
+    /// dimensions), so that 2× was an upscale of pixels we already had: it
+    /// doubled every exported file for no extra detail, while making the
+    /// dimensions in `buildText`'s header and every `px` coordinate under it
+    /// describe a grid half the size of the image they shipped with. An agent
+    /// acting on those numbers landed at a quarter of the intended point.
+    ///
+    /// The comment in `annotatedImage` already promised "1:1 into the image's
+    /// own pixel grid"; this is what makes it true.
+    private static func drawn(size: CGSize, matching source: NSImage?, _ body: () -> Void) -> NSImage {
+        let width = Int(size.width.rounded())
+        let height = Int(size.height.rounded())
+        guard width > 0, height > 0, let context = bitmapContext(width: width, height: height,
+                                                                 matching: source) else {
+            return NSImage(size: size)
         }
 
-        for pin in pins {
-            // Pin position is the marked point (top-left origin); NSImage
-            // drawing is bottom-left, so flip y.
-            let anchor = CGPoint(
-                x: pin.position.x * size.width,
-                y: (1 - pin.position.y) * size.height
-            )
-            // Keep the badge fully inside the image when the point is near an
-            // edge; the exact point is still carried by the % in the text.
-            let drawAnchor = clampedMarkerAnchor(anchor, metrics: metrics, style: style, in: size)
-            drawMarker(number: pin.number, anchor: drawAnchor, metrics: metrics, style: style)
-        }
+        NSGraphicsContext.saveGraphicsState()
+        // `flipped: false` keeps the bottom-left origin every drawing routine
+        // below already assumes, exactly as `lockFocus()` did.
+        NSGraphicsContext.current = NSGraphicsContext(cgContext: context, flipped: false)
+        NSGraphicsContext.current?.imageInterpolation = .high
+        body()
+        NSGraphicsContext.restoreGraphicsState()
 
-        result.unlockFocus()
-        return result
+        guard let cgImage = context.makeImage() else { return NSImage(size: size) }
+        let rep = NSBitmapImageRep(cgImage: cgImage)
+        rep.size = NSSize(width: width, height: height)
+        let image = NSImage(size: rep.size)
+        image.addRepresentation(rep)
+        return image
+    }
+
+    /// An 8-bit RGBA context of exactly `width`×`height` pixels, in the colour
+    /// space of `source` when that is an RGB one.
+    ///
+    /// Keeping the capture's own space matters for "Save image…", which writes a
+    /// file a human then looks at: forcing a generic space would quietly
+    /// desaturate a wide-gamut screenshot. Read off the backing `CGImage` rather
+    /// than off a representation, because the two kinds of image that reach here
+    /// are backed differently — a capture comes from `NSImage(cgImage:size:)`,
+    /// a Shelf file from an `NSBitmapImageRep` — and only the `CGImage` answers
+    /// for both. Anything that isn't RGB (grey, CMYK) can't back this pixel
+    /// format, so those fall back to sRGB.
+    private static func bitmapContext(width: Int, height: Int, matching source: NSImage?) -> CGContext? {
+        let sourceSpace = source?.cgImage(forProposedRect: nil, context: nil, hints: nil)?.colorSpace
+        let space = (sourceSpace?.model == .rgb ? sourceSpace : nil) ?? CGColorSpace(name: CGColorSpace.sRGB)
+        guard let space else { return nil }
+        return CGContext(data: nil, width: width, height: height,
+                         bitsPerComponent: 8, bytesPerRow: 0, space: space,
+                         bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
     }
 
     private static func drawMarkup(_ shape: Markup, in size: CGSize, metrics: MarkupMetrics) {
@@ -364,23 +421,24 @@ enum Exporter {
         let textHeight = ceil(legend.boundingRect(
             with: NSSize(width: textWidth, height: .greatestFiniteMagnitude),
             options: [.usesLineFragmentOrigin, .usesFontLeading]).height)
-        let panelHeight = textHeight + pad * 2
+        // Rounded up to a whole pixel: the capture is laid on top of this strip,
+        // and a fractional offset would resample it against the grid it is
+        // already aligned to.
+        let panelHeight = (textHeight + pad * 2).rounded(.up)
         let totalHeight = annotated.size.height + panelHeight
 
-        let result = NSImage(size: NSSize(width: width, height: totalHeight))
-        result.lockFocus()
-        // Capture on top (image space is bottom-left origin, so the panel sits
-        // at the bottom and the capture above it).
-        annotated.draw(in: NSRect(x: 0, y: panelHeight, width: width, height: annotated.size.height))
-        NSColor.white.setFill()
-        NSRect(x: 0, y: 0, width: width, height: panelHeight).fill()
-        NSColor.black.withAlphaComponent(0.10).setFill()
-        NSRect(x: 0, y: panelHeight - 1, width: width, height: 1).fill()
-        // .usesLineFragmentOrigin fills from the top edge of the rect downwards.
-        legend.draw(with: NSRect(x: pad, y: pad, width: textWidth, height: textHeight),
-                    options: [.usesLineFragmentOrigin])
-        result.unlockFocus()
-        return result
+        return drawn(size: NSSize(width: width, height: totalHeight), matching: base) {
+            // Capture on top (image space is bottom-left origin, so the panel sits
+            // at the bottom and the capture above it).
+            annotated.draw(in: NSRect(x: 0, y: panelHeight, width: width, height: annotated.size.height))
+            NSColor.white.setFill()
+            NSRect(x: 0, y: 0, width: width, height: panelHeight).fill()
+            NSColor.black.withAlphaComponent(0.10).setFill()
+            NSRect(x: 0, y: panelHeight - 1, width: width, height: 1).fill()
+            // .usesLineFragmentOrigin fills from the top edge of the rect downwards.
+            legend.draw(with: NSRect(x: pad, y: pad, width: textWidth, height: textHeight),
+                        options: [.usesLineFragmentOrigin])
+        }
     }
 
     /// The legend rendered into the exported image, or nil if there's nothing to
@@ -431,16 +489,50 @@ enum Exporter {
     /// image is downscaled to fit, while "Save image…" keeps full resolution.
     static let clipboardMaxDimension: CGFloat = 2000
 
+    /// A rendered export: the PNG bytes and the pixel grid they are in.
+    ///
+    /// The two travel together on purpose. Every coordinate Pinpoint writes —
+    /// the dimensions in `buildText`'s header, each marker's `px`, every box in
+    /// the JSON — is expressed in *this* grid, so a caller that gets the bytes
+    /// without the size has to guess, and guessing is precisely what #76 was:
+    /// the text quoted `base.size` while the file next to it was twice that,
+    /// then capped to `clipboardMaxDimension`.
+    struct RenderedPNG {
+        let data: Data
+        /// Actual pixel dimensions of `data`, after any downscale.
+        let pixelSize: CGSize
+    }
+
     /// PNG data for the annotated image (with legend when `includeLegend`),
     /// optionally downscaled so its longest edge is at most `maxDimension` pixels.
     /// Pass `nil` for full native resolution.
-    static func pngData(base: NSImage, pins: [Pin], shapes: [Markup], context: String,
-                        style: PinStyle, includeLegend: Bool, maxDimension: CGFloat?) -> Data? {
+    static func renderPNG(base: NSImage, pins: [Pin], shapes: [Markup], context: String,
+                          style: PinStyle, includeLegend: Bool, maxDimension: CGFloat?) -> RenderedPNG? {
         let image = exportImage(base: base, pins: pins, shapes: shapes, context: context,
                                 style: style, includeLegend: includeLegend)
-        guard let tiff = image.tiffRepresentation, let rep = NSBitmapImageRep(data: tiff) else { return nil }
+        guard let rep = bitmapRep(of: image) else { return nil }
         let output = maxDimension.flatMap { downscaled(rep, maxDimension: $0) } ?? rep
-        return output.representation(using: .png, properties: [:])
+        guard let data = output.representation(using: .png, properties: [:]) else { return nil }
+        return RenderedPNG(data: data,
+                           pixelSize: CGSize(width: output.pixelsWide, height: output.pixelsHigh))
+    }
+
+    /// The bytes alone, for callers that already know the grid (the full-res
+    /// "Save image…", which writes the file and nothing else).
+    static func pngData(base: NSImage, pins: [Pin], shapes: [Markup], context: String,
+                        style: PinStyle, includeLegend: Bool, maxDimension: CGFloat?) -> Data? {
+        renderPNG(base: base, pins: pins, shapes: shapes, context: context,
+                  style: style, includeLegend: includeLegend, maxDimension: maxDimension)?.data
+    }
+
+    /// The bitmap behind a rendered export. `drawn(size:matching:)` builds the
+    /// image around a single `NSBitmapImageRep`, so this is normally a lookup;
+    /// the TIFF round trip is only there for an image that came from elsewhere.
+    private static func bitmapRep(of image: NSImage) -> NSBitmapImageRep? {
+        if let rep = image.representations.compactMap({ $0 as? NSBitmapImageRep }).first {
+            return rep
+        }
+        return image.tiffRepresentation.flatMap { NSBitmapImageRep(data: $0) }
     }
 
     /// Returns `rep` shrunk so its longest pixel edge is `maxDimension`, or `rep`
@@ -485,13 +577,24 @@ enum Exporter {
         pasteboard.clearContents()
 
         var wrote = false
-        if let png = pngData(base: base, pins: pins, shapes: shapes, context: context,
-                             style: style, includeLegend: includeLegend, maxDimension: clipboardMaxDimension) {
-            wrote = pasteboard.setData(png, forType: .png)
+        // The grid the text below will describe. Seeded with the base size only
+        // so a failed render still produces coherent (if imageless) text.
+        var pixelSize = base.size
+        if let png = renderPNG(base: base, pins: pins, shapes: shapes, context: context,
+                               style: style, includeLegend: includeLegend,
+                               maxDimension: clipboardMaxDimension) {
+            pixelSize = png.pixelSize
+            wrote = pasteboard.setData(png.data, forType: .png)
         }
 
         if !includeLegend {
-            let text = buildText(pins: pins, shapes: shapes, context: context, imageSize: base.size,
+            // Measured off the PNG that just went on the pasteboard, never off
+            // `base.size` (#76). Two separate things moved that grid: the render
+            // used to double it on a Retina Mac, and `clipboardMaxDimension`
+            // still caps it — a 2560 px capture is pasted 2000 px wide. Quoting
+            // the capture's own dimensions there put every `px` in this text
+            // 1.28× (or 2.56×) off the pixels it names.
+            let text = buildText(pins: pins, shapes: shapes, context: context, imageSize: pixelSize,
                                  accessibility: accessibility)
             wrote = pasteboard.setString(text, forType: .string) || wrote
         }

--- a/Pinpoint/Exporter.swift
+++ b/Pinpoint/Exporter.swift
@@ -405,6 +405,44 @@ enum Exporter {
         }
     }
 
+    /// The same facts as `buildText`, in the versioned JSON contract (#52).
+    ///
+    /// Deliberately not a second schema. `FileHandoff.Document` is already the
+    /// thing the file handoff writes, the thing #55 hung the accessibility data
+    /// off, and the thing the CLI (#56) and the MCP server (#57) are being built
+    /// against — a rival shape for the clipboard would have meant two formats to
+    /// keep in step and a coin toss for whoever consumes them. This is that
+    /// document, serialized; `directory` is nil because an export chosen from a
+    /// save panel has no triplet around it to point at.
+    ///
+    /// Returns nil only if encoding fails, which for this document means a
+    /// programming error rather than a runtime condition — callers fall back to
+    /// the Markdown, since shipping no text at all would be worse.
+    static func buildJSON(pins: [Pin], shapes: [Markup] = [], context: String, imageSize: CGSize,
+                          style: PinStyle, preset: TaskPreset = .raw,
+                          accessibility: AXSnapshot? = nil) -> String? {
+        let document = FileHandoff.Document(pins: pins, shapes: shapes, context: context,
+                                            imageSize: imageSize, directory: nil,
+                                            style: style, preset: preset,
+                                            accessibility: accessibility)
+        guard let data = try? FileHandoff.encoder.encode(document) else { return nil }
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    /// The text half of an export, in whichever format the user asked for.
+    /// Falls back to the Markdown when the JSON can't be produced.
+    static func agentText(format: AgentTextFormat, pins: [Pin], shapes: [Markup], context: String,
+                          imageSize: CGSize, style: PinStyle, preset: TaskPreset,
+                          accessibility: AXSnapshot?) -> String {
+        if format == .json,
+           let json = buildJSON(pins: pins, shapes: shapes, context: context, imageSize: imageSize,
+                                style: style, preset: preset, accessibility: accessibility) {
+            return json
+        }
+        return buildText(pins: pins, shapes: shapes, context: context, imageSize: imageSize,
+                         preset: preset, accessibility: accessibility)
+    }
+
     /// `(1075, 259)` — a normalized point in the image's pixel grid, top-left origin.
     private static func pixels(_ point: CGPoint, in size: CGSize) -> String {
         "(\(Int((point.x * size.width).rounded())), \(Int((point.y * size.height).rounded())))"
@@ -606,7 +644,8 @@ enum Exporter {
     /// happened.
     @discardableResult
     static func copyToPasteboard(base: NSImage, pins: [Pin], shapes: [Markup], context: String,
-                                 style: PinStyle, includeLegend: Bool, preset: TaskPreset = .raw,
+                                 style: PinStyle, includeLegend: Bool,
+                                 preset: TaskPreset = .raw, format: AgentTextFormat = .markdown,
                                  accessibility: AXSnapshot? = nil) -> Bool {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
@@ -629,8 +668,14 @@ enum Exporter {
             // still caps it — a 2560 px capture is pasted 2000 px wide. Quoting
             // the capture's own dimensions there put every `px` in this text
             // 1.28× (or 2.56×) off the pixels it names.
-            let text = buildText(pins: pins, shapes: shapes, context: context, imageSize: pixelSize,
-                                 preset: preset, accessibility: accessibility)
+            let text = agentText(format: format, pins: pins, shapes: shapes, context: context,
+                                 imageSize: pixelSize, style: style, preset: preset,
+                                 accessibility: accessibility)
+            // Written as `.string` and nothing else, even for JSON. A pasteboard
+            // item advertising several types lets the receiver choose, and the
+            // ones that matter here choose badly — a terminal already drops the
+            // image the moment text shares the item (see above). One type, one
+            // outcome.
             wrote = pasteboard.setString(text, forType: .string) || wrote
         }
 

--- a/Pinpoint/FileHandoff.swift
+++ b/Pinpoint/FileHandoff.swift
@@ -106,7 +106,7 @@ enum FileHandoff {
     /// failure there only leaves `Output.archive` nil.
     @discardableResult
     static func write(base: NSImage, pins: [Pin], shapes: [Markup],
-                      context: String, style: PinStyle,
+                      context: String, style: PinStyle, preset: TaskPreset = .raw,
                       accessibility: AXSnapshot? = nil) throws -> Output {
         // No legend strip, whatever the editor's `includeLegend` setting says.
         // The legend grows the image downwards, which would shift every pixel
@@ -133,7 +133,7 @@ enum FileHandoff {
         // (#69).
         let markdown = Exporter.buildText(pins: pins, shapes: shapes,
                                           context: context, imageSize: pixelSize,
-                                          accessibility: accessibility)
+                                          preset: preset, accessibility: accessibility)
 
         let latest = latestDirectory
         try replaceDirectory(latest, with: files(png: png, markdown: markdown,

--- a/Pinpoint/FileHandoff.swift
+++ b/Pinpoint/FileHandoff.swift
@@ -114,19 +114,18 @@ enum FileHandoff {
         // the point of the triplet is that the text travels with the image, so
         // baking it in buys nothing here. Native resolution, no clipboard cap:
         // this file is read, not pasted.
-        guard let png = Exporter.pngData(base: base, pins: pins, shapes: shapes, context: context,
-                                         style: style, includeLegend: false, maxDimension: nil),
-              let rep = NSBitmapImageRep(data: png) else {
+        guard let render = Exporter.renderPNG(base: base, pins: pins, shapes: shapes, context: context,
+                                              style: style, includeLegend: false, maxDimension: nil) else {
             throw Failure.renderFailed
         }
+        let png = render.data
         // Measured off the PNG we just produced, not taken from `base.size`.
-        // `annotatedImage` draws through `lockFocus()`, whose backing store
-        // follows the deepest screen: on a Retina Mac the file comes out at 2×
-        // the size in points (and at 1× on a machine with no display at all).
-        // The .md and .json quote pixel coordinates, so they have to be in the
-        // grid of the file sitting next to them — a factor-two mismatch would
-        // send an agent to the wrong half of the image.
-        let pixelSize = CGSize(width: rep.pixelsWide, height: rep.pixelsHigh)
+        // The renderer now draws into a bitmap of exactly the requested pixel
+        // size (#76), so the two agree — but the .md and .json quote pixel
+        // coordinates in the grid of the file sitting next to them, and that
+        // guarantee belongs to whoever wrote the bytes, not to a caller's
+        // assumption about them.
+        let pixelSize = render.pixelSize
 
         // Always the full agent-ready text, again regardless of `includeLegend`
         // — which is what keeps the enriched export (#41) reachable even in the

--- a/Pinpoint/FileHandoff.swift
+++ b/Pinpoint/FileHandoff.swift
@@ -139,10 +139,12 @@ enum FileHandoff {
         try replaceDirectory(latest, with: files(png: png, markdown: markdown,
                                                  pins: pins, shapes: shapes, context: context,
                                                  imageSize: pixelSize, directory: latest,
+                                                 style: style, preset: preset,
                                                  accessibility: accessibility))
 
         let archived = try? archive(png: png, markdown: markdown, pins: pins, shapes: shapes,
                                     context: context, imageSize: pixelSize,
+                                    style: style, preset: preset,
                                     accessibility: accessibility)
 
         return Output(
@@ -159,20 +161,47 @@ enum FileHandoff {
     /// be built for its final home, not for the staging folder.
     private static func files(png: Data, markdown: String, pins: [Pin], shapes: [Markup],
                               context: String, imageSize: CGSize, directory: URL,
+                              style: PinStyle, preset: TaskPreset,
                               accessibility: AXSnapshot?) throws -> [(name: String, data: Data)] {
         let document = Document(pins: pins, shapes: shapes, context: context,
                                 imageSize: imageSize, directory: directory,
+                                style: style, preset: preset,
                                 accessibility: accessibility)
-        let encoder = JSONEncoder()
-        // Pretty-printed, key-sorted and unescaped: a human debugging this reads
-        // it, `\/Users\/…` for every path is noise, and a fixed key order keeps
-        // two handoffs of the same annotations byte-identical.
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
         return [
             (pngFileName, png),
             (markdownFileName, Data(markdown.utf8)),
             (jsonFileName, try encoder.encode(document))
         ]
+    }
+
+    /// The one encoder every producer of this contract uses.
+    ///
+    /// Pretty-printed, key-sorted and unescaped: a human debugging this reads it,
+    /// `\/Users\/…` for every path is noise, and a fixed key order keeps two
+    /// handoffs of the same annotations byte-identical. Shared with
+    /// `Exporter.buildJSON` so the file on disk and the JSON handed to the
+    /// clipboard can't drift into two dialects of the same schema.
+    static var encoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        return encoder
+    }
+
+    /// Reads a handoff document back.
+    ///
+    /// The contract was write-only until now, which is a strange thing to hand
+    /// somebody as an interoperability format: the CLI (#56) and the MCP server
+    /// (#57) both have to read `last/capture.json` before they can act on it, and
+    /// so does anything a user scripts. Every field decodes the way it encodes,
+    /// and the keys added since version 1 are optional, so a document written by
+    /// an older build still reads.
+    static func readDocument(at url: URL) throws -> Document {
+        try JSONDecoder().decode(Document.self, from: Data(contentsOf: url))
+    }
+
+    /// The most recent handoff, or nil when none has been written yet.
+    static func latestDocument() -> Document? {
+        try? readDocument(at: latestDirectory.appendingPathComponent(jsonFileName))
     }
 
     /// Writes `files` into `directory`, replacing whatever was there.
@@ -206,11 +235,13 @@ enum FileHandoff {
     /// Writes a timestamped copy of the handoff and prunes the oldest ones.
     private static func archive(png: Data, markdown: String, pins: [Pin], shapes: [Markup],
                                 context: String, imageSize: CGSize,
+                                style: PinStyle, preset: TaskPreset,
                                 accessibility: AXSnapshot?) throws -> URL {
         let folder = archiveDirectory.appendingPathComponent(timestamp(), isDirectory: true)
         try replaceDirectory(folder, with: files(png: png, markdown: markdown,
                                                  pins: pins, shapes: shapes, context: context,
                                                  imageSize: imageSize, directory: folder,
+                                                 style: style, preset: preset,
                                                  accessibility: accessibility))
         prune()
         return folder

--- a/Pinpoint/HandoffDocument.swift
+++ b/Pinpoint/HandoffDocument.swift
@@ -14,15 +14,36 @@ import Foundation
 // coordinate convention matches `capture.md`: pixels from the top-left corner
 // first, then the same point as a percentage of the image size.
 extension FileHandoff {
-    struct Document: Encodable {
+    struct Document: Codable {
         let schemaVersion: Int
         let generator: Generator
         /// When this handoff was written (ISO 8601, with offset).
         let generatedAt: String
+        /// When the screenshot itself was taken (ISO 8601), which can be days
+        /// before `generatedAt` — a capture is reopened from the history and
+        /// re-exported. Absent when nothing recorded it: the instant is read
+        /// from the accessibility snapshot (#55), so a capture taken with that
+        /// feature off carries no origin date. Same instant as
+        /// `accessibility.capturedAt` when both are present.
+        let capturedAt: String?
+        /// The framing chosen in the editor (#53). Always present: `preset` is
+        /// "raw" when the user asked for none, so a consumer never has to tell
+        /// "no preset" from "key not written by this version".
+        let task: TaskFraming
         let image: Image
+        /// How the numbered markers are drawn on the image, so a consumer can
+        /// describe or redraw them without looking at the pixels.
+        let markerStyle: MarkerStyle
+        /// What was in front of the lens: the app and window the capture was
+        /// pointed at, and the piece of screen it covers. Absent without an
+        /// accessibility snapshot, which is where every one of these facts comes
+        /// from.
+        let source: Source?
         /// Absolute path of the Markdown twin sitting next to this file — the
         /// same content in prose, for an agent that would rather read that.
-        let markdownPath: String
+        /// Absent when the JSON was exported on its own ("Export JSON…"), where
+        /// there is no twin and no image to point at.
+        let markdownPath: String?
         /// The user's instructions, verbatim. Empty string when they wrote none
         /// (the key is always present, so a consumer never has to branch on its
         /// absence).
@@ -36,23 +57,80 @@ extension FileHandoff {
         let markers: [Marker]
         let shapes: [Shape]
 
-        struct Generator: Encodable {
+        struct Generator: Codable {
             let name: String
             let version: String
         }
 
-        struct Image: Encodable {
-            /// Absolute path of the annotated PNG next to this file.
-            let path: String
+        struct Image: Codable {
+            /// Absolute path of the annotated PNG next to this file. Absent when
+            /// the JSON was exported alone — see `markdownPath`.
+            let path: String?
             /// Pixel dimensions of that PNG — the grid every `x`/`y` below is
             /// expressed in.
+            ///
+            /// Always the grid of the file this document describes, never the
+            /// capture's own: the clipboard copy is downscaled to stay pasteable,
+            /// and quoting the original dimensions there is exactly what sent
+            /// agents 1.28× off the mark (#76).
             let width: Int
             let height: Int
+            /// Image pixels per screen point — 2 on a Retina display. Lets a
+            /// consumer go from a pixel here back to the point on screen it was
+            /// read from, together with `source.screenRect`. Absent when the
+            /// captured region isn't known (no accessibility snapshot).
+            let scale: Double?
+        }
+
+        /// The task framing that was written into the export (#53).
+        struct TaskFraming: Codable {
+            /// The stable token — "raw", "bug", "review" or "implement". The
+            /// only field here meant to be switched on; the two below are prose
+            /// in the user's language.
+            let preset: String
+            /// The preset's name as the editor showed it.
+            let label: String
+            /// The paragraph that went into `capture.md` above the user's
+            /// instructions, repeated verbatim so a consumer building its own
+            /// prompt gets the same framing. Absent for the "raw" preset.
+            let guidance: String?
+        }
+
+        /// How the numbered badges are drawn.
+        struct MarkerStyle: Codable {
+            /// "disc", "pointer" or "outline".
+            let kind: String
+            /// `#RRGGBB`, sRGB — the vermillon every marker and outline is drawn
+            /// in. A constant today, stated rather than assumed so a consumer
+            /// looking for the badges in the pixels knows what to look for.
+            let color: String
+        }
+
+        /// The screen the capture was taken from.
+        struct Source: Codable {
+            /// The app owning the window under the middle of the capture.
+            let application: String?
+            let bundleIdentifier: String?
+            /// That window's title, when it has one.
+            let windowTitle: String?
+            /// The region the image covers, in screen points. With `image.scale`
+            /// this is what turns a pixel in the image back into a point the
+            /// macOS APIs accept.
+            let screenRect: ScreenRect
+        }
+
+        /// A rectangle in screen points, global top-left origin. Not
+        /// percentages: it isn't relative to the image.
+        struct ScreenRect: Codable {
+            let x: Double
+            let y: Double
+            let width: Double
+            let height: Double
         }
 
         /// A point in the image, given twice: pixels for an agent working on
         /// the file, percentages for one reasoning about a resized copy.
-        struct Point: Encodable {
+        struct Point: Codable {
             let x: Int
             let y: Int
             /// 0…100, two decimals.
@@ -61,7 +139,7 @@ extension FileHandoff {
         }
 
         /// Axis-aligned box, same dual units as `Point`.
-        struct Box: Encodable {
+        struct Box: Codable {
             let x: Int
             let y: Int
             let width: Int
@@ -74,7 +152,7 @@ extension FileHandoff {
 
         /// Snapshot-wide facts about the accessibility pass (#55). Lets a
         /// consumer reason about *why* a marker has no element attached.
-        struct AccessibilityContext: Encodable {
+        struct AccessibilityContext: Codable {
             /// Whether at least one element was collected.
             let available: Bool
             /// ISO 8601 instant the tree was read — the capture instant.
@@ -88,7 +166,7 @@ extension FileHandoff {
             /// missing `value` means "empty" or "withheld".
             let policy: Policy
 
-            struct Policy: Encodable {
+            struct Policy: Codable {
                 /// Always true. Password fields are never read, at any setting.
                 let secureFieldValuesOmitted: Bool
                 /// True unless the user opted in: the text typed in ordinary
@@ -104,7 +182,7 @@ extension FileHandoff {
         /// This is the point of the whole file: a marker is a pixel, and a pixel
         /// is not something you can go and edit. `role` + `identifier` + `path`
         /// are what turn it into a thing with a name in somebody's source code.
-        struct AccessibilityElement: Encodable {
+        struct AccessibilityElement: Codable {
             /// Raw accessibility role, e.g. "AXButton". Not translated into
             /// prose on purpose — it's the vocabulary every inspector shares.
             let role: String
@@ -141,24 +219,18 @@ extension FileHandoff {
             /// `AXRole “Name”`.
             let path: [String]
 
-            struct Application: Encodable {
+            struct Application: Codable {
                 let name: String?
                 let bundleIdentifier: String?
                 let processIdentifier: Int32
             }
 
-            /// Points, global top-left origin. Not percentages: this rect isn't
-            /// relative to the image.
-            struct ScreenFrame: Encodable {
-                let x: Double
-                let y: Double
-                let width: Double
-                let height: Double
-            }
+            /// The same shape as `source.screenRect`, and the same space.
+            typealias ScreenFrame = FileHandoff.Document.ScreenRect
         }
 
         /// A numbered marker.
-        struct Marker: Encodable {
+        struct Marker: Codable {
             /// Stable identifier, the same code `capture.md` prints in brackets.
             /// Survives the renumbering that follows a deletion, so two handoffs
             /// of one session refer to the same marker by the same id.
@@ -178,7 +250,7 @@ extension FileHandoff {
         }
 
         /// An unnumbered outline: arrow or rectangle.
-        struct Shape: Encodable {
+        struct Shape: Codable {
             let id: String
             /// "S1", "S2"… matching `capture.md`.
             let label: String
@@ -197,10 +269,17 @@ extension FileHandoff {
 }
 
 extension FileHandoff.Document {
-    /// Builds the document for a set of annotations. `directory` is where the
-    /// triplet will live, since the absolute paths below point at its siblings.
-    init(pins: [Pin], shapes: [Markup], context: String, imageSize: CGSize, directory: URL,
-         accessibility: AXSnapshot? = nil) {
+    /// Builds the document for a set of annotations.
+    ///
+    /// `directory` is where the triplet will live, since the absolute paths
+    /// below point at its siblings; nil when the JSON is exported on its own and
+    /// there is nothing to point at.
+    ///
+    /// `imageSize` must be the pixel grid of the image this document describes —
+    /// not the capture's own dimensions, which stopped being the same thing the
+    /// moment the clipboard copy started downscaling (#76).
+    init(pins: [Pin], shapes: [Markup], context: String, imageSize: CGSize, directory: URL?,
+         style: PinStyle, preset: TaskPreset, accessibility: AXSnapshot? = nil) {
         self.schemaVersion = FileHandoff.schemaVersion
         self.generator = Generator(
             name: "Pinpoint",
@@ -209,12 +288,25 @@ extension FileHandoff.Document {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
         self.generatedAt = formatter.string(from: Date())
+        self.capturedAt = accessibility.map { formatter.string(from: $0.capturedAt) }
+        self.task = TaskFraming(preset: preset.rawValue, label: preset.label, guidance: preset.guidance)
         self.image = Image(
-            path: directory.appendingPathComponent(FileHandoff.pngFileName).path,
+            path: directory?.appendingPathComponent(FileHandoff.pngFileName).path,
             width: Int(imageSize.width.rounded()),
-            height: Int(imageSize.height.rounded())
+            height: Int(imageSize.height.rounded()),
+            scale: accessibility.flatMap { $0.pixelsPerPoint(for: imageSize) }
         )
-        self.markdownPath = directory.appendingPathComponent(FileHandoff.markdownFileName).path
+        self.markerStyle = MarkerStyle(kind: style.rawValue, color: FileHandoff.markerColorHex)
+        self.source = accessibility.map { snapshot in
+            let window = snapshot.sourceWindow
+            return Source(
+                application: window?.application.name,
+                bundleIdentifier: window?.application.bundleIdentifier,
+                windowTitle: window?.title,
+                screenRect: ScreenRect(snapshot.captureRect)
+            )
+        }
+        self.markdownPath = directory?.appendingPathComponent(FileHandoff.markdownFileName).path
         self.context = context.trimmingCharacters(in: .whitespacesAndNewlines)
 
         let ordered = pins.sorted { $0.number < $1.number }
@@ -339,12 +431,7 @@ extension FileHandoff.Document.AccessibilityElement {
             redacted: element.redaction?.rawValue,
             enabled: element.enabled,
             box: FileHandoff.Document.Box(snapshot.normalizedRect(for: element.frame), in: imageSize),
-            screenFrame: ScreenFrame(
-                x: Double(element.frame.minX),
-                y: Double(element.frame.minY),
-                width: Double(element.frame.width),
-                height: Double(element.frame.height)
-            ),
+            screenFrame: ScreenFrame(element.frame),
             application: Application(
                 name: resolved.application.name,
                 bundleIdentifier: resolved.application.bundleIdentifier,
@@ -352,5 +439,46 @@ extension FileHandoff.Document.AccessibilityElement {
             ),
             path: (resolved.ancestors.map(\.summary) + [element.summary])
         )
+    }
+}
+
+extension FileHandoff.Document.ScreenRect {
+    init(_ rect: CGRect) {
+        self.init(x: Double(rect.minX), y: Double(rect.minY),
+                  width: Double(rect.width), height: Double(rect.height))
+    }
+}
+
+extension FileHandoff {
+    /// The vermillon `NSColor.pinpointVermillon` draws every marker and outline
+    /// in, spelled for the JSON. Hard-coded rather than read back off the colour:
+    /// this is a contract value, and it should take an edit here — not a change
+    /// of colour space on someone's Mac — to move it.
+    static let markerColorHex = "#FF4D2E"
+}
+
+extension AXSnapshot {
+    /// The window the capture was aimed at: whatever sits under the middle of
+    /// the image, walked back up to its outermost container.
+    ///
+    /// The centre rather than a scan of every window, and `element(atNormalized:)`
+    /// rather than a second selection rule: that method already knows how to pick
+    /// between overlapping windows (frontmost first), and the middle of a region
+    /// the user dragged themselves is the least ambiguous statement of what they
+    /// meant to photograph. Nothing there — a capture of the desktop, of a menu
+    /// that left no accessible window — simply yields nil.
+    var sourceWindow: (application: Application, title: String?)? {
+        guard let resolved = element(atNormalized: CGPoint(x: 0.5, y: 0.5)) else { return nil }
+        let window = resolved.ancestors.first ?? resolved.element
+        return (resolved.application, window.title ?? window.name)
+    }
+
+    /// How many pixels of an image of `imageSize` cover one screen point — 2 for
+    /// a Retina capture, less once the clipboard copy has been downscaled. Nil
+    /// when the captured region is degenerate, which would make the ratio
+    /// meaningless rather than merely unknown.
+    func pixelsPerPoint(for imageSize: CGSize) -> Double? {
+        guard captureRect.width > 0 else { return nil }
+        return ((Double(imageSize.width) / Double(captureRect.width)) * 1000).rounded() / 1000
     }
 }

--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -615,6 +615,18 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "# Capture annotée — %lld×%lld px" } }
       }
     },
+    "export.json.button" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Export JSON…" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Exporter en JSON…" } }
+      }
+    },
+    "export.json.error" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "The capture couldn’t be written as JSON." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "La capture n’a pas pu être écrite en JSON." } }
+      }
+    },
     "export.markers.legend" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "M1, M2… are the numbers drawn on the image; the code in brackets is a stable ID for that marker." } },
@@ -667,6 +679,18 @@
     "Follow the macOS screenshot location" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Suivre l’emplacement des captures de macOS" } }
+      }
+    },
+    "format.json.label" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "JSON" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "JSON" } }
+      }
+    },
+    "format.markdown.label" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Markdown" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Markdown" } }
       }
     },
     "handoff.error.body" : {
@@ -986,6 +1010,24 @@
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Describe the element under each marker" } },
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Décrire l’élément sous chaque repère" } }
+      }
+    },
+    "settings.format.explanation" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Markdown reads well when pasted into a conversation; JSON is the same facts in the versioned contract, for a script that indexes them. Both are always written to the files for the agent." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Markdown se lit bien collé dans une conversation ; JSON reprend les mêmes faits dans le contrat versionné, pour un script qui les indexe. Les deux sont de toute façon écrits dans les fichiers pour l’agent." } }
+      }
+    },
+    "settings.format.label" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Copied text:" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Texte copié :" } }
+      }
+    },
+    "settings.format.unused" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Unavailable while the legend is embedded: the clipboard then carries the image alone. The files for the agent are written in both formats either way." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Indisponible tant que la légende est incrustée : le presse-papier ne porte alors que l’image. Les fichiers pour l’agent sont écrits dans les deux formats quoi qu’il arrive." } }
       }
     },
     "Settings…" : {

--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -633,6 +633,12 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Tracés non numérotés dessinés sur l’image : les rectangles sont donnés haut-gauche → bas-droite, les flèches base → pointe, suivis de la taille de leur boîte englobante." } }
       }
     },
+    "export.task.heading" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Task — %@" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Tâche — %@" } }
+      }
+    },
     "Favorites" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Favoris" } }
@@ -1057,6 +1063,60 @@
     "Style:" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Style :" } }
+      }
+    },
+    "task.bug.guidance" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "The markers point at a defect. Find its cause before proposing anything: locate the code that produces what is marked, explain why it behaves this way, then propose the smallest change that addresses the cause rather than the symptom. If the capture isn’t enough to be sure, say what you would need to look at." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Les repères désignent un défaut. Cherchez-en la cause avant de proposer quoi que ce soit : localisez le code qui produit ce qui est marqué, expliquez pourquoi il se comporte ainsi, puis proposez la plus petite modification qui traite la cause plutôt que le symptôme. Si la capture ne suffit pas à en être sûr, dites ce qu’il faudrait aller regarder." } }
+      }
+    },
+    "task.bug.label" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Bug" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Bug" } }
+      }
+    },
+    "task.implement.guidance" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "The markers point at what has to be built or changed. Match what is already there: reuse the existing components, naming and spacing rather than introducing your own. Change only what is marked, and list at the end anything you had to assume because the capture didn’t say." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Les repères désignent ce qui est à construire ou à modifier. Alignez-vous sur l’existant : réutilisez les composants, le nommage et les espacements déjà en place plutôt que d’introduire les vôtres. Ne modifiez que ce qui est marqué, et listez à la fin ce que vous avez dû supposer faute d’information dans la capture." } }
+      }
+    },
+    "task.implement.label" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Implement" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Implémentation" } }
+      }
+    },
+    "task.picker.label" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Task:" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Tâche :" } }
+      }
+    },
+    "task.raw.caption" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "No framing — the export carries only the markers and your instructions." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Aucun cadrage — l’export ne porte que les repères et vos instructions." } }
+      }
+    },
+    "task.raw.label" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Raw" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Brut" } }
+      }
+    },
+    "task.review.guidance" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "The markers point at things to assess, not to fix. Give a short verdict on each one — what works, what doesn’t, and what it would cost to change — and order your remarks by importance rather than by position on the image. Say plainly when something is fine as it is; only suggest a change where it is worth the effort." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Les repères désignent des points à évaluer, pas à corriger. Donnez un verdict court sur chacun — ce qui fonctionne, ce qui ne fonctionne pas, et ce que coûterait un changement — et classez vos remarques par importance plutôt que par position sur l’image. Dites franchement quand quelque chose convient tel quel ; ne suggérez un changement que là où il en vaut la peine." } }
+      }
+    },
+    "task.review.label" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Review" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Revue" } }
       }
     },
     "The tip marks the exact pixel." : {

--- a/Pinpoint/PinpointApp.swift
+++ b/Pinpoint/PinpointApp.swift
@@ -58,6 +58,7 @@ struct SettingsView: View {
 struct CaptureSettingsView: View {
     @AppStorage(PinStyle.storageKey) private var pinStyle: PinStyle = .disc
     @AppStorage("includeLegend") private var includeLegend = true
+    @AppStorage(AgentTextFormat.storageKey) private var textFormat: AgentTextFormat = .markdown
     @AppStorage(CaptureDelay.storageKey) private var captureDelay: CaptureDelay = .off
     @AppStorage(AXContextSettings.enabledKey) private var axContext = true
     @AppStorage(AXContextSettings.fieldValuesKey) private var axFieldValues = false
@@ -96,6 +97,25 @@ struct CaptureSettingsView: View {
             Section("Agent sharing") {
                 Toggle("Embed legend in the image", isOn: $includeLegend)
                 Text("Adds the marker descriptions and instructions below the capture so a single paste carries everything to the agent.")
+                    .foregroundStyle(.secondary)
+                    .font(.callout)
+
+                Picker(String(localized: "settings.format.label",
+                              defaultValue: "Copied text:"), selection: $textFormat) {
+                    ForEach(AgentTextFormat.allCases) { format in
+                        Text(format.label).tag(format)
+                    }
+                }
+                // Nothing to choose while the legend is embedded: the image then
+                // carries everything and the clipboard deliberately holds no
+                // text at all, since a terminal pastes the string and drops the
+                // picture when both share an item.
+                .disabled(includeLegend)
+                Text(includeLegend
+                     ? String(localized: "settings.format.unused",
+                              defaultValue: "Unavailable while the legend is embedded: the clipboard then carries the image alone. The files for the agent are written in both formats either way.")
+                     : String(localized: "settings.format.explanation",
+                              defaultValue: "Markdown reads well when pasted into a conversation; JSON is the same facts in the versioned contract, for a script that indexes them. Both are always written to the files for the agent."))
                     .foregroundStyle(.secondary)
                     .font(.callout)
             }

--- a/Pinpoint/TaskPreset.swift
+++ b/Pinpoint/TaskPreset.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// The framing put in front of the user's own instructions when the capture is
+/// handed to an agent (#53).
+///
+/// The Instructions field starts empty at every capture, so the same three
+/// sentences of scaffolding got retyped over and over — "this is a bug, find the
+/// cause first", "just review this, don't rewrite it". A preset writes that part,
+/// and the field goes back to carrying only what is specific to *this* screenshot.
+///
+/// Persisted in UserDefaults via `@AppStorage(TaskPreset.storageKey)`, like
+/// `PinStyle`: the choice is a working habit, not a property of one capture, and
+/// a user who always debugs should find "Bug" already selected. The token in
+/// `rawValue` is the stable one — it is what lands in the JSON, and what the CLI
+/// (#56) and the MCP server (#57) will accept as `--task bug`.
+enum TaskPreset: String, CaseIterable, Identifiable {
+    /// No framing at all: the export is exactly what it was before presets
+    /// existed. The default, so nothing changes for anyone who ignores this.
+    case raw
+    case bug
+    case review
+    case implement
+
+    var id: String { rawValue }
+
+    static let storageKey = "taskPreset"
+
+    /// Name shown in the editor's picker.
+    var label: String {
+        switch self {
+        case .raw: return String(localized: "task.raw.label", defaultValue: "Raw")
+        case .bug: return String(localized: "task.bug.label", defaultValue: "Bug")
+        case .review: return String(localized: "task.review.label", defaultValue: "Review")
+        case .implement: return String(localized: "task.implement.label", defaultValue: "Implement")
+        }
+    }
+
+    /// The paragraph written into the export above the user's instructions, or
+    /// nil for `.raw`.
+    ///
+    /// Localized like the rest of the export: this is prose the user reads in
+    /// the tooltip before choosing, and prose they will find again in
+    /// `capture.md`. Each one says what to *do first* rather than describing a
+    /// role — an agent given "you are a debugging expert" behaves no differently
+    /// from one given nothing, whereas "find the cause before proposing a fix"
+    /// changes the order it works in. They also all license an "I can't tell
+    /// from this screenshot", which is the answer a capture most often deserves
+    /// and the one a model is least likely to volunteer.
+    var guidance: String? {
+        switch self {
+        case .raw:
+            return nil
+        case .bug:
+            return String(
+                localized: "task.bug.guidance",
+                defaultValue: "The markers point at a defect. Find its cause before proposing anything: locate the code that produces what is marked, explain why it behaves this way, then propose the smallest change that addresses the cause rather than the symptom. If the capture isn’t enough to be sure, say what you would need to look at."
+            )
+        case .review:
+            return String(
+                localized: "task.review.guidance",
+                defaultValue: "The markers point at things to assess, not to fix. Give a short verdict on each one — what works, what doesn’t, and what it would cost to change — and order your remarks by importance rather than by position on the image. Say plainly when something is fine as it is; only suggest a change where it is worth the effort."
+            )
+        case .implement:
+            return String(
+                localized: "task.implement.guidance",
+                defaultValue: "The markers point at what has to be built or changed. Match what is already there: reuse the existing components, naming and spacing rather than introducing your own. Change only what is marked, and list at the end anything you had to assume because the capture didn’t say."
+            )
+        }
+    }
+
+    /// The heading the guidance sits under in the exported text, e.g. "Task — Bug".
+    var heading: String {
+        String(localized: "export.task.heading", defaultValue: "Task — \(label)")
+    }
+}

--- a/docs/capture-schema.json
+++ b/docs/capture-schema.json
@@ -1,0 +1,251 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/croustibat/Pinpoint/blob/main/docs/capture-schema.json",
+  "title": "Pinpoint capture handoff",
+  "description": "The machine-readable form of an annotated capture. Written by Pinpoint to ~/Library/Application Support/Pinpoint/last/capture.json on every copy (next to capture.png and capture.md), to ~/Library/Application Support/Pinpoint/archive/<timestamp>/ as a timestamped copy, and to any path chosen through \"Export JSON…\" — where the two file paths below are absent because there are no siblings to point at. Coordinates are pixels from the top-left corner of the image described by `image`, then the same value as a percentage of it. `schemaVersion` moves only on a breaking change: keys are added between versions, so read the ones you know and ignore the rest. The authority is Pinpoint/HandoffDocument.swift; this file is its published restatement.",
+  "type": "object",
+  "required": ["schemaVersion", "generator", "generatedAt", "task", "image", "markerStyle", "context", "markers", "shapes"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Version of this contract. 1 today."
+    },
+    "generator": {
+      "type": "object",
+      "required": ["name", "version"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "const": "Pinpoint" },
+        "version": { "type": "string", "description": "Marketing version of the app that wrote the file, e.g. \"0.7.0\"." }
+      }
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When this document was written (ISO 8601 with offset)."
+    },
+    "capturedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When the screenshot itself was taken, which can be days earlier — a capture is reopened from the history and re-exported. Read from the accessibility snapshot, so absent when that feature was off or unauthorized. Same instant as accessibility.capturedAt when both are present."
+    },
+    "task": {
+      "type": "object",
+      "description": "The framing written above the user's instructions in capture.md.",
+      "required": ["preset", "label"],
+      "additionalProperties": false,
+      "properties": {
+        "preset": {
+          "type": "string",
+          "enum": ["raw", "bug", "review", "implement"],
+          "description": "The stable token — the only field here meant to be switched on. \"raw\" means the user asked for no framing."
+        },
+        "label": { "type": "string", "description": "The preset's name as the editor showed it, in the user's language." },
+        "guidance": { "type": "string", "description": "The paragraph that went into capture.md, verbatim and in the user's language, so a consumer building its own prompt can reuse the same framing. Absent for \"raw\"." }
+      }
+    },
+    "image": {
+      "type": "object",
+      "description": "The image this document describes, and the pixel grid every coordinate below is expressed in. Not necessarily the capture's own dimensions: the clipboard copy is downscaled to stay pasteable.",
+      "required": ["width", "height"],
+      "additionalProperties": false,
+      "properties": {
+        "path": { "type": "string", "description": "Absolute path of the annotated PNG sitting next to this file. Absent when the JSON was exported on its own." },
+        "width": { "type": "integer", "minimum": 1 },
+        "height": { "type": "integer", "minimum": 1 },
+        "scale": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Image pixels per screen point — 2 for a Retina capture at native resolution, less once downscaled. With source.screenRect, this is what turns a pixel here back into the point on screen it was read from. Absent when the captured region isn't known."
+        }
+      }
+    },
+    "markerStyle": {
+      "type": "object",
+      "description": "How the numbered badges are drawn on the image.",
+      "required": ["kind", "color"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["disc", "pointer", "outline"],
+          "description": "disc: filled badge centred on the point. pointer: map pin whose tip is the point. outline: hollow ring centred on the point."
+        },
+        "color": {
+          "type": "string",
+          "pattern": "^#[0-9A-Fa-f]{6}$",
+          "description": "sRGB colour every marker and outline is drawn in."
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "description": "What was in front of the lens. Every field comes from the accessibility snapshot, so the whole object is absent without one.",
+      "required": ["screenRect"],
+      "additionalProperties": false,
+      "properties": {
+        "application": { "type": "string", "description": "App owning the window under the middle of the capture." },
+        "bundleIdentifier": { "type": "string" },
+        "windowTitle": { "type": "string" },
+        "screenRect": { "$ref": "#/$defs/screenRect", "description": "The region the image covers, in screen points." }
+      }
+    },
+    "markdownPath": {
+      "type": "string",
+      "description": "Absolute path of the Markdown twin next to this file — the same facts in prose. Absent when the JSON was exported on its own."
+    },
+    "context": {
+      "type": "string",
+      "description": "The user's instructions, verbatim. Empty string when they wrote none; the key is always present."
+    },
+    "accessibility": {
+      "type": "object",
+      "description": "What the accessibility pass contributed overall. Absent when no walk happened (feature off, permission not granted). Present with available: false when a walk happened and came back empty — which is how a consumer tells \"not looked at\" from \"looked at, found nothing\".",
+      "required": ["available", "capturedAt", "elementCount", "truncated", "policy"],
+      "additionalProperties": false,
+      "properties": {
+        "available": { "type": "boolean" },
+        "capturedAt": { "type": "string", "format": "date-time" },
+        "elementCount": { "type": "integer", "minimum": 0 },
+        "truncated": {
+          "type": "boolean",
+          "description": "true when the walk stopped on one of its own limits (time, node budget). A missing element may then mean \"not looked at\"."
+        },
+        "policy": {
+          "type": "object",
+          "required": ["secureFieldValuesOmitted", "textFieldValuesOmitted"],
+          "additionalProperties": false,
+          "properties": {
+            "secureFieldValuesOmitted": { "type": "boolean", "const": true, "description": "Always true. Password fields are never read, at any setting." },
+            "textFieldValuesOmitted": { "type": "boolean", "description": "true unless the user opted into including what is typed in ordinary fields." }
+          }
+        }
+      }
+    },
+    "markers": {
+      "type": "array",
+      "description": "The numbered badges, ordered by number.",
+      "items": { "$ref": "#/$defs/marker" }
+    },
+    "shapes": {
+      "type": "array",
+      "description": "The unnumbered outlines — arrows and rectangles — in the order they were drawn.",
+      "items": { "$ref": "#/$defs/shape" }
+    }
+  },
+  "$defs": {
+    "point": {
+      "type": "object",
+      "description": "A point in the image, given twice: pixels for an agent working on this file, percentages for one reasoning about a resized copy.",
+      "required": ["x", "y", "xPercent", "yPercent"],
+      "additionalProperties": false,
+      "properties": {
+        "x": { "type": "integer" },
+        "y": { "type": "integer" },
+        "xPercent": { "type": "number", "description": "0…100, two decimals." },
+        "yPercent": { "type": "number" }
+      }
+    },
+    "box": {
+      "type": "object",
+      "description": "Axis-aligned rectangle in the image, same dual units as a point. May fall outside the image when it describes an element extending past the captured region.",
+      "required": ["x", "y", "width", "height", "xPercent", "yPercent", "widthPercent", "heightPercent"],
+      "additionalProperties": false,
+      "properties": {
+        "x": { "type": "integer" },
+        "y": { "type": "integer" },
+        "width": { "type": "integer" },
+        "height": { "type": "integer" },
+        "xPercent": { "type": "number" },
+        "yPercent": { "type": "number" },
+        "widthPercent": { "type": "number" },
+        "heightPercent": { "type": "number" }
+      }
+    },
+    "screenRect": {
+      "type": "object",
+      "description": "A rectangle in screen points, global top-left origin — the space the macOS accessibility APIs speak. Not relative to the image.",
+      "required": ["x", "y", "width", "height"],
+      "additionalProperties": false,
+      "properties": {
+        "x": { "type": "number" },
+        "y": { "type": "number" },
+        "width": { "type": "number" },
+        "height": { "type": "number" }
+      }
+    },
+    "marker": {
+      "type": "object",
+      "required": ["id", "label", "number", "note", "position"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Stable identifier, the same code capture.md prints in brackets. Survives the renumbering that follows a deletion, so two handoffs of one session name the same marker the same way."
+        },
+        "label": { "type": "string", "description": "What is drawn on the image: \"M1\", \"M2\"… Unlike id, this changes when an earlier marker is deleted." },
+        "number": { "type": "integer", "minimum": 1 },
+        "note": { "type": "string", "description": "The user's description. Empty when they left it blank." },
+        "position": { "$ref": "#/$defs/point" },
+        "accessibility": {
+          "$ref": "#/$defs/element",
+          "description": "The interface element under position, resolved against the snapshot taken at capture time. Absent when there is none — the normal case for a capture of something that isn't an app window, or with the feature switched off."
+        }
+      }
+    },
+    "shape": {
+      "type": "object",
+      "required": ["id", "label", "kind", "from", "to", "boundingBox"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "label": { "type": "string", "description": "\"S1\", \"S2\"… matching capture.md." },
+        "kind": { "type": "string", "enum": ["arrow", "rectangle"] },
+        "from": { "$ref": "#/$defs/point", "description": "Arrow: the tail. Rectangle: its top-left corner." },
+        "to": { "$ref": "#/$defs/point", "description": "Arrow: the tip, where the head is drawn. Rectangle: its bottom-right corner." },
+        "boundingBox": { "$ref": "#/$defs/box" }
+      }
+    },
+    "element": {
+      "type": "object",
+      "description": "An interface element read from the macOS accessibility tree while the capture was being taken. This is what turns a marker from a pixel into something with a name in somebody's source code.",
+      "required": ["role", "box", "screenFrame", "application", "path"],
+      "additionalProperties": false,
+      "properties": {
+        "role": { "type": "string", "description": "Raw accessibility role, e.g. \"AXButton\". Not translated into prose on purpose — it is the vocabulary every inspector shares." },
+        "subrole": { "type": "string" },
+        "title": { "type": "string", "description": "AXTitle — the control's visible label." },
+        "label": { "type": "string", "description": "AXDescription — what a screen reader announces." },
+        "identifier": { "type": "string", "description": "AXIdentifier, usually the accessibilityIdentifier written in the app's own source. The most directly actionable field here." },
+        "help": { "type": "string", "description": "AXHelp, collected only when nothing else named the element." },
+        "placeholder": { "type": "string", "description": "AXPlaceholderValue, for inputs." },
+        "value": { "type": "string", "description": "The element's value. Present only when the privacy policy allows it — see redacted." },
+        "redacted": {
+          "type": "string",
+          "enum": ["secureField", "textFieldPolicy"],
+          "description": "Why value is absent: secureField (a password field, never read) or textFieldPolicy (withheld by default). Absent when the element simply has no value worth reporting."
+        },
+        "enabled": { "type": "boolean" },
+        "box": { "$ref": "#/$defs/box", "description": "The element's rectangle in this image's pixel grid." },
+        "screenFrame": { "$ref": "#/$defs/screenRect", "description": "The same rectangle in screen points, for a consumer that wants to go back and drive the live UI." },
+        "application": {
+          "type": "object",
+          "required": ["processIdentifier"],
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string" },
+            "bundleIdentifier": { "type": "string" },
+            "processIdentifier": { "type": "integer" }
+          }
+        },
+        "path": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "The containers around the element, outermost first, each rendered as `AXRole \"Name\"`, ending with the element itself."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Trois sujets dans un seul lot : ils vivent tous dans `Exporter.swift`, les traiter
séparément aurait garanti des conflits. Un commit par issue.

Closes #76
Closes #53
Closes #52

---

## #76 — Le texte décrivait une grille deux fois plus petite que l'image

Traité en premier, parce qu'il faussait tout le reste : #52 expose `image {w,h,scale}`
et aurait hérité du même mensonge.

`annotatedImage` passait par `NSImage.lockFocus()`, dont le backing store suit
l'échelle de l'écran le plus profond. Mesuré sur une capture de 2560×1440 :

| | avant | après |
|---|---|---|
| bitmap annoté sérialisé | **5120×2880** | 2560×1440 |
| PNG pleine résolution | **532 741 o** | 75 202 o |
| PNG collé (plafond 2000 px) | 2000×1125 | 2000×1125 |
| en-tête du texte collé | **2560×1440 px** | 2000×1125 px |
| position de M1 (repère à 42 %/18 %) | **(1075, 259)** | (840, 203) |

Un agent qui lisait ces `px` se trompait d'un facteur 1,28 — et de 2 s'il lisait
le fichier pleine résolution. Sur une machine sans écran, le même code sortait
en 1× : l'export n'était pas reproductible.

**Décision : les deux options de l'issue, parce qu'aucune ne suffisait seule.**

1. *Rendu 1× forcé*, via un `CGContext` explicite d'exactement la taille demandée.
   C'est ce que le commentaire d'`annotatedImage` promettait déjà depuis toujours
   (« Drawn at 1:1 into the image's own pixel grid »).
2. *Mesure sur le bitmap produit* — l'approche de référence de `FileHandoff` (#54).
   `renderPNG` rend les octets **et** leur grille en pixels, et le texte du
   presse-papier est construit sur cette grille-là.

Le 1× seul n'aurait pas suffi : le plafond `clipboardMaxDimension` de 2000 px
décale la grille de toute façon. La mesure seule n'aurait pas suffi non plus :
elle laissait un export dont la résolution dépend du Mac qui l'exécute.

**La décision produit à assumer : le PNG exporté change de résolution.** Il n'y a
pas de perte. Les captures sont déjà stockées à la résolution native — `NSImage`
construite avec les dimensions en pixels du `CGImage` — donc le 2× était un
agrandissement de pixels déjà présents, pas du détail supplémentaire : d'où les
532 ko qui deviennent 75 ko à contenu identique. Les repères et formes sont
vectoriels et sont maintenant tracés dans la grille native de la capture, soit
exactement la finesse de l'écran photographié.

Effet de bord traité : le contexte reprend l'espace colorimétrique de la source
quand il est RGB, lu sur le `CGImage` sous-jacent (une capture et un fichier de
l'Étagère ne sont pas adossés de la même façon), pour ne pas désaturer une image
large gamut à l'enregistrement.

`FileHandoff` s'appuie sur `renderPNG` et perd son décodage redondant. Le handoff
par fichier était déjà correct et le reste.

## #53 — Presets de tâche

Sélecteur **Brut / Bug / Revue / Implémentation** au-dessus du champ Instructions.

- Les guidances sont rédigées comme des consignes d'ordre de travail, pas comme
  des rôles : « trouve la cause avant de proposer » change ce que fait l'agent,
  « tu es un expert du debug » ne change rien. Chacune autorise explicitement un
  « la capture ne suffit pas pour trancher », qui est souvent la bonne réponse et
  rarement celle qu'un modèle propose spontanément.
- Libellés **et** guidances localisés en/fr : ils sont lus dans l'infobulle avant
  le choix, et se retrouvent tels quels dans l'export.
- Le preset est une préférence (`@AppStorage`), comme `PinStyle` : c'est une
  manière de travailler, l'intérêt est de ne pas la re-choisir à chaque capture.
- **« Brut » n'ajoute rien du tout** — la sortie par défaut est identique au octet
  près (vérifié par assertion sur `buildText`).
- Le cadrage est aussi écrit dans **la légende incrustée**. Sans cela le preset
  n'aurait rien fait dans la configuration par défaut : légende incrustée = le
  presse-papier ne porte que l'image, donc ce qui manque au bandeau ne parvient
  jamais à l'agent.
- L'infobulle porte la guidance complète plutôt qu'une légende sous le sélecteur :
  trois phrases sous un panneau large de 260 pt au minimum, ça ne tient pas.

**Bug préexistant corrigé au passage** (le bandeau, que j'alourdissais) : sa
hauteur était mesurée avec `.usesFontLeading` et le texte dessiné sans, qui
compose des lignes plus hautes. Le panneau sortait quelques points trop court et
la dernière ligne des instructions de l'utilisateur était coupée par le bord de
l'image — reproduit tel quel sur `develop`. Mesure et dessin partagent désormais
la même constante d'options.

## #52 — Sortie JSON structurée

**Pas de second schéma.** `buildJSON` sérialise `FileHandoff.Document`, le
contrat versionné de #54 que #55 a étendu et contre lequel #56 et #57 seront
écrits. Deux formats concurrents auraient été le pire résultat possible.

Retenu de l'état des lieux laissé en #75 :

- **cible d'export explicite** — bouton « Exporter en JSON… » (⇧⌘S), plus un
  réglage pour le format du texte copié (Markdown par défaut, ou JSON) ;
- **style et couleur des repères** → `markerStyle` ;
- **horodatage de la capture d'origine** → `capturedAt`, distinct de `generatedAt` :
  une capture rouverte depuis l'historique peut dater de plusieurs jours ;
- **métadonnées de capture** → `image.scale` (pixels par point d'écran), `source`
  (application, titre de fenêtre, région capturée en points). Avec les deux, on
  repart d'un pixel de l'image vers le point d'écran correspondant ;
- **schéma publié hors du code** → `docs/capture-schema.json` (JSON Schema 2020-12) ;
- **chemin de relecture** → tout devient `Codable`, avec `readDocument(at:)` et
  `latestDocument()`.

Écarté, et pourquoi :

- **L'UTI de presse-papier dédié.** Un item de presse-papier annonçant plusieurs
  types laisse le receveur choisir, et ceux qui comptent ici choisissent mal — un
  terminal jette déjà l'image dès qu'un texte partage l'item (c'est la raison
  d'être du mode légende incrustée, #69). Le format choisi est écrit en `.string`
  et rien d'autre. Le réglage sert le même besoin sans le risque.
- **`CaptureRegion` comme source des métadonnées.** Elles sont déjà toutes dans
  l'instantané d'accessibilité (région, instant, fenêtre au centre de la capture),
  et les y prendre évite de faire transiter une nouvelle donnée par `AppDelegate`
  et `CaptureRecord`, qu'un autre chantier de cette vague touche. Contrepartie
  assumée : sans instantané AX, `source`, `capturedAt` et `image.scale` sont
  simplement absents.
- **Écrire le PNG à côté du JSON exporté.** L'utilisateur nomme un fichier, il en
  reçoit un. Le chemin « JSON + image ensemble » existe déjà et s'appelle
  `FileHandoff`.

`schemaVersion` reste à **1** : toutes les clés sont additives. `image.path` et
`markdownPath` deviennent optionnelles — elles restent écrites par le handoff par
fichier, seul un export JSON isolé les omet, faute de fichiers frères vers
lesquels pointer.

## Vérification

- `xcodegen generate` + `xcodebuild -scheme Pinpoint -destination 'platform=macOS'` → **BUILD SUCCEEDED**
- Harnais hors-app compilé sur les sources réelles : rendu 1:1 pour l'annoté, le
  pleine résolution, le presse-papier plafonné et la version à légende ; `px` du
  texte vérifiés contre la grille du PNG réellement produit ; comparaison
  avant/après contre le `Exporter.swift` de `develop` (le tableau ci-dessus).
- `buildText` avec « Brut » comparé octet à octet à la sortie sans preset.
- Trois documents produits par le code — minimal, complet, tel qu'écrit par le
  handoff — validés contre `docs/capture-schema.json` (jsonschema, Draft 2020-12),
  et relus par `JSONDecoder` (aller-retour complet).
- Éditeur rendu et capturé hors app pour vérifier la mise en page du sélecteur et
  du troisième bouton ; bandeau de légende rendu avec et sans preset.

## Périmètre

Pas touché au rendu des formes (`drawMarkup`) ni à leur description individuelle
dans `buildText` (#50), ni à `ScreenCapture` / la sélection de région (#51). Dans
`Localizable.xcstrings`, 17 clés insérées à leur place alphabétique : **102
lignes ajoutées, 0 supprimée**.
