### PR TITLE
OCR : faire voyager le texte sous les repères, pas seulement les pixels

### DIFF
--- a/Pinpoint/EditorView.swift
+++ b/Pinpoint/EditorView.swift
@@ -140,6 +140,8 @@ struct EditorView: View {
     /// feature is not having to pick it again every time.
     @AppStorage(TaskPreset.storageKey) private var taskPreset: TaskPreset = .raw
     @AppStorage(AgentTextFormat.storageKey) private var textFormat: AgentTextFormat = .markdown
+    /// Whether Pinpoint reads the text in the capture at all (#49).
+    @AppStorage(TextRecognitionSettings.enabledKey) private var textRecognition = true
 
     @State private var pins: [Pin] = []
     @State private var shapes: [Markup] = []
@@ -149,6 +151,17 @@ struct EditorView: View {
     /// name the element under each marker at export time — never queried live,
     /// since by now the photographed UI may be long gone.
     @State private var axSnapshot: AXSnapshot?
+    /// What the last recognition pass read in the capture (#49), or nil while
+    /// there is no usable answer — the feature is off, the pass hasn't finished
+    /// yet, or a crop has just replaced the image the boxes were measured in.
+    ///
+    /// Nil means "unknown", never "nothing there": `syncRecognizedText` returns
+    /// immediately on it rather than treating it as an empty read, so a marker
+    /// keeps whatever it already had until a real answer arrives. This is not
+    /// part of `EditorSnapshot` — it is derived from the image and the
+    /// redactions, both of which *are* — so undo re-derives it instead of
+    /// carrying a second copy around.
+    @State private var recognition: TextRecognition?
     @State private var tool: EditorTool = .pin
     @State private var selectedPinID: Pin.ID?
     @State private var selectedShapeID: Markup.ID?
@@ -225,6 +238,13 @@ struct EditorView: View {
                 .frame(minWidth: 260, idealWidth: 280, maxWidth: 360)
         }
         .frame(minWidth: 680, minHeight: 440)
+        // Reading the capture's text (#49). Keyed on everything the answer
+        // depends on, so SwiftUI cancels the pass in flight and starts a fresh
+        // one whenever the image is cropped, a redaction is drawn, moved,
+        // resized or deleted, or the setting is flipped. The work itself is
+        // `nonisolated async`, so it leaves the main actor at the `await` and
+        // the editor stays responsive while a full-screen capture is read.
+        .task(id: recognitionKey) { await refreshRecognition() }
         .onDisappear { onPersist(pins, shapes, context, image, axSnapshot) }
         // A text field changing hands closes one typing session and opens the
         // next. See `flushTextEdit()`.
@@ -998,13 +1018,31 @@ struct EditorView: View {
                 // so VoiceOver reads it once instead of twice.
                 .accessibilityHidden(true)
 
-            TextField("Describe this marker…", text: pin.note)
-                .textFieldStyle(.roundedBorder)
-                .focused($focusedField, equals: .note(pin.wrappedValue.id))
-                // Without this the placeholder is the label, and every field in
-                // the list announces itself identically.
-                .accessibilityLabel(String(localized: "a11y.marker.note",
-                                           defaultValue: "Description of marker \(number)"))
+            VStack(alignment: .leading, spacing: 3) {
+                TextField("Describe this marker…", text: pin.note)
+                    .textFieldStyle(.roundedBorder)
+                    .focused($focusedField, equals: .note(pin.wrappedValue.id))
+                    // Without this the placeholder is the label, and every field in
+                    // the list announces itself identically.
+                    .accessibilityLabel(String(localized: "a11y.marker.note",
+                                               defaultValue: "Description of marker \(number)"))
+
+                // What Pinpoint read under this marker, shown only once it has
+                // stopped being what the field above already says — i.e. once
+                // the user has written their own description over the pre-fill.
+                // The read still travels in the export, so it has to be visible
+                // somewhere: a feature that quietly puts a line of the screen
+                // into a file the user is about to hand to someone else should
+                // show them that line first.
+                if let read = recognizedCaption(for: pin.wrappedValue) {
+                    Text(read)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .help(read)
+                }
+            }
 
             Button {
                 removePin(pin.wrappedValue)
@@ -1024,6 +1062,20 @@ struct EditorView: View {
         // `onTapGesture` is a mouse affordance and nothing else; the same
         // selection has to be reachable from VoiceOver's actions menu.
         .accessibilityAction { selectPin(pin.wrappedValue.id) }
+    }
+
+    /// The one-line reminder of what was read under a marker, or nil when there
+    /// is nothing to add — no read, a read a redaction covers, or a read the
+    /// description already repeats word for word.
+    ///
+    /// Deliberately the same three conditions `Exporter.recognizedLines` uses,
+    /// so what the panel shows and what the export writes can't come apart.
+    private func recognizedCaption(for pin: Pin) -> String? {
+        guard let read = pin.recognizedText(hiddenBy: RedactionMask(shapes)) else { return nil }
+        let note = pin.note.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard note.caseInsensitiveCompare(read.text) != .orderedSame else { return nil }
+        return String(localized: "editor.marker.read",
+                      defaultValue: "Read in the image: “\(read.text)”")
     }
 
     /// Highlight for the selected row of the side panel.
@@ -1278,8 +1330,97 @@ struct EditorView: View {
         flushTextEdit()
         let before = snapshot()
         body()
+        // Recognized text is derived state, refreshed here rather than at each
+        // of the dozen call sites — so no future mutation can forget it, and so
+        // the refresh lands *inside* the entry of the action that caused it.
+        // That is what makes drawing a redaction over a quoted error one undo
+        // step and not two, and what makes dropping a marker arrive with its
+        // description already filled in.
+        syncRecognizedText()
         guard snapshot() != before else { return }
         history.record(before)
+    }
+
+    // MARK: - Recognized text (#49)
+
+    /// Everything the recognition pass depends on. Any change to it cancels the
+    /// pass in flight and schedules another.
+    ///
+    /// Only the *redactions* are listed, not every shape: an arrow moved across
+    /// the picture changes nothing about what can be read, and re-running a
+    /// second of OCR on every frame of a drag would be absurd. A redaction, on
+    /// the other hand, changes the image the recognizer is given.
+    private var recognitionKey: RecognitionKey {
+        RecognitionKey(image: ObjectIdentifier(image),
+                       redactions: shapes.filter(\.isRedaction).map(\.rect),
+                       enabled: textRecognition)
+    }
+
+    private struct RecognitionKey: Equatable {
+        let image: ObjectIdentifier
+        let redactions: [CGRect]
+        let enabled: Bool
+    }
+
+    /// Runs one recognition pass over the current image and folds its result
+    /// into the document.
+    ///
+    /// The `CGImage` is taken here, on the main actor, because `NSImage` is not
+    /// safe to touch from anywhere else; everything after the `await` runs off
+    /// it. The mask is read here too, so the pass is given the redactions as
+    /// they stood when it started — and `.task(id:)` restarts it if they move.
+    private func refreshRecognition() async {
+        // Settle before doing anything. A redaction is *dragged* into place, so
+        // `recognitionKey` changes on every frame of that gesture and SwiftUI
+        // restarts this task each time — and a pass is half a second of CPU
+        // that cancellation cannot claw back, because `perform(on:)` runs to
+        // completion whatever the task's state. Sleeping is the part that *is*
+        // cancellable, so putting it first is what turns sixty restarts into
+        // sixty abandoned waits and one pass.
+        do { try await Task.sleep(for: .milliseconds(250)) } catch { return }
+
+        guard textRecognition else {
+            // Switched off. The reads are dropped, so no `Text:` line and no
+            // `recognizedText` key leaves the app — but the notes stay exactly
+            // as they are. A description the user has been looking at, and may
+            // have accepted as their own, is not Pinpoint's to delete on a
+            // settings flip.
+            recognition = nil
+            withUndo { for index in pins.indices { pins[index].recognized = nil } }
+            return
+        }
+        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else { return }
+        let mask = RedactionMask(shapes)
+
+        let result = await TextRecognizer.recognize(in: cgImage, hiddenBy: mask)
+        guard !Task.isCancelled else { return }
+
+        recognition = result
+        // `withUndo` re-derives every marker's text and records an entry only
+        // if that actually changed the document — so a pass over a capture with
+        // no markers, or one that confirms what the markers already carry,
+        // leaves the undo stack alone.
+        withUndo(syncRecognizedText)
+    }
+
+    /// Re-derives every marker's recognized text from the current pass, the
+    /// current redactions and the current accessibility context.
+    ///
+    /// The rules themselves live in `Array<Pin>.applyRecognition` — including
+    /// the one that takes back a pre-filled description when a redaction covers
+    /// what it was read from — so they can be exercised without an editor on
+    /// screen. All that belongs here is the state to feed them.
+    private func syncRecognizedText() {
+        guard let recognition else { return }
+        let mask = RedactionMask(shapes)
+        // The accessibility tree gets first refusal on naming what a marker
+        // points at (#55); the read is kept only where it says something the
+        // tree did not. Deciding it here rather than in the exporters is what
+        // keeps the pre-filled description and the exported `Text:` line from
+        // ever disagreeing about it.
+        pins.applyRecognition(recognition, imageSize: image.size, hiddenBy: mask) { text, position in
+            axSnapshot?.names(text, atNormalized: position, hiddenBy: mask) ?? false
+        }
     }
 
     /// Closes the current typing session, if any, and folds it into one undo
@@ -1407,11 +1548,31 @@ struct EditorView: View {
             (0...1).contains(p.x) && (0...1).contains(p.y)
         }
 
+        // A read's box is normalized against the image, so it has to be remapped
+        // exactly like a marker's position — otherwise a crop would leave every
+        // marker quoting text at coordinates measured in the *previous* image,
+        // and the redaction check at the export boundary would be asking the
+        // mask about the wrong rectangle.
+        func remap(_ rect: CGRect) -> CGRect {
+            CGRect(x: (rect.minX - origin.x) / size.width, y: (rect.minY - origin.y) / size.height,
+                   width: rect.width / size.width, height: rect.height / size.height)
+        }
+        let unit = CGRect(x: 0, y: 0, width: 1, height: 1)
+
         var newPins: [Pin] = []
         for pin in pins {
             let q = remap(pin.position)
             guard inside(q) else { continue }
-            newPins.append(Pin(id: pin.id, number: pin.number, position: q, note: pin.note))
+            let recognized = pin.recognized.flatMap { read -> RecognizedText? in
+                let box = remap(read.box)
+                // A read cropped entirely out of the picture stops describing
+                // this image; the note keeps whatever it said, as the user's
+                // text now.
+                guard box.intersects(unit) else { return nil }
+                return RecognizedText(text: read.text, box: box)
+            }
+            newPins.append(Pin(id: pin.id, number: pin.number, position: q,
+                               note: pin.note, recognized: recognized))
         }
         var newShapes: [Markup] = []
         for shape in shapes {
@@ -1441,6 +1602,12 @@ struct EditorView: View {
         image = newImage
         pins = newPins
         shapes = newShapes
+        // The cached reading was measured in the image that has just been
+        // replaced. Dropping it stops `syncRecognizedText` — which `withUndo`
+        // is about to call — from resolving markers against boxes that no
+        // longer mean anything; `.task(id:)` starts a fresh pass on the new
+        // image, and the markers keep what they carry until it lands.
+        recognition = nil
         // The snapshot describes a screen region, not the image, so a crop only
         // has to narrow that region — every element frame stays valid as it is.
         axSnapshot = axSnapshot?.cropped(to: c)

--- a/Pinpoint/Exporter.swift
+++ b/Pinpoint/Exporter.swift
@@ -340,6 +340,14 @@ enum Exporter {
             if snapshot != nil {
                 lines.append(String(localized: "export.markers.accessibility.legend", defaultValue: "“UI” lines name the interface element found under the marker in the macOS accessibility tree at capture time — its role, its label, the app owning it, and its box in this image. “Path” is the chain of containers around it."))
             }
+            // Said once, and only when at least one marker actually carries a
+            // read: a reader has to know that a quoted line came out of the
+            // pixels rather than out of the user, and that a description may
+            // have started as one. Same rule as the accessibility legend above —
+            // no promise of details that never come.
+            if orderedPins.contains(where: { $0.recognizedText(hiddenBy: mask) != nil }) {
+                lines.append(String(localized: "export.markers.text.legend", defaultValue: "“Text” lines are what Pinpoint read in the pixels under the marker, on this Mac. A marker’s description may have been pre-filled from such a read and then edited by the user."))
+            }
             lines.append("")
             for pin in orderedPins {
                 let note = pin.note.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -352,6 +360,7 @@ enum Exporter {
                 // misread, and left out entirely when there's nothing to say.
                 lines.append(contentsOf: accessibilityLines(for: pin.position, snapshot: snapshot,
                                                             mask: mask, imageSize: imageSize))
+                lines.append(contentsOf: recognizedLines(for: pin, note: note, mask: mask))
             }
         }
 
@@ -442,6 +451,36 @@ enum Exporter {
         }
         lines.append("  - Path: " + resolved.path)
         return lines
+    }
+
+    /// The line quoting what Pinpoint read in the pixels under a marker (#49),
+    /// or nothing when there is nothing left to add.
+    ///
+    /// Two reasons it can come to nothing, and they are different reasons.
+    ///
+    /// **Nothing to add.** The marker's own description already *is* that text,
+    /// which is the common case: an empty description is pre-filled from the
+    /// read, so printing both would put the same string twice under one marker.
+    /// That is not corroboration — it is one source counted twice, and an agent
+    /// weighing "the label says X and the pixels say X" would be weighing a
+    /// copy of itself. The legend above says descriptions may come from a read;
+    /// this line exists for when the two have since diverged, which is exactly
+    /// when both are worth having.
+    ///
+    /// **Nothing allowed.** `recognizedText(hiddenBy:)` refuses a marker on a
+    /// redacted region and a read a bar touches.
+    ///
+    /// The accessibility overlap — a native app whose tree already names the
+    /// very string the pixels show — is settled earlier, in the editor, so that
+    /// `pin.recognized` is nil rather than filtered here: the pre-filled note
+    /// has to make the same choice, and one arbitration in one place is the
+    /// only way the note and the export can't disagree.
+    private static func recognizedLines(for pin: Pin, note: String, mask: RedactionMask) -> [String] {
+        guard let recognized = pin.recognizedText(hiddenBy: mask),
+              note.caseInsensitiveCompare(recognized.text) != .orderedSame else { return [] }
+        // `Text:` stays in English alongside `UI:`, `Value:` and `Path:`: these
+        // are field names in a machine-read file, not prose.
+        return ["  - Text: “\(recognized.text)”"]
     }
 
     /// An element's screen frame restated in the image's own pixel grid, so it

--- a/Pinpoint/HandoffDocument.swift
+++ b/Pinpoint/HandoffDocument.swift
@@ -252,6 +252,23 @@ extension FileHandoff {
             /// absent for a marker dropped on a redacted region, where naming
             /// what sits under the bar would undo the redaction in text.
             let accessibility: AccessibilityElement?
+            /// The text Pinpoint read in the pixels under this marker (#49),
+            /// recognized on the user's own Mac with no network call.
+            ///
+            /// A separate key from `note` rather than folded into it, even
+            /// though `note` is often pre-filled from this very string: the two
+            /// have different provenance — one is what a person wrote, the
+            /// other what a machine read — and a consumer weighing them has to
+            /// be able to tell which is which. `capture.md` drops the second
+            /// copy when they match because it is prose; this file keeps both,
+            /// because a missing key here would be ambiguous between "nothing
+            /// was read" and "what was read matched the note".
+            ///
+            /// Absent when nothing legible sat within reach of the marker, when
+            /// the accessibility element above already names the same thing,
+            /// when the feature is switched off — and always for a marker on a
+            /// redacted region or a read a bar touches.
+            let recognizedText: String?
         }
 
         /// An unnumbered shape: arrow, rectangle or redaction.
@@ -330,13 +347,13 @@ extension FileHandoff.Document {
         let mask = RedactionMask(shapes)
         if let snapshot = accessibility {
             self.markers = ordered.map { pin in
-                Marker(pin, in: imageSize,
+                Marker(pin, in: imageSize, hiddenBy: mask,
                        accessibility: snapshot.element(atNormalized: pin.position, hiddenBy: mask)
                     .map { AccessibilityElement($0, in: snapshot, imageSize: imageSize) })
             }
             self.accessibility = AccessibilityContext(snapshot, formatter: formatter)
         } else {
-            self.markers = ordered.map { Marker($0, in: imageSize, accessibility: nil) }
+            self.markers = ordered.map { Marker($0, in: imageSize, hiddenBy: mask, accessibility: nil) }
             self.accessibility = nil
         }
 
@@ -406,7 +423,11 @@ extension FileHandoff {
 }
 
 extension FileHandoff.Document.Marker {
-    init(_ pin: Pin, in size: CGSize,
+    /// `mask` is asked about the marker's read rather than about the marker
+    /// alone: the redaction has to reach the text Pinpoint recognized the same
+    /// way it already reaches the accessibility element, and this is the last
+    /// point before it is encoded.
+    init(_ pin: Pin, in size: CGSize, hiddenBy mask: RedactionMask,
          accessibility: FileHandoff.Document.AccessibilityElement?) {
         self.init(
             id: pin.id.shortToken,
@@ -414,7 +435,8 @@ extension FileHandoff.Document.Marker {
             number: pin.number,
             note: pin.note.trimmingCharacters(in: .whitespacesAndNewlines),
             position: FileHandoff.Document.Point(pin.position, in: size),
-            accessibility: accessibility
+            accessibility: accessibility,
+            recognizedText: pin.recognizedText(hiddenBy: mask)?.text
         )
     }
 }

--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -622,6 +622,12 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Dépose des captures dans %@ ou change le dossier surveillé dans les Réglages." } }
       }
     },
+    "editor.marker.read" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Read in the image: “%@”" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Lu dans l’image : « %@ »" } }
+      }
+    },
     "Embed legend in the image" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Inclure la légende dans l’image" } }
@@ -655,6 +661,12 @@
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "M1, M2… are the numbers drawn on the image; the code in brackets is a stable ID for that marker." } },
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "M1, M2… correspondent aux numéros dessinés sur l’image ; le code entre crochets est un identifiant stable de ce repère." } }
+      }
+    },
+    "export.markers.text.legend" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "“Text” lines are what Pinpoint read in the pixels under the marker, on this Mac. A marker’s description may have been pre-filled from such a read and then edited by the user." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Les lignes « Text » sont ce que Pinpoint a lu dans les pixels sous le repère, sur ce Mac. La description d’un repère a pu être pré-remplie à partir d’une telle lecture, puis modifiée par l’utilisateur." } }
       }
     },
     "export.shapes.heading" : {
@@ -1081,6 +1093,24 @@
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Unavailable while the legend is embedded: the clipboard then carries the image alone. The files for the agent are written in both formats either way." } },
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Indisponible tant que la légende est incrustée : le presse-papier ne porte alors que l’image. Les fichiers pour l’agent sont écrits dans les deux formats quoi qu’il arrive." } }
+      }
+    },
+    "settings.ocr.explanation" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Pre-fills a marker’s description with the line of text it points at, and writes that line into the files for the agent — so small text an agent would misread from the image travels as text. Read on this Mac; nothing is sent anywhere. Areas you have hidden are never read." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Pré-remplit la description d’un repère avec la ligne de texte qu’il désigne, et écrit cette ligne dans les fichiers pour l’agent — pour que le petit texte qu’un agent lirait de travers sur l’image voyage sous forme de texte. Lu sur ce Mac ; rien n’est envoyé nulle part. Les zones que vous avez masquées ne sont jamais lues." } }
+      }
+    },
+    "settings.ocr.section" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Text in the capture" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Texte de la capture" } }
+      }
+    },
+    "settings.ocr.toggle" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Read the text under each marker" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Lire le texte sous chaque repère" } }
       }
     },
     "Settings…" : {

--- a/Pinpoint/Pin.swift
+++ b/Pinpoint/Pin.swift
@@ -8,6 +8,18 @@ struct Pin: Identifiable, Equatable, Codable {
     var number: Int
     var position: CGPoint
     var note: String = ""
+    /// The text Pinpoint read in the pixels under this marker (#49).
+    ///
+    /// Kept apart from `note` so the two provenances never blur: `note` is what
+    /// the user wrote — even when it started life as a copy of this — and this
+    /// is what the machine read. Nothing downstream has to guess which it is
+    /// holding, and the editor can take back its own pre-fill when a redaction
+    /// covers the source without ever touching a word the user typed.
+    ///
+    /// Nil when nothing legible sat within reach, when the marker is on a
+    /// redacted region, when the accessibility tree already named the same
+    /// thing (see `EditorView.syncRecognizedText`), or when the feature is off.
+    var recognized: RecognizedText?
 }
 
 extension UUID {

--- a/Pinpoint/PinpointApp.swift
+++ b/Pinpoint/PinpointApp.swift
@@ -42,7 +42,7 @@ struct SettingsView: View {
                 .textSelection(.enabled)
                 .padding(.vertical, 6)
         }
-        .frame(width: 460, height: 470)
+        .frame(width: 460, height: 520)
     }
 
     /// Marketing version + build read from the bundle, e.g. "Pinpoint 0.3.0 (3)".
@@ -62,6 +62,7 @@ struct CaptureSettingsView: View {
     @AppStorage(CaptureDelay.storageKey) private var captureDelay: CaptureDelay = .off
     @AppStorage(AXContextSettings.enabledKey) private var axContext = true
     @AppStorage(AXContextSettings.fieldValuesKey) private var axFieldValues = false
+    @AppStorage(TextRecognitionSettings.enabledKey) private var textRecognition = true
 
     /// Whether macOS grants Accessibility, re-read whenever the window comes
     /// back — the switch is flipped in System Settings, in another process, so
@@ -120,6 +121,7 @@ struct CaptureSettingsView: View {
                     .font(.callout)
             }
             accessibilitySection
+            textRecognitionSection
         }
         .formStyle(.grouped)
         // Coming back from System Settings is the moment the answer can have
@@ -167,6 +169,26 @@ struct CaptureSettingsView: View {
                 .disabled(!axContext)
             Text(String(localized: "settings.ax.fieldValues.explanation",
                         defaultValue: "Off by default: the accessibility tree returns the whole contents of a field, including the part scrolled out of the picture. Password fields are never read, whatever this says."))
+                .foregroundStyle(.secondary)
+                .font(.callout)
+        }
+    }
+
+    /// Reading the text in the capture (#49).
+    ///
+    /// Needs no permission and reaches no network, so unlike the section above
+    /// there is nothing to prompt for and nothing to warn about. What the
+    /// explanation has to be straight about instead is the change it makes:
+    /// the text was always in the picture, and this puts it in the text files
+    /// too — where it can be searched, quoted and pasted on, which is both the
+    /// point of the feature and the reason someone might want it off.
+    private var textRecognitionSection: some View {
+        Section(String(localized: "settings.ocr.section", defaultValue: "Text in the capture")) {
+            Toggle(String(localized: "settings.ocr.toggle",
+                          defaultValue: "Read the text under each marker"),
+                   isOn: $textRecognition)
+            Text(String(localized: "settings.ocr.explanation",
+                        defaultValue: "Pre-fills a marker’s description with the line of text it points at, and writes that line into the files for the agent — so small text an agent would misread from the image travels as text. Read on this Mac; nothing is sent anywhere. Areas you have hidden are never read."))
                 .foregroundStyle(.secondary)
                 .font(.callout)
         }

--- a/Pinpoint/Redaction.swift
+++ b/Pinpoint/Redaction.swift
@@ -117,3 +117,41 @@ extension AXSnapshot {
         return stripped
     }
 }
