### PR TITLE
Serveur MCP stdio pour Pinpoint : capture_region, get_last_capture, list_recent

### DIFF
--- a/Pinpoint/FileHandoff.swift
+++ b/Pinpoint/FileHandoff.swift
@@ -27,13 +27,6 @@ import AppKit
 /// the writing half, and it stays in the app: nothing here works without
 /// AppKit, `Exporter` and the annotation model.
 extension FileHandoff {
-    /// How many timestamped folders `archive/` keeps; the oldest are deleted on
-    /// every write. Kept deliberately low because each folder carries a
-    /// full-resolution copy of the PNG (a Retina capture runs to several MB),
-    /// and this directory is never surfaced in the UI — nobody would notice it
-    /// growing.
-    static var maxArchiveEntries: Int { 10 }
-
     /// Where a handoff landed. Returned so the callers that come next (the CLI
     /// of #56, the MCP server of #57) can report the paths without rebuilding
     /// them.

--- a/Pinpoint/HandoffContract.swift
+++ b/Pinpoint/HandoffContract.swift
@@ -50,6 +50,18 @@ enum FileHandoff {
         rootDirectory.appendingPathComponent("archive", isDirectory: true)
     }
 
+    /// How many timestamped folders `archive/` keeps; the oldest are deleted on
+    /// every write. Kept deliberately low because each folder carries a
+    /// full-resolution copy of the PNG (a Retina capture runs to several MB),
+    /// and this directory is never surfaced in the UI — nobody would notice it
+    /// growing.
+    ///
+    /// Part of the contract rather than of the writing half: the MCP server's
+    /// `list_recent` (#57) states this cap in its own tool schema and in the
+    /// sentence it hands the agent, and a second copy of the number is a second
+    /// thing to keep in step.
+    static let maxArchiveEntries = 10
+
     static let pngFileName = "capture.png"
     static let markdownFileName = "capture.md"
     static let jsonFileName = "capture.json"

--- a/PinpointCLI/AppBridge.swift
+++ b/PinpointCLI/AppBridge.swift
@@ -30,6 +30,13 @@ enum AppBridge {
 /// A handoff as this tool sees it: the raw JSON exactly as the app wrote it,
 /// plus the decoded document to reason about.
 struct Handoff {
+    /// The folder the three files live in: `last/` for the current handoff, a
+    /// timestamped folder under `archive/` for an older one. Carried on the
+    /// value rather than looked up from `FileHandoff` at each use, because the
+    /// MCP server's `list_recent` (#57) reports handoffs that are *not* the
+    /// current one, and a path helper that always answered `last/` would point
+    /// every one of them at the same file.
+    let directory: URL
     /// The parsed contract — what the summary is built from.
     let document: FileHandoff.Document
     /// The same file as a plain JSON object, untouched.
@@ -44,9 +51,27 @@ struct Handoff {
     /// next.
     let modified: Date?
 
+    /// The annotated PNG of *this* handoff.
+    var png: URL { directory.appendingPathComponent(FileHandoff.pngFileName) }
+    /// Its agent-ready Markdown.
+    var markdown: URL { directory.appendingPathComponent(FileHandoff.markdownFileName) }
+    /// The machine-readable twin this value was decoded from.
+    var json: URL { directory.appendingPathComponent(FileHandoff.jsonFileName) }
+
     /// Reads the current handoff, or nil when none has been written.
     static func latest() throws -> Handoff? {
-        let url = FileHandoff.latestJSON
+        try read(in: FileHandoff.latestDirectory)
+    }
+
+    /// Reads the handoff in `directory`, or nil when there is no `capture.json`
+    /// there.
+    ///
+    /// Split out from `latest()` for the archive: `list_recent` (#57) reads the
+    /// timestamped folders, and they hold exactly the same triplet under
+    /// exactly the same names — that is the contract, not a coincidence, so
+    /// they are read by the same code.
+    static func read(in directory: URL) throws -> Handoff? {
+        let url = directory.appendingPathComponent(FileHandoff.jsonFileName)
         guard FileManager.default.fileExists(atPath: url.path) else { return nil }
 
         let data: Data
@@ -64,7 +89,40 @@ struct Handoff {
 
         let modified = try? url.resourceValues(forKeys: [.contentModificationDateKey])
             .contentModificationDate
-        return Handoff(document: document, raw: raw, modified: modified)
+        return Handoff(directory: directory, document: document, raw: raw, modified: modified)
+    }
+
+    /// The most recent archived handoffs, newest first, at most `limit` of them.
+    ///
+    /// Best effort by design: a folder that won't read is skipped rather than
+    /// failing the list. The archive is a convenience the app itself writes
+    /// with `try?` (see `FileHandoff.archive`), and an agent asking "what have I
+    /// captured lately" is better served by four answers than by an error about
+    /// the fifth.
+    ///
+    /// The newest entry here is the same handoff `latest()` returns — `last/`
+    /// and `archive/<newest>/` are written from the same bytes in the same
+    /// copy. Not deduplicated: they are two paths to one capture, and hiding
+    /// one of them would only make an agent wonder which it is holding.
+    static func recent(limit: Int) -> [Handoff] {
+        let fileManager = FileManager.default
+        guard let folders = try? fileManager.contentsOfDirectory(
+            at: FileHandoff.archiveDirectory,
+            includingPropertiesForKeys: [.creationDateKey, .isDirectoryKey],
+            options: [.skipsHiddenFiles]) else { return [] }
+
+        // By creation date rather than by folder name, for the same reason
+        // `FileHandoff.prune` sorts that way: the names carry local time, so a
+        // DST rollback would order an hour's worth of them backwards.
+        let newestFirst = folders
+            .filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true }
+            .sorted { left, right in
+                let leftDate = (try? left.resourceValues(forKeys: [.creationDateKey]).creationDate) ?? .distantPast
+                let rightDate = (try? right.resourceValues(forKeys: [.creationDateKey]).creationDate) ?? .distantPast
+                return leftDate > rightDate
+            }
+
+        return newestFirst.prefix(limit).compactMap { (try? read(in: $0)) ?? nil }
     }
 
     /// What tells two handoffs apart.

--- a/PinpointCLI/Arguments.swift
+++ b/PinpointCLI/Arguments.swift
@@ -11,6 +11,7 @@ struct Arguments {
     enum Command {
         case capture
         case last
+        case mcp
         case help
         case version
     }
@@ -107,6 +108,7 @@ struct Arguments {
         switch positional {
         case "capture": result.command = .capture
         case "last": result.command = .last
+        case "mcp": result.command = .mcp
         case nil: result.command = .help
         case let other?: throw CLIError.usage("Unknown command “\(other)”.")
         }

--- a/PinpointCLI/Commands.swift
+++ b/PinpointCLI/Commands.swift
@@ -58,31 +58,15 @@ enum Commands {
         // caller asked for.
         Out.stderr("Waiting for the capture to be copied (\(Int(arguments.timeout))s)…")
 
-        guard let handoff = try waitForHandoff(after: before, timeout: arguments.timeout) else {
+        switch HandoffWatcher.wait(after: before, timeout: arguments.timeout) {
+        case .handoff(let handoff):
+            let saved = try copyPNG(to: arguments.out)
+            try Report.emit(handoff, savedTo: saved, format: arguments.format)
+        case .timedOut, .cancelled:
+            // Nothing cancels this one — the CLI passes no `isCancelled` — so
+            // the two collapse into the same answer for the caller.
             throw CLIError.timedOut(arguments.timeout)
         }
-        let saved = try copyPNG(to: arguments.out)
-        try Report.emit(handoff, savedTo: saved, format: arguments.format)
-    }
-
-    /// Polls `last/capture.json` until it is a different document from `before`.
-    ///
-    /// Polling rather than a filesystem watcher: this process exists for a few
-    /// seconds, the directory is swapped in one move (so there is no
-    /// half-written state to catch), and a quarter-second granularity is well
-    /// under the time it takes a person to drag a rectangle. A watcher would be
-    /// more machinery for a race that cannot happen.
-    private static func waitForHandoff(after before: Handoff.Fingerprint,
-                                       timeout: TimeInterval) throws -> Handoff? {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            Thread.sleep(forTimeInterval: 0.25)
-            // A read that fails here is transient by nature — the directory is
-            // being replaced under us — so it doesn't end the wait.
-            guard let handoff = try? Handoff.latest() else { continue }
-            if handoff.fingerprint != before { return handoff }
-        }
-        return nil
     }
 
     // MARK: - Shared

--- a/PinpointCLI/HandoffWatcher.swift
+++ b/PinpointCLI/HandoffWatcher.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Waits for the app to write the next handoff.
+///
+/// Both halves of this tool need it: `pinpoint capture` (#56) fires the deep
+/// link and blocks until the user presses Copy, and the MCP server's
+/// `capture_region` (#57) does the same thing on behalf of an agent. Written
+/// once, here, rather than twice — the tricky part isn't the loop, it's what
+/// counts as "the next handoff" (see `Handoff.Fingerprint`) and getting that
+/// answer to differ between the two would mean one of them returns the
+/// *previous* capture.
+///
+/// Polling rather than a filesystem watcher: this process exists for a few
+/// seconds to a couple of minutes, `last/` is swapped in one move so there is
+/// no half-written state to catch, and a quarter-second granularity is well
+/// under the time it takes a person to drag a rectangle. A watcher would be
+/// more machinery for a race that cannot happen.
+enum HandoffWatcher {
+    /// The interval between two reads of `last/capture.json`.
+    ///
+    /// Also the granularity at which `isCancelled` is consulted, which is why
+    /// it stays short: an agent that gave up shouldn't wait a second to be told
+    /// we noticed.
+    static let pollInterval: TimeInterval = 0.25
+
+    enum Result {
+        /// A handoff different from the one that was there when we started.
+        case handoff(Handoff)
+        /// The deadline passed: the region was never copied, or the user
+        /// cancelled with Esc, which looks the same from out here.
+        case timedOut
+        /// `isCancelled` came back true. Only the MCP server passes one — a
+        /// client can cancel a request mid-flight.
+        case cancelled
+    }
+
+    /// Blocks until a new handoff lands, the deadline passes, or `isCancelled`
+    /// returns true.
+    ///
+    /// - Parameters:
+    ///   - before: what `last/` looked like *before* the capture was asked for.
+    ///     Read by the caller ahead of firing the deep link — comparing against
+    ///     a fingerprint taken afterwards would race with a fast user.
+    ///   - isCancelled: consulted once per poll. Defaults to "never", which is
+    ///     the CLI's case: there is nobody to cancel it but the terminal.
+    static func wait(after before: Handoff.Fingerprint,
+                     timeout: TimeInterval,
+                     isCancelled: () -> Bool = { false }) -> Result {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if isCancelled() { return .cancelled }
+            Thread.sleep(forTimeInterval: pollInterval)
+            // A read that fails here is transient by nature — the directory is
+            // being replaced under us — so it doesn't end the wait.
+            guard let handoff = try? Handoff.latest() else { continue }
+            if handoff.fingerprint != before { return .handoff(handoff) }
+        }
+        return .timedOut
+    }
+}

--- a/PinpointCLI/MCP/JSONRPC.swift
+++ b/PinpointCLI/MCP/JSONRPC.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// The wire format under MCP: JSON-RPC 2.0, one message per line (#57).
+///
+/// Hand-rolled on `JSONSerialization` rather than `Codable`, for the same
+/// reason `Arguments` is hand-rolled rather than pulled from
+/// swift-argument-parser: this code is compiled into the `pinpoint` tool, which
+/// ships inside the app bundle and is signed and notarized with it. Every
+/// dependency added here is one more thing to sign and one more reason the app
+/// itself fails to build — and the protocol surface we answer is eight methods
+/// wide.
+///
+/// `Codable` would also fight the shape of the data. A JSON-RPC `id` is "string
+/// or number", a tool's arguments are an arbitrary object, and `capture.json`
+/// travels through here verbatim as the untyped dictionary `Handoff.raw`
+/// already holds. Dictionaries all the way down is what those three want.
+enum JSONRPC {
+    static let version = "2.0"
+
+    // MARK: - Errors
+
+    /// The subset of JSON-RPC error codes this server can produce.
+    ///
+    /// Deliberately small, and deliberately *not* where tool failures go: a
+    /// capture that timed out is a result the model has to see and can act on,
+    /// so it comes back as a normal tool result carrying `isError`. These codes
+    /// are for the protocol itself — a message that didn't parse, a method that
+    /// doesn't exist. See `MCPTools.result(for:)`.
+    enum ErrorCode: Int {
+        case parseError = -32700
+        case invalidRequest = -32600
+        case methodNotFound = -32601
+        case invalidParams = -32602
+        case internalError = -32603
+    }
+
+    // MARK: - Identity
+
+    /// A request id, carried back out exactly as it came in.
+    ///
+    /// JSON-RPC lets a client number its requests or name them, and a response
+    /// has to echo the id it answers *in the same type* — a client that sent
+    /// `"id": 7` and reads back `"id": "7"` has an unanswered request and a
+    /// reply it can't place. So the original value is kept as-is rather than
+    /// parsed into a Swift type and re-encoded from it.
+    struct RequestID: Hashable {
+        /// The value to write back into the response, untouched.
+        let json: Any
+        /// A typed spelling of that value, so two ids compare (and hash) the way
+        /// JSON-RPC says they do: `1` and `"1"` are different requests.
+        private let key: String
+
+        init?(_ value: Any?) {
+            switch value {
+            case let string as String:
+                json = string
+                key = "s:\(string)"
+            case let number as NSNumber:
+                // `NSNumber` is what JSONSerialization hands back for every
+                // numeric id. Kept as the same object so an integer stays an
+                // integer and a float — legal, if odd — stays a float.
+                json = number
+                key = "n:\(number.stringValue)"
+            default:
+                // Includes `nil` and `NSNull`: a request without an id is a
+                // notification, which is answered with silence, not with an
+                // error addressed to nobody.
+                return nil
+            }
+        }
+
+        static func == (lhs: RequestID, rhs: RequestID) -> Bool { lhs.key == rhs.key }
+        func hash(into hasher: inout Hasher) { hasher.combine(key) }
+    }
+
+    // MARK: - Messages
+
+    /// One inbound message, already sorted into "expects an answer" or not.
+    struct Message {
+        let id: RequestID?
+        let method: String
+        let params: [String: Any]
+
+        /// A message with no id. Notifications are never answered — not even to
+        /// say the method is unknown.
+        var isNotification: Bool { id == nil }
+
+        /// Parses one line of stdin.
+        ///
+        /// Returns nil for anything that isn't a request or a notification we
+        /// could act on. The caller turns that into a parse error only when it
+        /// can address one, which is the honest reading of a line that may have
+        /// had no id to begin with.
+        static func parse(_ line: String) -> Message? {
+            guard let data = line.data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: data),
+                  let dictionary = object as? [String: Any],
+                  let method = dictionary["method"] as? String else { return nil }
+            return Message(
+                id: RequestID(dictionary["id"]),
+                method: method,
+                params: dictionary["params"] as? [String: Any] ?? [:]
+            )
+        }
+    }
+
+    // MARK: - Responses
+
+    static func response(id: RequestID, result: [String: Any]) -> [String: Any] {
+        ["jsonrpc": version, "id": id.json, "result": result]
+    }
+
+    static func response(id: RequestID, error code: ErrorCode, message: String) -> [String: Any] {
+        ["jsonrpc": version, "id": id.json,
+         "error": ["code": code.rawValue, "message": message]]
+    }
+}

--- a/PinpointCLI/MCP/MCPServer.swift
+++ b/PinpointCLI/MCP/MCPServer.swift
@@ -1,0 +1,213 @@
+import Foundation
+
+/// `pinpoint mcp` — the stdio server (#57).
+///
+/// A client launches this process, speaks JSON-RPC to it over stdin/stdout,
+/// and expects nothing else on stdout ever — see `MCPTransport`. The eight
+/// methods below are the whole surface: a client that sends anything else
+/// gets `methodNotFound`, which is the correct answer and not a gap to fill,
+/// since MCP defines a much larger protocol (resources, prompts, sampling…)
+/// this server has no use for. It offers tools. That's all.
+final class MCPServer {
+    /// Versions this server will negotiate. Newest first: `initialize` echoes
+    /// back the client's requested version when it's one of these, and offers
+    /// the newest otherwise — the client then disconnects if it can't follow,
+    /// which is the protocol's own rule, not a case this server has to guard.
+    private static let supportedProtocolVersions = [
+        "2026-07-28", "2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05"
+    ]
+
+    private let transport = MCPTransport()
+
+    /// One in-flight `tools/call`: how to cancel it, and how long it's still
+    /// entitled to run — the same clamp `capture_region` waits against, so
+    /// stdin closing doesn't cut a call off before its own stated deadline.
+    private struct PendingCall {
+        let cancel: () -> Void
+        let deadline: Date
+    }
+
+    /// Keyed by request id, so a `notifications/cancelled` can find the right
+    /// one. Locked because the read loop's thread and every call's own queue
+    /// touch it.
+    ///
+    /// Each call runs on its own queue rather than the read loop's thread:
+    /// `capture_region` blocks for up to an hour by request (`timeoutSeconds`
+    /// caps at 3600), and a client is free to send `tools/list` — or cancel
+    /// that very call — while it waits.
+    private let inFlightLock = NSLock()
+    private var inFlight: [JSONRPC.RequestID: PendingCall] = [:]
+
+    /// Counts calls that have started but not yet sent their response.
+    ///
+    /// stdin closing (the client is done, or the pipe just broke) makes
+    /// `readLoop` return — but a `tools/call` dispatched moments earlier is
+    /// still running on its own queue, and `main.swift` exits the process the
+    /// instant `run()` returns. Without this, a fast `get_last_capture` that
+    /// hadn't quite finished writing its reply when EOF landed would simply
+    /// never answer: the process would be gone before its `transport.send`
+    /// ran. `run()` waits on this after the read loop ends so every call that
+    /// was already running gets to finish — bounded by its own deadline, so a
+    /// `capture_region` nobody is listening to anymore can't hold the process
+    /// open for the full hour.
+    private let inFlightGroup = DispatchGroup()
+
+    func run() {
+        transport.readLoop { [weak self] line in
+            self?.handle(line)
+        }
+
+        let deadline: Date = {
+            inFlightLock.lock()
+            defer { inFlightLock.unlock() }
+            return inFlight.values.map(\.deadline).max() ?? Date()
+        }()
+        let remainingMilliseconds = Int(max(0, deadline.timeIntervalSinceNow) * 1000)
+        // Returns as soon as the count reaches zero, whichever comes first —
+        // this is an upper bound, not a fixed wait.
+        _ = inFlightGroup.wait(timeout: .now() + .milliseconds(remainingMilliseconds))
+    }
+
+    private func handle(_ line: String) {
+        guard let message = JSONRPC.Message.parse(line) else {
+            // Not a request we can address: either the JSON itself didn't
+            // parse, or it parsed but named no id and no method we recognize
+            // as a notification. Neither has an id to answer to, so — per
+            // JSON-RPC — this is logged and dropped rather than met with a
+            // response addressed to nobody.
+            MCPTransport.log("dropped an unparsable line")
+            return
+        }
+
+        switch message.method {
+        case "initialize":
+            respond(to: message, with: initializeResult(message.params))
+        case "notifications/initialized":
+            break // Acknowledges nothing; there is nothing to set up on our side.
+        case "ping":
+            respond(to: message, with: [:])
+        case "tools/list":
+            respond(to: message, with: ["tools": MCPTools.definitions])
+        case "tools/call":
+            handleToolCall(message)
+        case "notifications/cancelled":
+            cancel(requestID: message.params["requestId"])
+        default:
+            guard let id = message.id else { return } // Unknown notification: ignored, per spec.
+            transport.send(JSONRPC.response(id: id, error: .methodNotFound,
+                                            message: "Unknown method “\(message.method)”."))
+        }
+    }
+
+    // MARK: - initialize
+
+    private func initializeResult(_ params: [String: Any]) -> [String: Any] {
+        let requested = params["protocolVersion"] as? String
+        let version = requested.flatMap { Self.supportedProtocolVersions.contains($0) ? $0 : nil }
+            ?? Self.supportedProtocolVersions[0]
+
+        return [
+            "protocolVersion": version,
+            "capabilities": [
+                // No `listChanged`: this server's three tools are fixed for
+                // the life of the process, so there is never a list-changed
+                // notification to send.
+                "tools": [String: Any]()
+            ],
+            "serverInfo": [
+                "name": "pinpoint",
+                "title": "Pinpoint",
+                "version": Usage.version
+            ],
+            "instructions": """
+            Pinpoint annotates a region of this Mac's screen with numbered \
+            markers and hands you the result as a file, never as inline image \
+            bytes: every tool here returns an absolute PNG path plus structured \
+            Markdown, and expects you to open the PNG with your own \
+            file-reading tool. Call capture_region to ask for a new one (it \
+            blocks until the user finishes drawing and pressing Copy — a real \
+            person has to choose what's in frame), get_last_capture to reread \
+            the most recent one without prompting for a new screenshot, and \
+            list_recent to find an earlier one in the same session.
+            """
+        ]
+    }
+
+    // MARK: - tools/call
+
+    private func handleToolCall(_ message: JSONRPC.Message) {
+        guard let name = message.params["name"] as? String else {
+            guard let id = message.id else { return }
+            transport.send(JSONRPC.response(id: id, error: .invalidParams,
+                                            message: "\"tools/call\" needs a \"name\"."))
+            return
+        }
+        let arguments = message.params["arguments"] as? [String: Any] ?? [:]
+
+        // A notification calling a tool is a client bug — there is no id to
+        // answer on — but running the tool anyway would leave a capture
+        // half-started with nobody watching for it. Refused instead.
+        guard let id = message.id else {
+            MCPTransport.log("ignored a tools/call notification for “\(name)” (no request id)")
+            return
+        }
+
+        // The same clamp `capture_region` itself waits against — anything
+        // else gets a short, fixed grace, since a `get_last_capture` or
+        // `list_recent` that's still running has nothing left to wait on but
+        // a couple of file reads.
+        let deadline = Date().addingTimeInterval(
+            name == "capture_region" ? MCPTools.clampedTimeout(arguments["timeoutSeconds"]) : 5)
+
+        var cancelled = false
+        let cancelLock = NSLock()
+        inFlightLock.lock()
+        inFlight[id] = PendingCall(cancel: {
+            cancelLock.lock(); cancelled = true; cancelLock.unlock()
+        }, deadline: deadline)
+        inFlightLock.unlock()
+        inFlightGroup.enter()
+
+        // Off the read loop's thread: `capture_region` can run for up to an
+        // hour, and nothing else queued behind it should have to wait that
+        // long for a `tools/list` or a `ping`.
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let outcome = MCPTools.call(name, arguments: arguments, isCancelled: {
+                cancelLock.lock(); defer { cancelLock.unlock() }
+                return cancelled
+            })
+
+            defer { self?.inFlightGroup.leave() }
+            guard let self else { return }
+            self.inFlightLock.lock()
+            self.inFlight.removeValue(forKey: id)
+            self.inFlightLock.unlock()
+
+            self.transport.send(JSONRPC.response(id: id, result: [
+                "content": [["type": "text", "text": outcome.text]],
+                "isError": outcome.isError,
+                // Only when there's something to structure: an error result
+                // has nothing beyond the sentence a model already read in
+                // `content`, and a key holding `nil` is a key a strict decoder
+                // might choke rendering, not a fact worth stating twice.
+                "structuredContent": outcome.structured as Any
+            ].compactMapValues { value in
+                if case Optional<Any>.none = value { return nil }
+                return value
+            }))
+        }
+    }
+
+    private func cancel(requestID raw: Any?) {
+        guard let id = JSONRPC.RequestID(raw) else { return }
+        inFlightLock.lock()
+        let pending = inFlight[id]
+        inFlightLock.unlock()
+        pending?.cancel()
+    }
+
+    private func respond(to message: JSONRPC.Message, with result: [String: Any]) {
+        guard let id = message.id else { return } // A notification: no reply, ever.
+        transport.send(JSONRPC.response(id: id, result: result))
+    }
+}

--- a/PinpointCLI/MCP/MCPTools.swift
+++ b/PinpointCLI/MCP/MCPTools.swift
@@ -1,0 +1,293 @@
+import Foundation
+
+/// The three tools this server exposes (#57), and the one rule every one of
+/// them obeys: **never return image bytes**. Claude Code doesn't render an
+/// image an MCP tool returns inline — the base64 lands in the transcript as
+/// raw text (anthropics/claude-code#31208, closed "not planned") — so a tool
+/// that tried would burn the model's context on a wall of characters it can't
+/// even look at. What actually reaches the model is a file path it reads with
+/// its own `Read` tool, which is the one thing every one of these result
+/// bodies leads with and says outright.
+///
+/// Built on `Handoff` and `HandoffWatcher` rather than a second reading of
+/// `capture.json`: the CLI (#56) and this server answer the same two
+/// questions — "what's the latest handoff" and "wait for the next one" — and
+/// a second implementation of either is a second place for the two to drift.
+enum MCPTools {
+    // MARK: - Definitions
+
+    /// What `tools/list` answers. `inputSchema` is JSON Schema, by the
+    /// protocol's own rule — not `Codable`, because a schema is data a client
+    /// introspects, not a type this process needs to decode.
+    static let definitions: [[String: Any]] = [
+        [
+            "name": "capture_region",
+            "title": "Capture a region",
+            "description": """
+            Ask Pinpoint to start an interactive screen capture. The screen dims, \
+            the user drags a rectangle by hand, drops numbered markers on what \
+            matters, optionally types instructions, and presses Copy in the \
+            editor — this call blocks until that happens. Pinpoint cannot select \
+            a region or take the screenshot on its own; there is no parameter \
+            here that skips the human step, because a capture is only ever what \
+            somebody chose to point at.
+
+            Returns the absolute path of the annotated PNG plus the same \
+            structured Markdown Pinpoint would have put on the clipboard — never \
+            the image itself. Open the PNG with your own file-reading tool; the \
+            Markdown alone tells you where every marker sits (pixels and percent \
+            of the image), what accessibility element and on-screen text was \
+            found under it, and what the user asked for.
+            """,
+            "inputSchema": [
+                "type": "object",
+                "additionalProperties": false,
+                "properties": [
+                    "timeoutSeconds": [
+                        "type": "number",
+                        "minimum": 1,
+                        "maximum": 3600,
+                        "default": 120,
+                        "description": "How long to wait for the user to press Copy before giving up."
+                    ]
+                ]
+            ]
+        ],
+        [
+            "name": "get_last_capture",
+            "title": "Get the last capture",
+            "description": """
+            Read the most recent handoff Pinpoint wrote — files only, no app, no \
+            permission, no new screenshot. Use this when the user says "look at \
+            what I just captured" or "the screenshot I sent you" rather than \
+            calling capture_region again: the capture they mean already exists on \
+            disk.
+
+            Returns the same shape as capture_region: the PNG's absolute path \
+            plus structured Markdown, never inline image bytes. Fails with a \
+            distinct error when nothing has been handed off yet, so you can tell \
+            "no capture" from "something broke".
+            """,
+            "inputSchema": [
+                "type": "object",
+                "additionalProperties": false,
+                "properties": [:]
+            ]
+        ],
+        [
+            "name": "list_recent",
+            "title": "List recent captures",
+            "description": """
+            List the most recent captures Pinpoint has archived, newest first — \
+            up to the last \(FileHandoff.maxArchiveEntries), which is all this \
+            Mac keeps. Each entry names its PNG and Markdown paths plus a short \
+            summary (dimensions, marker count, when it was copied) but, like \
+            every tool here, never the image bytes themselves; open a PNG with \
+            your own file-reading tool once you know which capture you want.
+
+            Use this to find an earlier capture in the same session rather than \
+            the very latest one — for a "the screenshot from a minute ago, not \
+            this one" kind of request.
+            """,
+            "inputSchema": [
+                "type": "object",
+                "additionalProperties": false,
+                "properties": [
+                    "limit": [
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": FileHandoff.maxArchiveEntries,
+                        "default": 5,
+                        "description": "How many captures to list, newest first."
+                    ]
+                ]
+            ]
+        ]
+    ]
+
+    // MARK: - Dispatch
+
+    /// A tool's outcome, kept apart from the transport: `MCPServer` is the
+    /// only thing that knows how a `CallToolResult` is spelled on the wire.
+    struct Outcome {
+        /// One line for the model to read, Markdown-formatted like every other
+        /// text this app produces.
+        let text: String
+        /// Whether this is a tool-level failure (`isError: true` on the
+        /// result) rather than a success. Per the spec, a capture that timed
+        /// out or a missing handoff is *not* a protocol error — the model has
+        /// to see it in the result and can act on it, the same way a person
+        /// reading `pinpoint`'s exit code can.
+        let isError: Bool
+        /// The parsed handoff, verbatim, alongside the prose — for a client
+        /// that would rather index the facts than parse them back out of
+        /// Markdown. Absent on error, where there is nothing to structure.
+        let structured: [String: Any]?
+
+        static func success(text: String, structured: [String: Any]) -> Outcome {
+            Outcome(text: text, isError: false, structured: structured)
+        }
+        static func failure(_ text: String) -> Outcome {
+            Outcome(text: text, isError: true, structured: nil)
+        }
+    }
+
+    /// Runs `name` with `arguments`, blocking the calling thread — `MCPServer`
+    /// is what keeps a long-running `capture_region` from starving the rest of
+    /// the session, by giving each call its own queue.
+    static func call(_ name: String, arguments: [String: Any],
+                     isCancelled: @escaping () -> Bool) -> Outcome {
+        switch name {
+        case "capture_region":
+            return captureRegion(arguments: arguments, isCancelled: isCancelled)
+        case "get_last_capture":
+            return getLastCapture()
+        case "list_recent":
+            return listRecent(arguments: arguments)
+        default:
+            return .failure("Unknown tool “\(name)”. Known tools: capture_region, get_last_capture, list_recent.")
+        }
+    }
+
+    // MARK: - capture_region
+
+    private static func captureRegion(arguments: [String: Any],
+                                      isCancelled: @escaping () -> Bool) -> Outcome {
+        guard AppBridge.isAvailable else {
+            return .failure("""
+            Pinpoint isn’t installed, or macOS has no handler registered for \
+            pinpoint://. Install it from https://pinpoint-ashy.vercel.app and \
+            launch it once, then try again.
+            """)
+        }
+
+        let timeout = clampedTimeout(arguments["timeoutSeconds"])
+
+        // Read *before* firing, same as `Commands.capture`: the wait that
+        // follows is "is this a different handoff from the one that was there
+        // when I asked", and that comparison only means anything if the
+        // baseline was taken first.
+        let before = Handoff.currentFingerprint()
+
+        guard AppBridge.open(.capture) else {
+            return .failure("Couldn’t open \(URLCommand.capture.url.absoluteString).")
+        }
+
+        switch HandoffWatcher.wait(after: before, timeout: timeout, isCancelled: isCancelled) {
+        case .handoff(let handoff):
+            return .success(text: agentText(for: handoff), structured: structured(handoff))
+        case .timedOut:
+            return .failure("""
+            No capture was copied within \(Int(timeout))s. The user may still be \
+            drawing the region, may have pressed Esc to cancel, or the editor \
+            window may be waiting off-screen. Ask before retrying — a second \
+            capture_region call opens a second overlay on top of whatever is \
+            already there.
+            """)
+        case .cancelled:
+            return .failure("Cancelled before a capture was copied.")
+        }
+    }
+
+    /// Shared with `MCPServer`, which needs the same bound to decide how long
+    /// to keep the process alive for an in-flight `capture_region` after stdin
+    /// closes — a second clamp there, disagreeing with this one by even a
+    /// second, would let a still-running call get killed before it could
+    /// answer.
+    static func clampedTimeout(_ raw: Any?) -> TimeInterval {
+        let seconds: Double
+        switch raw {
+        case let number as NSNumber: seconds = number.doubleValue
+        default: seconds = 120
+        }
+        return min(max(seconds, 1), 3600)
+    }
+
+    // MARK: - get_last_capture
+
+    private static func getLastCapture() -> Outcome {
+        guard let handoff = (try? Handoff.latest()) ?? nil else {
+            return .failure("""
+            No capture has been handed off yet. Ask the user to take one — with \
+            ⌘⇧1, or by calling capture_region — then try again.
+            """)
+        }
+        return .success(text: agentText(for: handoff), structured: structured(handoff))
+    }
+
+    // MARK: - list_recent
+
+    private static func listRecent(arguments: [String: Any]) -> Outcome {
+        let limit = clampedLimit(arguments["limit"])
+        let handoffs = Handoff.recent(limit: limit)
+        guard !handoffs.isEmpty else {
+            return .failure("""
+            No captures have been archived yet. Ask the user to take one — with \
+            ⌘⇧1, or by calling capture_region — then try again.
+            """)
+        }
+
+        var lines = ["# \(handoffs.count) recent capture\(handoffs.count == 1 ? "" : "s")", ""]
+        for handoff in handoffs {
+            let document = handoff.document
+            lines.append("- `\(handoff.png.path)` — \(document.image.width)×\(document.image.height) px · "
+                         + "\(document.markers.count) marker\(document.markers.count == 1 ? "" : "s") · "
+                         + document.generatedAt)
+        }
+        lines.append("")
+        lines.append("Open the PNG at the path of whichever entry you mean with your own file-reading "
+                     + "tool. Call get_last_capture for the full Markdown of the newest one, or read its "
+                     + "sibling `.md` file directly for any of the others.")
+
+        let structured: [String: Any] = [
+            "captures": handoffs.map { handoff -> [String: Any] in
+                [
+                    "png": handoff.png.path,
+                    "markdown": handoff.markdown.path,
+                    "json": handoff.json.path,
+                    "capture": handoff.raw
+                ]
+            }
+        ]
+        return .success(text: lines.joined(separator: "\n"), structured: structured)
+    }
+
+    private static func clampedLimit(_ raw: Any?) -> Int {
+        let value: Int
+        switch raw {
+        case let number as NSNumber: value = number.intValue
+        default: value = 5
+        }
+        return min(max(value, 1), FileHandoff.maxArchiveEntries)
+    }
+
+    // MARK: - Shared
+
+    /// The Markdown handed back for a single handoff: `capture.md`, verbatim,
+    /// with the file paths stated up front so the instruction to open the PNG
+    /// is the first thing read rather than a footnote.
+    private static func agentText(for handoff: Handoff) -> String {
+        let header = """
+        PNG: \(handoff.png.path)
+        Open that file with your own file-reading tool to see the image — this \
+        result deliberately carries no image bytes.
+
+        """
+        let markdown = (try? String(contentsOf: handoff.markdown, encoding: .utf8)) ?? """
+        (capture.md couldn’t be read at \(handoff.markdown.path); the facts below \
+        come from capture.json instead.)
+
+        \(handoff.document.markers.count) marker(s), \(handoff.document.shapes.count) shape(s).
+        """
+        return header + markdown
+    }
+
+    private static func structured(_ handoff: Handoff) -> [String: Any] {
+        [
+            "png": handoff.png.path,
+            "markdown": handoff.markdown.path,
+            "json": handoff.json.path,
+            "capture": handoff.raw
+        ]
+    }
+}

--- a/PinpointCLI/MCP/MCPTransport.swift
+++ b/PinpointCLI/MCP/MCPTransport.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// The stdio pipe, and the one rule that makes it work.
+///
+/// An MCP client launches this process and speaks to it over the standard
+/// streams. Messages are newline-delimited JSON, so **stdout carries protocol
+/// and nothing else**: one stray line — a `print`, a warning, a progress dot —
+/// lands in the middle of the stream, fails to parse as a JSON-RPC message, and
+/// takes the whole session down. Every human-facing word goes to stderr, which
+/// the client is free to log or drop.
+///
+/// That is why `Out.stdout` is never called from anywhere under `MCP/`, and why
+/// writing goes through `send` alone: it is the only door to stdout, it holds a
+/// lock while it writes, and it serializes compactly on purpose. Pretty-printed
+/// JSON contains real newlines, which here is not a formatting choice but a
+/// framing bug.
+final class MCPTransport {
+    /// Guards stdout. Tool calls run concurrently (see `MCPServer`), so two
+    /// responses can be ready at the same instant; without this they interleave
+    /// mid-line and both are lost.
+    private let writeLock = NSLock()
+    private let handle = FileHandle.standardOutput
+
+    /// Writes one JSON-RPC message, followed by its newline.
+    func send(_ message: [String: Any]) {
+        guard let data = try? JSONSerialization.data(withJSONObject: message,
+                                                     options: [.withoutEscapingSlashes]) else {
+            // Only reachable if a value isn't JSON-representable — a bug here,
+            // not a state of the world. Say so on stderr and write nothing:
+            // half a document on stdout is worse than no document.
+            Self.log("couldn’t encode an outgoing message")
+            return
+        }
+
+        // Body and newline in a single write, so nothing can slip between a
+        // message and its delimiter.
+        var line = data
+        line.append(0x0A)
+
+        writeLock.lock()
+        defer { writeLock.unlock() }
+        do {
+            try handle.write(contentsOf: line)
+        } catch {
+            // The client closed the pipe while we were answering. Nothing to
+            // do about it and nowhere to report it to but stderr; the read loop
+            // will see EOF on its own and end the process.
+            Self.log("couldn’t write to stdout: \(error.localizedDescription)")
+        }
+    }
+
+    /// Reads lines from stdin until the client closes it, handing each to
+    /// `handler`.
+    ///
+    /// Blocking and single-threaded by design: this is the only reader of
+    /// stdin, and the messages on it are ordered. Anything slow that `handler`
+    /// starts belongs on another queue — see `MCPServer.handle`.
+    func readLoop(_ handler: (String) -> Void) {
+        while let line = readLine(strippingNewline: true) {
+            // Clients are allowed to send blank lines between messages, and a
+            // pipe that ends without a trailing newline produces one here.
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            handler(trimmed)
+        }
+    }
+
+    /// The only logging channel a stdio server has.
+    static func log(_ text: String) {
+        FileHandle.standardError.write(Data(("pinpoint mcp: " + text + "\n").utf8))
+    }
+}

--- a/PinpointCLI/Usage.swift
+++ b/PinpointCLI/Usage.swift
@@ -18,6 +18,7 @@ enum Usage {
     USAGE
       \(toolName) capture [--out <file.png>] [--json | --format <fmt>] [--timeout <seconds>] [--no-wait]
       \(toolName) last    [--out <file.png>] [--json | --format <fmt>]
+      \(toolName) mcp
       \(toolName) --help | --version
 
     COMMANDS
@@ -28,6 +29,12 @@ enum Usage {
                 picture on its own.
       last      Print the most recent handoff. Reads files only — it needs
                 neither the app running nor any permission.
+      mcp       Run as a stdio MCP server exposing capture_region,
+                get_last_capture and list_recent to an agent (#57). Speaks
+                JSON-RPC on stdin/stdout and nothing else — every human sentence
+                goes to stderr instead, same rule as --json above but absolute
+                here, because one stray line on stdout breaks the protocol. See
+                the README for the exact `claude mcp add` invocation.
 
     OPTIONS
       --out <file>       Copy the annotated PNG to <file>.

--- a/PinpointCLI/main.swift
+++ b/PinpointCLI/main.swift
@@ -30,6 +30,12 @@ do {
         try Commands.last(parsed)
     case .capture:
         try Commands.capture(parsed)
+    case .mcp:
+        // Blocks until the client closes stdin — an MCP session lasts as long
+        // as the client wants it to, not a fixed number of round trips. See
+        // MCPServer and MCPTransport for the one rule that makes this safe:
+        // nothing but protocol ever reaches stdout from here on.
+        MCPServer().run()
     }
     exit(ExitCode.ok.rawValue)
 } catch let error as CLIError {

--- a/README.md
+++ b/README.md
@@ -78,8 +78,10 @@ relaunch Pinpoint once.
 - **The shelf** — a built-in library of your screenshots: browse, favorite, sort,
   rename, Quick Look, and reopen any capture with its annotations.
 - **Global shortcuts** — capture or open the shelf from anywhere, fully rebindable.
-- **Scriptable** — a `pinpoint` CLI and a `pinpoint://` URL scheme, so agents,
-  hooks and `!`-commands can ask for a capture and read the result.
+- **Scriptable** — a `pinpoint` CLI, a `pinpoint://` URL scheme, and an
+  [MCP](https://modelcontextprotocol.io) server (`pinpoint mcp`) so agents,
+  hooks and `!`-commands can ask for a capture and read the result directly —
+  the file path and structured Markdown, never an inline image.
 - **Bilingual** — follows your macOS language (English / French).
 - **Native & private** — SwiftUI + ScreenCaptureKit, living in your menu bar.
   Your captures never leave your Mac.
@@ -161,6 +163,8 @@ Pinpoint/
   Localizable.xcstrings           # String Catalog (English base, French)
   Shelf/                          # the screenshot library (Models, Services, Stores, Views)
 PinpointCLI/                      # the `pinpoint` tool, embedded in the app at Contents/Helpers
+  MCP/                             # `pinpoint mcp` — the stdio server (JSONRPC, MCPTransport,
+                                    # MCPTools, MCPServer); reads the same HandoffContract
 landing/                          # the marketing site (Astro + Tailwind v4, bilingual)
 ```
 
@@ -233,6 +237,69 @@ The output is built to be read by a program:
 - Exit codes tell a state from an error: `0` done · `1` failed · `2` bad usage ·
   `3` no capture handed off yet · `4` timed out waiting for the copy · `5` Pinpoint
   isn't installed.
+
+## MCP server: `pinpoint mcp`
+
+The same binary also speaks [MCP](https://modelcontextprotocol.io) over stdio, so
+an agent can ask for a capture itself instead of you pasting one in. It is **the
+one MCP annotation server that works system-wide** rather than only inside a
+browser DOM — Pinpoint captures whatever is on screen, any app, any window.
+
+The whole design turns on one fact: **Claude Code doesn't render an image an MCP
+tool returns inline** — the base64 lands in the transcript as raw text
+([anthropics/claude-code#31208](https://github.com/anthropics/claude-code/issues/31208),
+closed "not planned"). So `pinpoint mcp` never sends image bytes over the wire.
+Every tool call returns the **absolute path of the annotated PNG plus the
+structured Markdown** described above, and tells the agent outright to open the
+PNG with its own file-reading tool. That's the file handoff this README already
+describes — the MCP server is a thin JSON-RPC front door onto it, built on the
+very same `HandoffContract` the CLI reads, so the three never disagree about
+where a capture lives or what it contains.
+
+Add it with the Claude Code CLI, pointing at the binary the app already ships:
+
+```sh
+claude mcp add pinpoint -- /Applications/Pinpoint.app/Contents/Helpers/pinpoint mcp
+```
+
+or, if you linked `pinpoint` onto your `PATH` as shown above:
+
+```sh
+claude mcp add pinpoint -- pinpoint mcp
+```
+
+Equivalently, the JSON entry in `.mcp.json` or your client's config:
+
+```json
+{
+  "mcpServers": {
+    "pinpoint": {
+      "command": "/Applications/Pinpoint.app/Contents/Helpers/pinpoint",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Three tools:
+
+| tool | needs | does |
+| --- | --- | --- |
+| `capture_region` | the running app | starts an interactive region capture and blocks until you press Copy — same as `pinpoint capture` |
+| `get_last_capture` | nothing — reads files | returns the most recent handoff without prompting for a new screenshot |
+| `list_recent` | nothing — reads files | lists up to the last 10 archived captures, newest first |
+
+Every result carries the PNG's path, the same Markdown `capture.md` holds, and a
+`structuredContent` object with `capture.json` verbatim — so an agent that would
+rather index the facts than parse them back out of prose can. A capture that
+timed out or a "nothing handed off yet" comes back as a normal tool result with
+`isError: true`, not a protocol failure, so the agent can see what happened and
+retry or ask instead of just failing silently.
+
+`pinpoint mcp` writes **only** JSON-RPC to stdout — that's the stdio transport's
+rule, and one stray log line breaks it for the whole session. Every human-facing
+sentence, including the ones you'd see running `pinpoint capture` at a terminal,
+goes to stderr instead.
 
 ## Deep links (`pinpoint://`)
 

--- a/project.yml
+++ b/project.yml
@@ -84,20 +84,27 @@ targets:
         ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
 
-  # The scriptable entry point (#56): `pinpoint capture`, `pinpoint last`.
-  # A command-line tool, not a second app — it drives the running app through
-  # the `pinpoint://` scheme above, because a bare executable has none of the
+  # The scriptable entry point (#56): `pinpoint capture`, `pinpoint last`, and
+  # the stdio MCP server (#57) at `pinpoint mcp` — a subcommand of this same
+  # tool rather than a second binary, so there is nothing new to sign
+  # individually in scripts/release.sh and scripts/install-local.sh, and
+  # nothing new to embed in project.yml's `Pinpoint` target above. A command-
+  # line tool, not a second app — it drives the running app through the
+  # `pinpoint://` scheme above, because a bare executable has none of the
   # app's TCC grants and could never take the screenshot itself.
   PinpointCLI:
     type: tool
     platform: macOS
     sources:
+      # Recurses into PinpointCLI/MCP/, which holds the JSON-RPC transport and
+      # tool definitions for `pinpoint mcp` (#57).
       - PinpointCLI
       # The handoff contract, compiled into both binaries instead of restated
-      # in the CLI: `pinpoint last` reads the very file the app writes, and a
-      # second copy of the paths or of the schema is a second thing to keep in
-      # step. A build error here is the point — it fires the day the contract
-      # grows a dependency a file reader shouldn't need.
+      # in the CLI: `pinpoint last` and `pinpoint mcp` read the very file the
+      # app writes, and a second copy of the paths or of the schema is a
+      # second thing to keep in step. A build error here is the point — it
+      # fires the day the contract grows a dependency a file reader shouldn't
+      # need.
       - path: Pinpoint/HandoffContract.swift
       - path: Pinpoint/HandoffDocument.swift
       # The deep-link vocabulary, for the same reason: the tool that fires


### PR DESCRIPTION
## Résumé

Ajoute `pinpoint mcp`, un serveur MCP stdio exposant trois outils à un agent (Claude Code, etc.) :

- `capture_region` — déclenche une capture interactive via `pinpoint://capture` et attend que l'utilisateur ait dessiné la région et appuyé sur Copier dans l'éditeur.
- `get_last_capture` — relit le dernier handoff (`last/capture.{png,md,json}`), fichiers seuls, sans app ni permission.
- `list_recent` — liste les captures archivées (`archive/<horodatage>/`), jusqu'aux 10 les plus récentes.

**Le point non négociable de l'issue #57** : aucun outil ne renvoie jamais d'octets d'image en base64 inline. Claude Code n'affiche pas les images renvoyées ainsi par un serveur MCP (anthropics/claude-code#31208, fermé « not planned »). Chaque réponse porte le **chemin absolu du PNG annoté** plus le **Markdown structuré** de `capture.md`, avec l'instruction explicite d'ouvrir le PNG avec l'outil `Read` propre à l'agent.

## Choix d'architecture

- **Sous-commande du CLI existant (`pinpoint mcp`), pas un second binaire.** Le CLI (#56) est déjà packagé, signé individuellement et embarqué dans `Contents/Helpers/`. Ajouter une cible séparée aurait dupliqué toute cette mécanique de signature dans `scripts/release.sh` / `scripts/install-local.sh` pour un service qui partage 100 % de son code de lecture de handoff avec le CLI. Zéro fichier de packaging touché.
- **Le contrat de handoff n'existe qu'à un seul endroit.** Le serveur MCP lit `Handoff` / `HandoffWatcher` — déjà utilisés par `pinpoint capture` / `pinpoint last` — plutôt que de relire `capture.json` à sa façon. `HandoffContract.swift` / `HandoffDocument.swift` restent l'unique source de vérité, compilée dans l'app, le CLI et maintenant ce serveur.
- **stdio propre.** `MCPTransport` est le seul point d'écriture vers `stdout` (verrouillé, un message JSON compact par ligne) ; tout log passe par `stderr`. Testé à la main : `initialize` → `tools/list` → `tools/call` → `ping`, méthode inconnue, ligne non-JSON, id de type string — stdout ne porte jamais que du JSON-RPC valide.

## Bug trouvé et corrigé pendant le test manuel

Chaque `tools/call` tourne sur sa propre file d'attente (pour ne pas bloquer `tools/list` derrière un `capture_region` qui peut attendre jusqu'à une heure). Premier test : le process quittait dès la fermeture de `stdin`, avant que les appels asynchrones aient fini d'écrire leur réponse — 3 réponses sur 6 disparaissaient. `MCPServer.run()` attend maintenant les appels en vol via un `DispatchGroup`, borné par leur propre timeout (`capture_region`) ou une grâce courte de 5 s (lectures de fichiers), avant de rendre la main.

## Vérification

```
xcodegen generate
xcodebuild -scheme Pinpoint -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO clean build
```
→ vert. Handshake JSON-RPC testé à la main contre le binaire compilé dans le DerivedData du worktree (jamais l'app installée de l'utilisateur).

## Documentation

README : nouvelle section « MCP server: `pinpoint mcp` » avec le bloc `claude mcp add` exact (chemin réel du binaire embarqué) et l'entrée JSON équivalente, table des trois outils.

`docs/capture-schema.json` inchangé : aucune clé n'est ajoutée au contrat par ce PR.

Closes #57