### PR TITLE
Prépare la v0.7.0 — changelog et bump de version

### DIFF
--- a/landing/public/appcast.xml
+++ b/landing/public/appcast.xml
@@ -7,6 +7,14 @@
     <language>en</language>
     <!-- NEWEST-ITEM-ANCHOR — scripts/update-appcast.sh inserts each release below this line. -->
     <item>
+      <title>Version 0.6.0</title>
+      <pubDate>Wed, 15 Jul 2026 08:26:19 +0200</pubDate>
+      <sparkle:version>6</sparkle:version>
+      <sparkle:shortVersionString>0.6.0</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
+      <enclosure url="https://github.com/croustibat/Pinpoint/releases/download/v0.6.0/Pinpoint.dmg" sparkle:edSignature="Fbx3a8VF0LzMhAp7mdbiFxUXlv4H8bRcjWCXyo22EjQ6ngpKZISRXmF9VeGjx2+uTZquYhBAzkdQXjro3umDDg==" length="2809517" type="application/octet-stream" />
+    </item>
+    <item>
       <title>Version 0.5.0</title>
       <pubDate>Thu, 09 Jul 2026 10:48:43 +0200</pubDate>
       <sparkle:version>5</sparkle:version>

--- a/landing/src/changelog.ts
+++ b/landing/src/changelog.ts
@@ -16,9 +16,29 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.7.0',
+    date: '2026-08-21',
+    latest: true,
+    changes: [
+      { type: 'added', text: 'Pinpoint now hands your capture to an AI agent as files. Every copy also writes capture.png, capture.md and capture.json to a stable folder, so an agent opens the real image with its own Read tool instead of choking on an inline one.' },
+      { type: 'added', text: 'Accessibility context under every marker — a pin is no longer just a percentage but “AXButton ‘Login’ in Safari”, turning a spot on your screen into an anchor an agent can act on. Optional, and off until you grant the permission.' },
+      { type: 'added', text: 'On-device OCR reads the text under each marker — error messages, logs, class names — and sends it along with the capture. Nothing is uploaded anywhere.' },
+      { type: 'added', text: 'A pinpoint command line, an MCP server (pinpoint mcp) and a pinpoint:// URL scheme, so agents, scripts and shell hooks can drive Pinpoint. The MCP server hands over file paths, never inline images.' },
+      { type: 'added', text: 'Redaction tool (⌘4) — drag over a token or an API key and it is painted out of the picture, the text, the JSON and the accessibility context alike, before anything is shared.' },
+      { type: 'added', text: 'Undo and Redo (⌘Z / ⇧⌘Z) throughout the editor — and arrows and rectangles can finally be selected, moved and resized after you have drawn them.' },
+      { type: 'added', text: 'Window capture — hold Space while selecting to highlight a single window and grab it cleanly, rounded corners included.' },
+      { type: 'added', text: 'The selection rectangle is now adjustable before you commit it: drag it around, resize it by its handles, nudge it with the arrow keys, Enter to confirm.' },
+      { type: 'added', text: 'Task presets (Bug, Review, Implement) prefill the framing you keep retyping, and a structured JSON export documents every capture against a published schema.' },
+      { type: 'added', text: 'Shelf: search your library, contextual empty states, and a confirmation before deleting several screenshots at once. Editor: delete the selected marker with ⌫, tool shortcuts ⌘1/⌘2/⌘3, and tooltips everywhere.' },
+      { type: 'added', text: 'VoiceOver labels, Dynamic Type and reduce-motion support across the editor and the shelf.' },
+      { type: 'fixed', text: 'What you see is now what you export: on-screen marker and stroke sizes follow the same formula as the exported image, so a small capture no longer ships with oversized annotations.' },
+      { type: 'fixed', text: 'Exported images were silently rendered at twice the requested size on Retina, which made every pixel coordinate in the copied text describe a grid half the size of the image it shipped with. Files are smaller and the numbers now match.' },
+      { type: 'fixed', text: 'A failed copy or save is reported instead of quietly showing “Copied!”, and the Screen Recording permission is checked before a capture, with a button that opens the right System Settings pane.' },
+    ],
+  },
+  {
     version: '0.6.0',
     date: '2026-07-14',
-    latest: true,
     changes: [
       { type: 'added', text: 'Crop tool in the editor — trim a capture with eight handles and a rule-of-thirds grid; existing markers and arrows are remapped into the cropped frame.' },
       { type: 'added', text: 'Optional capture timer — a 3, 5, or 10-second countdown before the shot so you can arrange your UI or open a menu; press Esc to cancel.' },

--- a/project.yml
+++ b/project.yml
@@ -69,8 +69,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: app.croustibat.Pinpoint
-        MARKETING_VERSION: "0.6.0"
-        CURRENT_PROJECT_VERSION: "6"
+        MARKETING_VERSION: "0.7.0"
+        CURRENT_PROJECT_VERSION: "7"
         GENERATE_INFOPLIST_FILE: NO
         SWIFT_VERSION: "5.0"
         CODE_SIGN_STYLE: Automatic
@@ -114,8 +114,8 @@ targets:
       base:
         PRODUCT_NAME: pinpoint
         PRODUCT_BUNDLE_IDENTIFIER: app.croustibat.Pinpoint.cli
-        MARKETING_VERSION: "0.6.0"
-        CURRENT_PROJECT_VERSION: "6"
+        MARKETING_VERSION: "0.7.0"
+        CURRENT_PROJECT_VERSION: "7"
         # A tool has no Info.plist of its own; this embeds one in the binary so
         # `pinpoint --version` can read the version it was built with.
         GENERATE_INFOPLIST_FILE: YES


### PR DESCRIPTION
Préparation de la release **v0.7.0**, à merger dans `develop` avant la PR `develop` → `main`.

## Contenu

- Entrée `0.7.0` en tête de `landing/src/changelog.ts` (`latest: true`), `0.6.0` perd `latest`.
- `MARKETING_VERSION` 0.6.0 → **0.7.0** et `CURRENT_PROJECT_VERSION` 6 → **7**, sur la target app **et** la target `PinpointCLI`.
- Merge de `main` : récupère l'entrée appcast v0.6.0 qui n'existait que sur `main`, pour que `develop` ne parte pas en retard.

## Ce que contient la v0.7.0

**20 issues de la roadmap #59** — les Tiers 0, 1, 2 et 3 au complet, soit +9 389 lignes et 29 nouveaux fichiers Swift.

| Thème | Issues |
| --- | --- |
| Intégration agents | #41, #49, #52, #53, #54, #55, #56, #57, #58 |
| Éditeur | #37, #38, #43, #44, #45, #48, #50 |
| Capture | #39, #47, #51 |
| Étagère | #40, #42 |
| Accessibilité | #46 |
| Correctif | #76 |

## ⚠️ À faire avant / pendant la release

1. **Cask Homebrew** — le CLI `pinpoint` est désormais embarqué dans `Contents/Helpers/`. La stanza `binary` doit être ajoutée à `Casks/pinpoint.rb` dans le tap `croustibat/homebrew-tap` (dépôt séparé, rien n'y a été poussé) ; la stanza exacte est dans la PR #82.
2. **Signature** — `scripts/release.sh` et `scripts/install-local.sh` signent maintenant le binaire CLI **avant** l'app. Sans cela `codesign` refuse de signer le bundle.
3. **Validations manuelles restantes** — ⌘Z de bout en bout, glisser-déplacer des formes, alerte de permission Accessibilité, chemin succès de `capture_region` via un vrai client MCP.

Vérifié : `xcodegen generate` + `xcodebuild` verts, `npm run build` de la landing vert.