+
+// MARK: - Recognized text
+
+extension Pin {
+
+    /// What Pinpoint read in the pixels under this marker (#49), with anything
+    /// a redaction covers taken out of the answer — the only reading the
+    /// exporters are allowed to publish.
+    ///
+    /// The recognizer already worked on an image with the bars painted onto it,
+    /// so in the ordinary flow there is nothing left here to catch. This is the
+    /// check that makes that a *belt* rather than the only strap, and it earns
+    /// its keep in the cases where the two can drift apart:
+    ///
+    /// - a read taken before the bar was drawn, still cached on the marker
+    ///   while the next pass runs;
+    /// - a capture re-opened from the Shelf or the history, whose markers carry
+    ///   reads recorded in an earlier session;
+    /// - any future caller that builds a document straight from stored pins
+    ///   without an editor in the loop.
+    ///
+    /// In each of those the mask is right there in `shapes` and the read is
+    /// right there on the pin, so the exporters can simply ask — the same shape
+    /// as `AXSnapshot.element(atNormalized:hiddenBy:)`, and for the same
+    /// reason: this file is where the question "may this leave?" is answered,
+    /// and no exporter should have to trust that another one was careful.
+    ///
+    /// Two rules, mirroring the accessibility ones. A marker *on* a redacted
+    /// region reads nothing. A read whose box a redaction touches — however
+    /// little of it — is dropped whole, because a line's characters live inside
+    /// its box and the covered ones are exactly the ones the user meant to
+    /// hide.
+    func recognizedText(hiddenBy mask: RedactionMask) -> RecognizedText? {
+        guard let recognized else { return nil }
+        guard !mask.hides(position), !mask.hides(recognized.box) else { return nil }
+        return recognized
+    }
+}

--- a/Pinpoint/TextRecognizer.swift
+++ b/Pinpoint/TextRecognizer.swift
@@ -1,0 +1,383 @@
+import CoreGraphics
+import Foundation
+import Vision
+
+/// A line of text Pinpoint read in a capture, and where it sits (#49).
+///
+/// The point of the feature in one sentence: an agent handed a screenshot has
+/// to guess at the small text in it — a module name, a stack frame, a hex code
+/// — and it guesses badly. macOS can read those pixels on this machine, so the
+/// string itself travels in `capture.md` and `capture.json` next to the picture
+/// instead of only being *in* the picture.
+///
+/// `box` is normalized (0…1) in image space, top-left origin: the convention
+/// `Pin`, `Markup` and `RedactionMask` already speak, so the mask can be asked
+/// about a read without converting anything — which is what makes the
+/// redaction check at the export boundary a one-liner.
+struct RecognizedText: Equatable, Codable, Sendable {
+    /// What was read. Trimmed, whitespace-collapsed, never empty.
+    var text: String
+    /// Where it was read, normalized in image space, top-left origin.
+    var box: CGRect
+}
+
+/// Everything one recognition pass over a capture found, and the only question
+/// the editor asks of it: "what is this marker pointing at?".
+///
+/// A pass covers the whole image rather than a crop around each marker, and
+/// that is deliberate. Vision recognizes *lines*, using the layout of the page
+/// around them; a window cut around a marker slices words in half and hands the
+/// recognizer a fragment to guess at, which is exactly the failure this feature
+/// exists to fix. One pass also costs one pass, however many markers get
+/// dropped afterwards — and markers are dropped one at a time, interactively,
+/// where a per-marker request would be felt.
+///
+/// So the window is applied to the *results* instead: `text(near:)` picks the
+/// line closest to the marker and refuses anything further off than a badge and
+/// a half. Whole lines in, whole lines out, nothing cut.
+struct TextRecognition: Equatable, Sendable {
+    /// The legible lines of the capture, already filtered against the mask the
+    /// pass ran under. Empty when nothing was readable — a photo, a video
+    /// still, a chart — which is a perfectly ordinary outcome.
+    var lines: [RecognizedText]
+
+    static let empty = TextRecognition(lines: [])
+}
+
+extension TextRecognition {
+
+    /// The line of text a marker at `point` is pointing at, or nil when there
+    /// is nothing legible within reach.
+    ///
+    /// `mask` is applied again here, on top of the painting the pass already
+    /// did (see `TextRecognizer.redacted`): the pass ran under the redactions
+    /// as they stood *then*, and the user can paint a new bar at any moment
+    /// while its result is still cached. Re-asking is pure geometry and makes
+    /// the answer follow the current mask without waiting for a new pass.
+    func text(near point: CGPoint, imageSize: CGSize, hiddenBy mask: RedactionMask) -> RecognizedText? {
+        guard imageSize.width > 0, imageSize.height > 0 else { return nil }
+        // A marker dropped on a redacted region reads nothing at all — the same
+        // blunt rule `AXSnapshot.element(atNormalized:hiddenBy:)` applies, for
+        // the same reason: the user pointed at something they had just decided
+        // to hide, and the honest answer is silence.
+        guard !mask.hides(point) else { return nil }
+
+        let reach = Self.reach(for: imageSize)
+        let anchor = CGPoint(x: point.x * imageSize.width, y: point.y * imageSize.height)
+
+        var best: (line: RecognizedText, distance: CGFloat, area: CGFloat)?
+        for line in lines where !mask.hides(line.box) {
+            let box = CGRect(x: line.box.minX * imageSize.width,
+                             y: line.box.minY * imageSize.height,
+                             width: line.box.width * imageSize.width,
+                             height: line.box.height * imageSize.height)
+            let distance = Self.distance(from: anchor, to: box)
+            guard distance <= reach else { continue }
+            let area = box.width * box.height
+            // Nearest wins; the smaller box breaks a tie, since a marker inside
+            // two nested reads is pointing at the more specific one.
+            if let current = best, (current.distance, current.area) <= (distance, area) { continue }
+            best = (line, distance, area)
+        }
+        return best?.line
+    }
+
+    /// How far from a marker a line of text may sit and still count as what
+    /// that marker points at, in image pixels.
+    ///
+    /// Expressed as the marker badge's own radius (#48) rather than as a fresh
+    /// constant, for two reasons. The badge is the thing the user aimed with,
+    /// so it is the honest unit for "close enough". And the metric already
+    /// scales with the capture — `max(16, width × 0.014)` — so a Retina
+    /// screenshot, stored at twice the pixels the 1× one would have, gets twice
+    /// the reach and therefore the *same* physical window on screen. Nothing
+    /// else in this file needs to know about backing scales.
+    ///
+    /// Half again as much as the badge covers the ordinary miss of clicking
+    /// just under a line of text; much more than that starts pulling in the
+    /// sentence above and the one below, which is the failure mode on the other
+    /// side — a marker quoting text it was never pointing at.
+    static func reach(for imageSize: CGSize) -> CGFloat {
+        MarkupMetrics(imageWidth: imageSize.width).pinRadius * 1.5
+    }
+
+    /// Euclidean distance from a point to the nearest edge of a rect; zero for
+    /// a point inside it, which is how "the marker is on the text" wins.
+    private static func distance(from point: CGPoint, to rect: CGRect) -> CGFloat {
+        let dx = max(rect.minX - point.x, 0, point.x - rect.maxX)
+        let dy = max(rect.minY - point.y, 0, point.y - rect.maxY)
+        return hypot(dx, dy)
+    }
+}
+
+// MARK: - Recognition
+
+/// Reads the text of a capture with Vision, on this Mac and without a network
+/// call of any kind (#49).
+enum TextRecognizer {
+
+    /// Longest read kept whole. Past it the line is cut rather than dropped:
+    /// the first 200 characters of an error message are still the error
+    /// message, while a whole paragraph under one marker is not context.
+    static let maximumLength = 200
+
+    /// Reads below this are discarded. `.accurate` reports comfortably above it
+    /// for text it actually resolved, so the floor mostly catches what it
+    /// hallucinated out of icons, gradients and window chrome — the "noise"
+    /// half of "don't put a note there unless there is something to say".
+    private static let minimumConfidence: Float = 0.4
+
+    /// Every legible line of `image`, with the regions `mask` covers taken out.
+    ///
+    /// Fails closed in every branch: an unreadable image, a recognizer error,
+    /// a redaction that could not be painted — all of them return no lines
+    /// rather than lines from an image that might not have been redacted.
+    static func recognize(in image: CGImage, hiddenBy mask: RedactionMask) async -> TextRecognition {
+        guard let input = redacted(image, by: mask) else { return .empty }
+
+        var request = RecognizeTextRequest()
+        // `.accurate` and not `.fast`. The strings this feature exists for are
+        // small, dense and unforgiving — a module path, a hex address, a class
+        // name — and `.fast` mangles exactly those: on five such lines of 13 pt
+        // Menlo it returned none of them character-perfect at either 1× or 2×,
+        // reading `react-dom/client` as `react-doTh/client` and breaking words
+        // in two, where `.accurate` got 4 of 5 exact at 2×. A read that is
+        // *nearly* right is worse than no read at all here, because nothing
+        // downstream can tell the difference.
+        //
+        // It is 10 to 20 times slower — measured on an M-series Mac, roughly
+        // 0.65 s for a 3024×1964 full-screen capture and 0.81 s for a
+        // 5120×2880 one, against 0.04 s and 0.06 s — and that is affordable
+        // precisely because it is one pass per capture, off the main actor,
+        // running while the user is still deciding where to click.
+        request.recognitionLevel = .accurate
+        request.usesLanguageCorrection = true
+        request.recognitionLanguages = languages
+
+        guard let observations = try? await request.perform(on: input) else { return .empty }
+
+        let size = CGSize(width: input.width, height: input.height)
+        let lines = observations
+            .compactMap { line(from: $0, in: size) }
+            // Second lock. The bars are already painted, so nothing here should
+            // touch one; a glyph straddling the edge of a bar can still leave a
+            // legible half, and half of a secret is a secret.
+            .filter { !mask.hides($0.box) }
+        return TextRecognition(lines: lines)
+    }
+
+    /// English and French — the two the app speaks — with the user's own first.
+    /// Vision weighs the order, and a French interface is far likelier to be
+    /// what is on screen when Pinpoint itself is running in French.
+    private static var languages: [Locale.Language] {
+        let french = Locale.Language(identifier: "fr-FR")
+        let english = Locale.Language(identifier: "en-US")
+        return Locale.current.language.languageCode?.identifier == "fr"
+            ? [french, english]
+            : [english, french]
+    }
+
+    /// One observation as a `RecognizedText`, or nil when it isn't worth
+    /// putting under a marker.
+    private static func line(from observation: RecognizedTextObservation,
+                             in size: CGSize) -> RecognizedText? {
+        guard size.width > 0, size.height > 0,
+              let candidate = observation.topCandidates(1).first,
+              candidate.confidence >= minimumConfidence,
+              let text = cleaned(candidate.string) else { return nil }
+
+        // Vision answers in its own normalized space, bottom-left origin;
+        // `.upperLeft` flips it into the image's pixel grid, which the divide
+        // then puts back into the 0…1 top-left space the rest of the app uses.
+        // Both steps are resolution-independent, which is what makes a 1× and a
+        // 2× capture of the same window produce the same box.
+        let pixels = observation.boundingBox.toImageCoordinates(size, origin: .upperLeft)
+        return RecognizedText(
+            text: text,
+            box: CGRect(x: pixels.minX / size.width, y: pixels.minY / size.height,
+                        width: pixels.width / size.width, height: pixels.height / size.height)
+        )
+    }
+
+    /// Collapses the runs of whitespace a recognizer leaves between columns,
+    /// and rejects what would be worse than nothing under a marker: an empty
+    /// read, a lone stray glyph, a smudge with no letter or digit in it.
+    ///
+    /// This is the "nothing legible" case the feature has to get right. A
+    /// marker whose description is `l` or `—` is not a marker with context, it
+    /// is a marker with a wrong answer, and an agent has no way to tell the two
+    /// apart.
+    static func cleaned(_ string: String) -> String? {
+        let collapsed = string.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+        guard collapsed.count >= 2,
+              collapsed.rangeOfCharacter(from: .alphanumerics) != nil else { return nil }
+        guard collapsed.count > maximumLength else { return collapsed }
+        return collapsed.prefix(maximumLength).trimmingCharacters(in: .whitespaces) + "…"
+    }
+
+    /// The capture with every redacted region filled solid — the image the
+    /// recognizer is actually handed.
+    ///
+    /// This is the load-bearing half of the promise `RedactionMask` makes, and
+    /// the order matters more than it looks. Recognizing first and filtering
+    /// afterwards would mean the text under the bar had been read into memory
+    /// and was one missed check away from `capture.md`; painting first means
+    /// there is nothing there to read. The filter in `recognize` stays as well,
+    /// but as a second lock and not as the mechanism.
+    ///
+    /// Solid black rather than the export's bar-with-a-border: fidelity is
+    /// irrelevant to a recognizer, only coverage is, and covering *more* than
+    /// the export does can only be safe. The rect is grown by a pixel for the
+    /// same reason — an antialiased fringe of a character surviving at the edge
+    /// of a bar is exactly the kind of half-glyph `.accurate` is good at
+    /// finishing for you.
+    ///
+    /// Returns nil rather than the original whenever anything fails. A capture
+    /// with no redactions at all short-circuits to the original, which is the
+    /// only path that hands back an unpainted image.
+    private static func redacted(_ image: CGImage, by mask: RedactionMask) -> CGImage? {
+        guard !mask.isEmpty else { return image }
+        let width = image.width
+        let height = image.height
+        guard width > 0, height > 0 else { return nil }
+
+        let sourceSpace = image.colorSpace
+        let space = (sourceSpace?.model == .rgb ? sourceSpace : nil) ?? CGColorSpace(name: CGColorSpace.sRGB)
+        guard let space,
+              let context = CGContext(data: nil, width: width, height: height,
+                                      bitsPerComponent: 8, bytesPerRow: 0, space: space,
+                                      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+        else { return nil }
+
+        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+        context.setFillColor(gray: 0, alpha: 1)
+        for rect in mask.rects {
+            // Normalized, top-left → the context's bottom-left pixel grid.
+            let pixels = CGRect(x: rect.minX * CGFloat(width),
+                                y: (1 - rect.maxY) * CGFloat(height),
+                                width: rect.width * CGFloat(width),
+                                height: rect.height * CGFloat(height))
+            context.fill(pixels.integral.insetBy(dx: -1, dy: -1))
+        }
+        return context.makeImage()
+    }
+}
+
+// MARK: - Arbitration with the accessibility context (#55)
+
+extension AXSnapshot {
+
+    /// Whether the interface element under a marker already puts this string
+    /// there — as its name, or as the value of the field it points at.
+    ///
+    /// The arbitration between the two sources of "what is under this marker",
+    /// made once and in one place. Neither wins in the abstract, because which
+    /// one is worth having depends entirely on what was photographed. On a
+    /// native app the tree usually holds the exact string the pixels show, and
+    /// holds it *better*: spelled from the source rather than guessed from
+    /// antialiased glyphs, and arriving with a role, a box and a path around
+    /// it. On an Electron or web window — Slack, VS Code, a Chrome tab — the
+    /// tree is often a stack of anonymous groups and the pixels are the only
+    /// place the text exists at all, which is where reading them earns its
+    /// keep.
+    ///
+    /// So the rule is not "prefer one" but **never say it twice**: the read is
+    /// dropped exactly when the tree already carries it, and kept whenever it
+    /// says something the tree did not. Two lines under one marker repeating
+    /// each other are not corroboration — they are one source counted twice,
+    /// and an agent weighing "the label says X and the pixels say X" would be
+    /// weighing a copy of itself.
+    ///
+    /// Containment either way round, because the two rarely match to the
+    /// character: a recognizer reads a button's whole row where `AXTitle` holds
+    /// just the word, and reads the word where the label is a full sentence.
+    /// Strings under three characters are ignored on both sides — "OK" found
+    /// inside anything proves nothing.
+    func names(_ text: String, atNormalized point: CGPoint, hiddenBy mask: RedactionMask) -> Bool {
+        guard let resolved = element(atNormalized: point, hiddenBy: mask) else { return false }
+        let needle = Self.comparable(text)
+        guard needle.count >= 3 else { return false }
+        return [resolved.element.name, resolved.element.value]
+            .compactMap { $0.map(Self.comparable) }
+            .filter { $0.count >= 3 }
+            .contains { $0.contains(needle) || needle.contains($0) }
+    }
+
+    /// Case- and spacing-insensitive form, used only to decide whether two
+    /// strings carry the same information. Never displayed, never exported.
+    private static func comparable(_ string: String) -> String {
+        string.lowercased().split(whereSeparator: \.isWhitespace).joined(separator: " ")
+    }
+}
+
+// MARK: - Applying a pass to the markers
+
+extension Array where Element == Pin {
+
+    /// Re-derives every marker's recognized text from a pass, and keeps the
+    /// descriptions Pinpoint pre-filled in step with it.
+    ///
+    /// Deliberately here and not in `EditorView`: these are the rules that
+    /// decide whether an API key stays in a marker's description after the user
+    /// has painted over it, and rules like that should be checkable without a
+    /// window on screen (`scripts/verify-ocr-redaction.swift` runs exactly this
+    /// function). The editor calls it inside `withUndo`, so every change it
+    /// makes is one undo step with the action that caused it.
+    ///
+    /// The note rules, in the order they are applied:
+    ///
+    /// - A description that is still *exactly* what Pinpoint put there follows
+    ///   its source, including all the way back to empty when a redaction has
+    ///   just taken that source away. This is the case #50 hinges on: a
+    ///   description auto-filled with a token, then painted over, must not ship
+    ///   the token — and this text is Pinpoint's own output, so taking it back
+    ///   costs the user nothing they wrote.
+    /// - An empty description is filled from a first read.
+    /// - Anything else — a description the user typed, or one they deliberately
+    ///   cleared — is never touched. The mask governs what Pinpoint collects,
+    ///   not what a person chose to write.
+    ///
+    /// `isSuperseded` is asked before a read is kept at all, and is how the
+    /// accessibility context (#55) wins where it already names the same thing.
+    mutating func applyRecognition(_ recognition: TextRecognition,
+                                   imageSize: CGSize,
+                                   hiddenBy mask: RedactionMask,
+                                   isSuperseded: (String, CGPoint) -> Bool = { _, _ in false }) {
+        for index in indices {
+            let position = self[index].position
+            var current = recognition.text(near: position, imageSize: imageSize, hiddenBy: mask)
+            if let read = current, isSuperseded(read.text, position) { current = nil }
+
+            let previous = self[index].recognized
+            guard previous != current else { continue }
+
+            let note = self[index].note.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let previous, note == previous.text {
+                self[index].note = current?.text ?? ""
+            } else if previous == nil, note.isEmpty, let current {
+                self[index].note = current.text
+            }
+            self[index].recognized = current
+        }
+    }
+}
+
+// MARK: - Settings
+
+/// Whether Pinpoint reads the text in a capture at all.
+enum TextRecognitionSettings {
+    static let enabledKey = "textRecognitionEnabled"
+
+    /// On by default. The recognizer runs on this Mac with no network call, and
+    /// everything it can read is already leaving in the picture next to it —
+    /// what changes is that the string becomes greppable instead of only
+    /// visible, which is the entire point of handing a capture to an agent.
+    ///
+    /// It is still a switch, because "greppable" is not nothing: a reader who
+    /// would never have squinted at the corner of a screenshot will read a
+    /// quoted line in a text file. Off, the pixels are unchanged and no
+    /// `Text:` line is written.
+    static var isEnabled: Bool {
+        UserDefaults.standard.object(forKey: enabledKey) as? Bool ?? true
+    }
+}

--- a/docs/capture-schema.json
+++ b/docs/capture-schema.json
@@ -131,7 +131,7 @@
     },
     "shapes": {
       "type": "array",
-      "description": "The unnumbered outlines — arrows and rectangles — in the order they were drawn.",
+      "description": "The unnumbered outlines — arrows, rectangles and redactions — in the order they were drawn.",
       "items": { "$ref": "#/$defs/shape" }
     }
   },
@@ -192,6 +192,11 @@
         "accessibility": {
           "$ref": "#/$defs/element",
           "description": "The interface element under position, resolved against the snapshot taken at capture time. Absent when there is none — the normal case for a capture of something that isn't an app window, or with the feature switched off."
+        },
+        "recognizedText": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The line of text Pinpoint read in the pixels under this marker, recognized on the user's Mac with no network call. A separate field from note on purpose: note is what a person wrote, this is what a machine read, and note is often — but not always — pre-filled from this. Absent when nothing legible sat within reach of the marker, when the accessibility element above already names the same string (it is not repeated), when the feature is switched off, and always for a marker on a redacted region or a read a redaction touches."
         }
       }
     },
@@ -202,9 +207,9 @@
       "properties": {
         "id": { "type": "string" },
         "label": { "type": "string", "description": "\"S1\", \"S2\"… matching capture.md." },
-        "kind": { "type": "string", "enum": ["arrow", "rectangle"] },
-        "from": { "$ref": "#/$defs/point", "description": "Arrow: the tail. Rectangle: its top-left corner." },
-        "to": { "$ref": "#/$defs/point", "description": "Arrow: the tip, where the head is drawn. Rectangle: its bottom-right corner." },
+        "kind": { "type": "string", "enum": ["arrow", "rectangle", "redaction"], "description": "A redaction is a region the user painted over before sharing: its pixels are gone from the PNG, and nothing under it — no accessibility element, no recognized text — is described anywhere in this file. Its box is still given: where something was hidden is not itself a secret, and a consumer that knows a region is unreadable asks rather than guessing." },
+        "from": { "$ref": "#/$defs/point", "description": "Arrow: the tail. Rectangle/redaction: its top-left corner." },
+        "to": { "$ref": "#/$defs/point", "description": "Arrow: the tip, where the head is drawn. Rectangle/redaction: its bottom-right corner." },
         "boundingBox": { "$ref": "#/$defs/box" }
       }
     },

--- a/scripts/verify-ocr-redaction.sh
+++ b/scripts/verify-ocr-redaction.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Builds and runs the redaction check of #49 against the app's own sources.
+#
+# Not part of the CI build: it exercises Vision's text recognizer, whose exact
+# output is a model's and not a contract's, and a check that can go amber on an
+# OS update has no business gating a merge. Run it when the recognizer, the
+# mask, or either exporter is touched.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+out="$(mktemp -d)/verify-ocr-redaction"
+
+xcrun swiftc -O -target "$(uname -m)-apple-macos15.0" -o "$out" \
+    Pinpoint/AgentTextFormat.swift \
+    Pinpoint/AXSnapshot.swift \
+    Pinpoint/Exporter.swift \
+    Pinpoint/FileHandoff.swift \
+    Pinpoint/HandoffDocument.swift \
+    Pinpoint/Markup.swift \
+    Pinpoint/MarkupMetrics.swift \
+    Pinpoint/Pin.swift \
+    Pinpoint/PinStyle.swift \
+    Pinpoint/Redaction.swift \
+    Pinpoint/TaskPreset.swift \
+    Pinpoint/TextRecognizer.swift \
+    Pinpoint/Theme.swift \
+    scripts/verify-ocr-redaction.swift
+
+exec "$out"

--- a/scripts/verify-ocr-redaction.swift
+++ b/scripts/verify-ocr-redaction.swift
@@ -1,0 +1,317 @@
+import AppKit
+import CoreText
+import Foundation
+
+// Proves, against the real code, that the text recognizer of #49 cannot put
+// something the user painted over (#50) into the files a capture is handed
+// over in.
+//
+// The app itself is a menu-bar SwiftUI app with no test target, so this is a
+// small executable compiled from the very same sources — `TextRecognizer`,
+// `RedactionMask`, `Exporter`, `FileHandoff.Document` — rather than a
+// reimplementation of them. What it asserts is what actually ships.
+//
+//   scripts/verify-ocr-redaction.sh
+//
+// The first case is the one that gives the others their teeth: it puts a fake
+// API key on a synthetic screen with no redaction at all and *requires* the
+// recognizer to read it. A harness that can't find the secret when it is in
+// plain sight would pass every redaction check below while proving nothing.
+
+@main
+struct VerifyOCRRedaction {
+
+    /// The string that must never leave. Shaped like the thing this is actually
+    /// about — an API key sitting in a terminal someone is about to screenshot.
+    static let secret = "sk-live-9F3KQ2ZP7X"
+    /// A line with nothing sensitive in it, on the same synthetic screen. Every
+    /// redaction case checks this one *survives*: a recognizer that returned
+    /// nothing at all would otherwise look like a recognizer that was careful.
+    static let ordinary = "Cannot find module 'react'"
+
+    /// Where the two lines sit, normalized (0…1), top-left origin. Baselines;
+    /// the boxes are measured from the rendered glyphs.
+    static let ordinaryBaseline = CGPoint(x: 0.08, y: 0.32)
+    static let secretBaseline = CGPoint(x: 0.08, y: 0.62)
+
+    static var failures = 0
+
+    static func main() async {
+        // 1× and 2× renderings of the same screen. A Retina capture is stored
+        // at its native pixel count, so the 2× image is twice the pixels of the
+        // 1× one for the same content — every box, every reach and every
+        // redaction rect below is normalized, and both have to come out the
+        // same. That equality *is* the Retina check.
+        for scale in [1, 2] {
+            let capture = render(scale: scale)
+            let size = CGSize(width: capture.image.width, height: capture.image.height)
+            print("\n── \(scale)× — \(capture.image.width)×\(capture.image.height) px ──")
+
+            // The reference read: no redaction anywhere.
+            let clock = ContinuousClock()
+            var elapsed = Duration.zero
+            var open = TextRecognition.empty
+            elapsed = await clock.measure {
+                open = await TextRecognizer.recognize(in: capture.image, hiddenBy: RedactionMask([]))
+            }
+            print("   .accurate over the whole image: \(elapsed)")
+
+            check("the recognizer reads the secret when nothing hides it",
+                  contains(open, secret))
+            check("the recognizer reads the ordinary line",
+                  contains(open, ordinary))
+            check("a marker on the secret resolves to it",
+                  open.text(near: capture.secretAnchor, imageSize: size,
+                            hiddenBy: RedactionMask([]))?.text.contains(secret) == true)
+            check("a marker on the ordinary line resolves to it, not to the secret",
+                  open.text(near: capture.ordinaryAnchor, imageSize: size,
+                            hiddenBy: RedactionMask([]))?.text.contains("module") == true)
+            check("a marker in empty space resolves to nothing",
+                  open.text(near: CGPoint(x: 0.5, y: 0.93), imageSize: size,
+                            hiddenBy: RedactionMask([])) == nil)
+
+            // The redactions to try: the whole line, a bar over half of it, and
+            // a bar clipping only its last few characters. All three must end
+            // the same way — any overlap at all takes the whole read out.
+            let full = capture.secretBox.insetBy(dx: -0.005, dy: -0.005)
+            let half = CGRect(x: capture.secretBox.midX, y: capture.secretBox.minY,
+                              width: capture.secretBox.width / 2, height: capture.secretBox.height)
+            let tail = CGRect(x: capture.secretBox.maxX - capture.secretBox.width * 0.12,
+                              y: capture.secretBox.minY,
+                              width: capture.secretBox.width * 0.12, height: capture.secretBox.height)
+
+            for (label, rect) in [("the whole line", full), ("half of it", half), ("its last characters", tail)] {
+                await verify(covering: label, rect: rect, capture: capture, size: size)
+            }
+        }
+
+        await verifyAccessibilityArbitration()
+        await showExport()
+
+        print(failures == 0
+              ? "\n\u{2713} every check passed"
+              : "\n\u{2717} \(failures) check(s) failed")
+        exit(failures == 0 ? 0 : 1)
+    }
+
+    /// The other half of "don't say it twice": a read is dropped when the
+    /// accessibility tree already names the same thing (a native app), and kept
+    /// when it doesn't (an Electron window, where the tree is anonymous groups
+    /// and the pixels are the only place the string exists).
+    static func verifyAccessibilityArbitration() async {
+        print("\n── accessibility arbitration (#55) ──")
+        let capture = render(scale: 2)
+        let size = CGSize(width: capture.image.width, height: capture.image.height)
+        let open = RedactionMask([])
+        let read = await TextRecognizer.recognize(in: capture.image, hiddenBy: open)
+
+        // A tree that already spells out the ordinary line, the way a native
+        // app's `AXStaticText` would. The snapshot covers the whole capture, so
+        // one screen point maps to one normalized point.
+        let screen = CGRect(x: 0, y: 0, width: size.width, height: size.height)
+        func snapshot(named name: String?) -> AXSnapshot {
+            AXSnapshot(
+                captureRect: screen,
+                applications: [.init(name: "Example", bundleIdentifier: "com.example", processIdentifier: 1)],
+                elements: [AXSnapshot.Element(role: "AXStaticText", title: name, frame: screen,
+                                              application: 0, windowOrder: 0, depth: 0)],
+                truncated: false, capturedAt: Date(), includesFieldValues: false
+            )
+        }
+
+        var native = [Pin(number: 1, position: capture.ordinaryAnchor)]
+        let tree = snapshot(named: ordinary)
+        native.applyRecognition(read, imageSize: size, hiddenBy: open) { text, point in
+            tree.names(text, atNormalized: point, hiddenBy: open)
+        }
+        check("a read the tree already names is dropped", native[0].recognized == nil)
+        check("and no description is pre-filled from it", native[0].note.isEmpty)
+
+        var electron = [Pin(number: 1, position: capture.ordinaryAnchor)]
+        let anonymous = snapshot(named: nil)
+        electron.applyRecognition(read, imageSize: size, hiddenBy: open) { text, point in
+            anonymous.names(text, atNormalized: point, hiddenBy: open)
+        }
+        check("a read the tree has no name for is kept",
+              electron[0].recognized?.text.contains("module") == true)
+        check("and pre-fills the description", electron[0].note.contains("module"))
+    }
+
+    /// Prints one real `capture.md`, so the shape of what an agent receives can
+    /// be read rather than inferred — and asserts the one thing that shape must
+    /// never do, which is print the same string twice under one marker.
+    static func showExport() async {
+        print("\n── capture.md as an agent receives it ──")
+        let capture = render(scale: 2)
+        let size = CGSize(width: capture.image.width, height: capture.image.height)
+        let open = RedactionMask([])
+        let read = await TextRecognizer.recognize(in: capture.image, hiddenBy: open)
+
+        // Two markers on the same line: one left as Pinpoint pre-filled it, one
+        // the user has since described in their own words.
+        var pins = [Pin(number: 1, position: capture.ordinaryAnchor),
+                    Pin(number: 2, position: capture.ordinaryAnchor)]
+        pins.applyRecognition(read, imageSize: size, hiddenBy: open)
+        pins[1].note = "this is the error I keep hitting"
+
+        let markdown = Exporter.buildText(pins: pins, shapes: [], context: "why does this happen?",
+                                          imageSize: size, preset: .bug)
+        print(markdown.split(separator: "\n").map { "   " + $0 }.joined(separator: "\n"))
+
+        let rows = markdown.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        func lineAfter(_ marker: String) -> String {
+            guard let index = rows.firstIndex(where: { $0.hasPrefix("- \(marker) [") }),
+                  index + 1 < rows.count else { return "" }
+            return rows[index + 1]
+        }
+        check("the pre-filled marker prints its text once, as its description",
+              rows.contains { $0.hasPrefix("- M1 [") && $0.contains(ordinary) }
+              && !lineAfter("M1").hasPrefix("  - Text:"))
+        check("the marker described by the user carries both its words and the read",
+              rows.contains { $0.hasPrefix("- M2 [") && $0.contains("this is the error") }
+              && lineAfter("M2").hasPrefix("  - Text: “"))
+        check("the read is never printed twice under one marker",
+              rows.filter { $0.hasPrefix("  - Text:") }.count == 1)
+    }
+
+    /// One redaction, taken all the way through to the two files a capture is
+    /// handed over in.
+    static func verify(covering label: String, rect: CGRect,
+                       capture: Capture, size: CGSize) async {
+        print("   redaction over \(label):")
+        let shapes = [Markup(kind: .redaction,
+                             start: CGPoint(x: rect.minX, y: rect.minY),
+                             end: CGPoint(x: rect.maxX, y: rect.maxY))]
+        let mask = RedactionMask(shapes)
+
+        let read = await TextRecognizer.recognize(in: capture.image, hiddenBy: mask)
+        check("      no recognized line contains the secret", !contains(read, secret))
+        check("      the ordinary line is still read", contains(read, ordinary))
+
+        // Two markers: one on the covered secret, one on the untouched line.
+        // Both start with an empty description, the way a marker dropped in the
+        // editor does, so `applyRecognition` runs its pre-fill.
+        var pins = [Pin(number: 1, position: capture.ordinaryAnchor),
+                    Pin(number: 2, position: capture.secretAnchor)]
+        pins.applyRecognition(read, imageSize: size, hiddenBy: mask)
+
+        check("      the marker on the redaction gets no text", pins[1].recognized == nil)
+        check("      its description is left empty", pins[1].note.isEmpty)
+        check("      the other marker is still pre-filled",
+              pins[0].note.contains("module"))
+
+        // The case a naive implementation gets wrong: the marker was dropped
+        // *before* the bar was drawn, so its description was pre-filled with
+        // the secret and is still carrying it when the redaction arrives.
+        var late = [Pin(number: 1, position: capture.secretAnchor)]
+        let openMask = RedactionMask([])
+        let open = await TextRecognizer.recognize(in: capture.image, hiddenBy: openMask)
+        late.applyRecognition(open, imageSize: size, hiddenBy: openMask)
+        check("      (before the bar) the description holds the secret",
+              late[0].note.contains(secret))
+        late.applyRecognition(open, imageSize: size, hiddenBy: mask)
+        check("      drawing the bar takes the secret back out of the description",
+              !late[0].note.contains(secret) && late[0].recognized == nil)
+
+        // A description the user typed themselves is theirs, and stays.
+        var typed = [Pin(number: 1, position: capture.secretAnchor, note: "look at this line")]
+        typed.applyRecognition(open, imageSize: size, hiddenBy: mask)
+        check("      a description the user typed is not touched",
+              typed[0].note == "look at this line")
+
+        // And finally the files. Both markers keep whatever they hold — this is
+        // the exporters' own redaction check being tested, not the editor's.
+        let all = pins + late + typed
+        let markdown = Exporter.buildText(pins: all.enumerated().map { renumber($1, $0 + 1) },
+                                          shapes: shapes, context: "check this out",
+                                          imageSize: size)
+        check("      capture.md does not contain the secret", !markdown.contains(secret))
+        check("      capture.md still carries the ordinary line", markdown.contains("module"))
+
+        let json = Exporter.buildJSON(pins: all.enumerated().map { renumber($1, $0 + 1) },
+                                      shapes: shapes, context: "check this out",
+                                      imageSize: size, style: .disc) ?? ""
+        check("      capture.json does not contain the secret", !json.contains(secret))
+        check("      capture.json carries the recognized text as its own key",
+              json.contains("\"recognizedText\""))
+    }
+
+    // MARK: - The synthetic screen
+
+    struct Capture {
+        let image: CGImage
+        /// Where a marker dropped on each line would sit, normalized.
+        let ordinaryAnchor: CGPoint
+        let secretAnchor: CGPoint
+        /// The rendered extent of the secret, normalized — what a user painting
+        /// over it would cover.
+        let secretBox: CGRect
+    }
+
+    /// A plain white screen with two lines of dark text on it, at `scale` times
+    /// a 1280×800 point grid.
+    static func render(scale: Int) -> Capture {
+        let width = 1280 * scale
+        let height = 800 * scale
+        let fontSize = CGFloat(22 * scale)
+        let space = CGColorSpace(name: CGColorSpace.sRGB)!
+        let context = CGContext(data: nil, width: width, height: height,
+                                bitsPerComponent: 8, bytesPerRow: 0, space: space,
+                                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)!
+        context.setFillColor(gray: 1, alpha: 1)
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+
+        let size = CGSize(width: width, height: height)
+        let ordinaryBox = draw(ordinary, baseline: ordinaryBaseline, fontSize: fontSize,
+                               in: context, size: size)
+        let secretBox = draw("API key: " + secret, baseline: secretBaseline, fontSize: fontSize,
+                             in: context, size: size)
+
+        return Capture(image: context.makeImage()!,
+                       ordinaryAnchor: CGPoint(x: ordinaryBox.midX, y: ordinaryBox.midY),
+                       secretAnchor: CGPoint(x: secretBox.maxX - secretBox.width * 0.15,
+                                             y: secretBox.midY),
+                       secretBox: secretBox)
+    }
+
+    /// Draws one line and hands back the box it covers, normalized, top-left.
+    static func draw(_ string: String, baseline: CGPoint, fontSize: CGFloat,
+                     in context: CGContext, size: CGSize) -> CGRect {
+        let font = CTFontCreateWithName("Menlo" as CFString, fontSize, nil)
+        let attributed = NSAttributedString(string: string, attributes: [
+            .font: font,
+            .foregroundColor: CGColor(gray: 0.08, alpha: 1)
+        ])
+        let line = CTLineCreateWithAttributedString(attributed)
+        let origin = CGPoint(x: baseline.x * size.width, y: (1 - baseline.y) * size.height)
+        context.textPosition = origin
+        CTLineDraw(line, context)
+
+        // CTLine bounds are relative to the baseline, y up; the capture's
+        // convention is 0…1 from the top.
+        let bounds = CTLineGetBoundsWithOptions(line, .useOpticalBounds)
+        let box = CGRect(x: origin.x + bounds.minX, y: origin.y + bounds.minY,
+                         width: bounds.width, height: bounds.height)
+        return CGRect(x: box.minX / size.width,
+                      y: (size.height - box.maxY) / size.height,
+                      width: box.width / size.width,
+                      height: box.height / size.height)
+    }
+
+    // MARK: - Assertions
+
+    static func contains(_ recognition: TextRecognition, _ needle: String) -> Bool {
+        recognition.lines.contains { $0.text.contains(needle) }
+    }
+
+    static func renumber(_ pin: Pin, _ number: Int) -> Pin {
+        var copy = pin
+        copy.number = number
+        return copy
+    }
+
+    static func check(_ what: String, _ passed: Bool) {
+        print("   \(passed ? "\u{2713}" : "\u{2717}") \(what)")
+        if !passed { failures += 1 }
+    }
+}


### PR DESCRIPTION
Un agent à qui on tend une capture doit deviner le petit texte qu'elle contient — un nom de module, une adresse hexadécimale, une classe — et il devine mal. macOS sait lire ces pixels sur la machine : la chaîne elle-même voyage désormais dans `capture.md` et `capture.json`, au lieu de n'exister que dans l'image. On-device, aucune dépendance, aucun appel réseau.

## Une passe sur l'image entière, la fenêtre appliquée aux résultats

L'issue proposait `VNRecognizeTextRequest` sur la région autour de chaque repère. J'ai fait l'inverse, et c'est le seul écart notable :

- Vision reconnaît des **lignes**, en s'appuyant sur la mise en page autour d'elles. Une fenêtre découpée autour d'un repère coupe les mots en deux et lui donne un fragment à deviner — précisément l'échec que la fonctionnalité corrige.
- Une passe coûte une passe, quel que soit le nombre de repères posés ensuite — et les repères se posent un par un, interactivement, là où une requête par repère se sentirait.

La fenêtre est donc appliquée aux *résultats* : `TextRecognition.text(near:)` retient la ligne la plus proche et refuse tout ce qui dépasse **une pastille et demie** (`MarkupMetrics.pinRadius * 1.5`, soit `max(24, largeur × 0,021)` px). Ce n'est pas une constante neuve : la pastille est ce avec quoi l'utilisateur a visé, et la métrique de #48 met déjà à l'échelle avec la capture — une capture Retina, stockée au double de pixels, obtient le double de portée et donc **la même fenêtre physique à l'écran**. C'est ce qui rend le 1× et le 2× corrects sans qu'aucun code ne parle de backing scale. Le contenu gagne (distance 0), la plus petite boîte départage.

## L'OCR ne lit jamais dans une zone masquée

L'OCR est le même canal d'exfiltration que le contexte d'accessibilité de #55, et il est traité pareil. **L'ordre compte plus qu'il n'y paraît** : reconnaître puis filtrer signifierait que le texte sous la barre a été lu en mémoire et n'est qu'à un contrôle manquant du `.md`. Donc on peint d'abord.

1. `TextRecognizer.redacted` construit l'image donnée à Vision : la capture avec chaque rect de `RedactionMask` rempli en noir opaque, élargi d'un pixel (pas de frange antialiasée qu'`.accurate` saurait terminer). Ce chemin **échoue fermé** : contexte impossible à créer, `makeImage()` qui rate — on rend zéro ligne, jamais l'image d'origine.
2. Les observations dont la boîte touche une barre sont écartées (second verrou, pour un glyphe à cheval dont la moitié reste lisible).
3. `text(near:)` redemande au masque *courant* : une passe en vol a tourné sous les rédactions d'il y a un instant, l'utilisateur peut peindre entre-temps.
4. `Pin.recognizedText(hiddenBy:)`, dans `Redaction.swift` à côté de `AXSnapshot.element(atNormalized:hiddenBy:)`, est le dernier verrou — les deux exporteurs le traversent. Aucun exporteur n'a à faire confiance à la prudence de l'autre.
5. Une description **pré-remplie et non modifiée** est reprise quand une barre recouvre sa source : c'est la sortie de Pinpoint, pas un mot de l'utilisateur. Ce qu'il a tapé lui-même n'est jamais touché.

### Vérifié, pas supposé

`scripts/verify-ocr-redaction.sh` compile les sources de l'app (`TextRecognizer`, `RedactionMask`, `Exporter`, `FileHandoff.Document`) et lance 101 contrôles — c'est ce qui est livré qui est testé, pas une réimplémentation. **Le premier cas donne du mordant aux autres** : il pose une fausse clé d'API sur un écran de synthèse *sans aucune rédaction* et exige que le recognizer la lise. Un harnais incapable de trouver le secret à découvert passerait tous les contrôles de rédaction sans rien prouver.

Trois rédactions sont essayées — la ligne entière, la moitié, les derniers caractères — en 1× et en 2×, et chacune vérifie que le secret est absent du `capture.md` **et** du `capture.json`, que la ligne anodine voisine est toujours lue (un recognizer qui ne renvoie rien aurait l'air prudent), que le repère posé sur la barre ne lit rien, et que le cas piégeux passe : repère posé **avant** la barre, description déjà pré-remplie avec le secret → dessiner la barre le retire.

```
✓ every check passed          (1× et 2×, 101 contrôles)
```

Volontairement **hors CI** : il exerce un modèle de reconnaissance, dont la sortie exacte n'est pas un contrat, et un test qui peut virer à l'orange sur une mise à jour d'OS n'a pas à bloquer une fusion.

## Arbitrage avec le contexte d'accessibilité (#55)

Ni l'un ni l'autre ne gagne dans l'absolu, parce que cela dépend entièrement de ce qui a été photographié. Sur une app native, l'arbre contient la chaîne exacte et la contient **mieux** : épelée depuis le source plutôt que devinée sur des glyphes, avec un rôle, une boîte et un chemin autour. Sur Electron ou Chrome, l'arbre est une pile de groupes anonymes et les pixels sont le seul endroit où le texte existe.

La règle n'est donc pas « préférer l'un » mais **ne jamais le dire deux fois** : `AXSnapshot.names(_:atNormalized:hiddenBy:)` abandonne la lecture exactement quand l'arbre la porte déjà, et la garde sinon. Décidé une fois, dans l'éditeur, avant que `pin.recognized` ne soit posé — pas dans les exporteurs : la description pré-remplie doit faire le même choix, et une seule décision en un seul endroit est la seule façon que la note et l'export ne se contredisent pas.

Même règle pour la note elle-même : quand la description **est** la lecture (cas courant, puisqu'une description vide est pré-remplie), la ligne `Text:` est omise. La même chaîne deux fois sous un repère n'est pas une corroboration — c'est une source comptée deux fois, et un agent pesant « le libellé dit X et les pixels disent X » pèserait une copie de lui-même.

```
- M1 [065a44] · Cannot find module 'react' — (549, 497) px · (21 %, 31 %)
- M2 [0ab9a0] · this is the error I keep hitting — (549, 497) px · (21 %, 31 %)
  - Text: “Cannot find module 'react'”
```

## Undo (#44)

`pin.note` pré-remplie est une mutation du document, donc annulable. `syncRecognizedText()` est appelé **depuis `withUndo` lui-même**, après le corps : aucun futur site d'appel ne peut l'oublier, et le rafraîchissement atterrit *dans* l'entrée de l'action qui l'a causé. Poser un repère arrive avec sa description déjà remplie, en **une** entrée ; dessiner une rédaction sur une erreur citée en fait **une**, pas deux.

Si l'utilisateur a déjà saisi une note, elle n'est jamais écrasée : le pré-remplissage ne touche qu'une description vide, et la reprise ne concerne qu'une description encore *exactement* égale à ce que Pinpoint y avait mis. Une description délibérément vidée n'est pas re-remplie.

Les règles vivent dans `Array<Pin>.applyRecognition`, hors de la vue : ce sont elles qui décident si une clé d'API reste dans une description après qu'on a peint dessus, et des règles pareilles doivent être vérifiables sans fenêtre à l'écran.

## Le reste des intégrations

- **JSON (#52/#54)** — `markers[].recognizedText`, clé distincte de `note` : les deux ont des provenances différentes (ce qu'une personne a écrit, ce qu'une machine a lu) et un consommateur doit pouvoir les distinguer. Le `.md` déduplique parce que c'est de la prose ; le JSON garde les deux, une clé absente y serait ambiguë entre « rien lu » et « identique à la note ». `schemaVersion` ne bouge pas. `docs/capture-schema.json` suit — et au passage son enum `shape.kind` accepte enfin `"redaction"`, oublié par #50, qui faisait échouer toute capture rédigée contre son propre schéma publié.
- **Presets (#53)** — la ligne `Text:` s'insère sous son repère, avec `UI:`/`Value:`/`Path:` ; l'en-tête de tâche est intouché.
- **Rendu (#76)** — tout est normalisé (0…1, origine haut-gauche), la convention que `Pin`, `Markup` et `RedactionMask` parlent déjà. Le référentiel de pixels est le même que celui des coordonnées exportées, et un crop remappe la boîte de lecture exactement comme la position d'un repère.

## Performance — mesurée

`.accurate` et pas `.fast`. Les chaînes visées sont petites, denses et sans pardon, et `.fast` massacre exactement celles-là. Sur cinq lignes de Menlo 13 pt, mesuré :

| | exactes 1× | exactes 2× |
|---|---|---|
| `.accurate` | 3/5 | 4/5 |
| `.fast` | **0/5** | **0/5** |

`.fast` lit `react-dom/client` comme `react-doTh/client` et coupe les mots en deux. Une lecture *presque* juste est pire qu'aucune lecture, parce que rien en aval ne peut faire la différence.

Coût (Mac Apple Silicon, moyenne de 3) :

| capture | `.accurate` | `.fast` |
|---|---|---|
| plein écran 3024×1964 | 0,65 s | 0,04 s |
| plein écran 5120×2880 | 0,81 s | 0,06 s |
| fenêtre 2000×1400 | 0,43 s | 0,02 s |
| 1920×1080 non-Retina | 0,50 s | 0,03 s |

Abordable précisément parce que c'est **une passe par capture**, hors du main actor (`nonisolated async`, l'éditeur ne bloque pas), pendant que l'utilisateur décide encore où cliquer.

Un point qui n'était pas évident : une rédaction se **glisse** en place, donc `recognitionKey` change à chaque frame du geste et SwiftUI relance la tâche à chaque fois — et `perform(on:)` va au bout quel que soit l'état de la tâche, l'annulation ne récupère rien. D'où un `Task.sleep(250 ms)` en tête, qui est la partie *annulable* : soixante relances deviennent soixante attentes abandonnées et une passe.

## Vie privée — ce qui part réellement

Hors zone masquée, l'OCR lit ce qui est affiché, et cela part dans le `.md` et le `.json` sous forme de ligne `Text:` et de clé `recognizedText`. C'était déjà dans l'image ; ce qui change est que la chaîne devient **greppable** au lieu d'être seulement visible. Ce n'est pas rien : quelqu'un qui n'aurait jamais plissé les yeux sur le coin d'une capture lira une ligne citée dans un fichier texte.

D'où trois choses :

1. **Un réglage** — « Lire le texte sous chaque repère », dans un nouvel onglet Capture § *Texte de la capture*. **Activé par défaut** : c'est le pitch, il ne demande aucune permission et n'atteint aucun réseau. Désactivé, les pixels sont inchangés et aucune ligne `Text:` n'est écrite. Le basculer ne supprime pas les descriptions déjà affichées — l'utilisateur les a vues et a pu les accepter, ce n'est pas à Pinpoint de les effacer sur un changement de réglage.
2. **La lecture est visible dans l'éditeur** — sous le champ de description, dès qu'elle en diffère (`Lu dans l'image : « … »`). Une fonctionnalité qui met discrètement une ligne de l'écran dans un fichier qu'on s'apprête à donner à quelqu'un doit d'abord montrer cette ligne.
3. **Une légende dans l'export**, écrite une seule fois et seulement si un repère porte une lecture, pour qu'un lecteur sache qu'une chaîne citée sort des pixels et pas de l'utilisateur.

## « Rien de lisible »

Une description qui vaut `l` ou `—` n'est pas un repère avec du contexte, c'est un repère avec une mauvaise réponse, et un agent n'a aucun moyen de faire la différence. Sont donc écartés : confiance < 0,4, moins de 2 caractères, rien d'alphanumérique. Au-delà de 200 caractères la ligne est coupée plutôt que jetée — les 200 premiers caractères d'un message d'erreur restent le message d'erreur. Si rien ne passe : `recognized` reste nil, la note reste vide, aucune ligne n'est écrite.

Langues : `en-US` et `fr-FR`, celle de l'utilisateur en premier (Vision pondère l'ordre).

## Vérification

- `xcodegen generate` + `xcodebuild -scheme Pinpoint -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED**, sans avertissement.
- `scripts/verify-ocr-redaction.sh` → **101/101**, en 1× et en 2×.
- Binaire du worktree lancé et piloté : l'app démarre, la fenêtre Réglages s'ouvre et se peuple. L'application installée de l'utilisateur n'a pas été touchée ; le pilotage complet de l'éditeur n'a pas été poussé plus loin, la capture d'écran d'un binaire non signé déclenchant une demande de permission TCC.

Closes #49
