### PR TITLE
landing: rafraîchit la section agents pour la v0.7.0 (contexte d'accessibilité, OCR, CLI/MCP)

### DIFF
--- a/landing/src/components/Landing.astro
+++ b/landing/src/components/Landing.astro
@@ -9,11 +9,23 @@ const t = content[lang];
 const alt = otherLang[lang];
 
 const featureIcons = [
+  // Accessibility context — tag
+  'M6 3a3 3 0 00-3 3v4.586a3 3 0 00.879 2.121l7.5 7.5a3 3 0 004.242 0l4.586-4.586a3 3 0 000-4.242l-7.5-7.5A3 3 0 0010.586 3H6z',
+  // On-device text reading — eye
+  'M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z M15 12a3 3 0 11-6 0 3 3 0 016 0z',
+  // Redaction — eye-slash
+  'M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88',
+  // Undo, redo, still editable — u-turn arrow
+  'M9 15L4 10m0 0l5-5m-5 5h11a4 4 0 014 4v2',
+  // Window capture — app window
+  'M4 5a2 2 0 012-2h12a2 2 0 012 2v14a2 2 0 01-2 2H6a2 2 0 01-2-2V5z M4 9h16',
+  // Markers, arrows & rectangles — ringed marker
   'M12 2a10 10 0 100 20 10 10 0 000-20zm0 6a4 4 0 110 8 4 4 0 010-8z',
-  'M5 19L19 5M19 5h-7M19 5v7',
+  // Legend baked in — lines
   'M4 7h16M4 12h16M4 17h10',
+  // The shelf — grid
   'M4 5h7v7H4zM13 5h7v4h-7zM13 12h7v7h-7zM4 15h7v4H4z',
-  'M9 9V7a3 3 0 10-3 3h12a3 3 0 10-3-3v2m-6 0h6m-6 0v6m6-6v6m-6 0a3 3 0 103 3v-2m0-1h0',
+  // Native & private — shield
   'M12 2l8 4v6c0 5-3.5 8-8 10-4.5-2-8-5-8-10V6l8-4z',
 ];
 ---
@@ -175,12 +187,15 @@ const featureIcons = [
       <h2 class="mt-3 text-3xl font-semibold tracking-tight text-white md:text-4xl">{t.agents.title}</h2>
       <p class="mt-5 text-lg leading-relaxed text-zinc-400">{t.agents.body}</p>
     </div>
-    <div class="overflow-hidden rounded-2xl border border-white/10 bg-ink-2 shadow-xl">
-      <div class="flex items-center gap-2 border-b border-white/5 px-4 py-2.5">
-        <span class="h-2.5 w-2.5 rounded-full bg-white/15"></span>
-        <span class="text-xs text-zinc-500">clipboard.txt</span>
+    <div>
+      <div class="overflow-hidden rounded-2xl border border-white/10 bg-ink-2 shadow-xl">
+        <div class="flex items-center gap-2 border-b border-white/5 px-4 py-2.5">
+          <span class="h-2.5 w-2.5 rounded-full bg-white/15"></span>
+          <span class="text-xs text-zinc-500">capture.md</span>
+        </div>
+        <pre class="max-h-[420px] overflow-y-auto whitespace-pre-wrap break-words p-5 text-[13px] leading-relaxed text-zinc-300"><code style="font-family: var(--font-mono)">{t.agents.sample}</code></pre>
       </div>
-      <pre class="overflow-x-auto p-5 text-[13px] leading-relaxed text-zinc-300"><code style="font-family: var(--font-mono)">{t.agents.sample}</code></pre>
+      <p class="mt-4 text-xs leading-relaxed text-zinc-500">{t.agents.access}</p>
     </div>
   </div>
 </section>

--- a/landing/src/i18n.ts
+++ b/landing/src/i18n.ts
@@ -30,7 +30,7 @@ type Content = {
   steps: { title: string; subtitle: string; items: { n: string; t: string; d: string }[] };
   features: { title: string; subtitle: string; items: { t: string; d: string }[] };
   tour: { title: string; subtitle: string; shelf: string; settings: string };
-  agents: { eyebrow: string; title: string; body: string; sample: string };
+  agents: { eyebrow: string; title: string; body: string; sample: string; access: string };
   download: { title: string; body: string; cta: string; req: string; source: string; brew: string };
   footer: { tagline: string; rights: string; os: string };
 };
@@ -62,19 +62,22 @@ export const content: Record<Lang, Content> = {
       items: [
         { n: '1', t: 'Capture a region', d: 'Press ⌘⇧1 and drag a rectangle. Native resolution, multi-display and Retina aware.' },
         { n: '2', t: 'Drop numbered markers', d: 'Click to place pins and add a note to each. Add arrows and rectangles for emphasis.' },
-        { n: '3', t: 'Copy for your agent', d: '⌘C copies the annotated image and a structured text that references every marker.' },
+        { n: '3', t: 'Copy for your agent', d: '⌘C copies the annotated image and a structured text that references every marker — and drops the same three files at a stable path your agent can read on its own.' },
       ],
     },
     features: {
       title: 'Built to be precise',
       subtitle: 'Everything you need to point an agent at the right pixel.',
       items: [
-        { t: 'Numbered markers', d: 'Ringed, numbered pins that stay legible on any background — in three styles.' },
-        { t: 'Arrows & rectangles', d: 'Add visual emphasis right on top of your capture.' },
+        { t: 'Accessibility context', d: 'Each marker also carries what macOS knows about the element under it — role, label, owning app and its frame.' },
+        { t: 'On-device text reading', d: 'Vision reads the text under each marker — errors, class names, log lines — and it travels with the capture.' },
+        { t: 'Redaction', d: 'Drag over a token or a secret before it ships. Hidden in the image, the text and the accessibility context alike.' },
+        { t: 'Undo, redo, still editable', d: '⌘Z through any change. Markers, arrows and rectangles stay selectable, movable and resizable after you drop them.' },
+        { t: 'Window capture', d: 'Hold Space while dragging to snap the selection to a window instead of drawing it freehand.' },
+        { t: 'Markers, arrows & rectangles', d: 'Ringed, numbered pins in three styles, plus arrows and rectangles for emphasis, drawn straight on the capture.' },
         { t: 'Legend baked in', d: 'Optionally embed the marker descriptions and instructions into the image, so a single paste carries everything.' },
-        { t: 'The shelf', d: 'Browse, favorite and reopen your screenshots from a built-in library.' },
-        { t: 'Global shortcuts', d: 'Capture or open the shelf from anywhere — fully rebindable.' },
-        { t: 'Native & private', d: 'SwiftUI + ScreenCaptureKit, living in your menu bar. Your captures never leave your Mac.' },
+        { t: 'The shelf', d: 'Browse, search, favorite and reopen your screenshots from a built-in library.' },
+        { t: 'Native & private', d: 'SwiftUI + ScreenCaptureKit, living in your menu bar. Captures, OCR reads and accessibility context stay on your Mac.' },
       ],
     },
     tour: {
@@ -85,18 +88,32 @@ export const content: Record<Lang, Content> = {
     },
     agents: {
       eyebrow: 'Made for AI agents',
-      title: 'A prompt your agent can actually read',
-      body: 'Most chat UIs paste only the image and drop the clipboard text. Pinpoint can bake the legend into the picture — and always copies a structured prompt that an agent like Claude Code or Codex can parse: image size, each marker’s description and position, then your instructions.',
-      sample: `# Annotated capture — 1280×800 px
+      title: 'The file your agent reads directly',
+      body: 'Every copy also writes capture.png, capture.md and capture.json to a stable path — because Claude Code and most MCP clients don’t render inline images (the upstream bug was closed “not planned”), so a file an agent opens itself is the channel that actually works. capture.md lists each marker’s position in pixels and percent, the accessibility element found under it — role, label, owning app — and whatever text was read there on device. None of it depends on a page’s DOM, so it reads the same in any app.',
+      sample: `# Annotated capture — 1720×1046 px
 
 An image is attached. Numbered (ringed) badges point to specific elements.
-Markers (position in % of the image, top-left origin):
+Positions are given in pixels from the top-left corner (0, 0), then as a percentage of the image size.
 
-1. Primary CTA button · ~62 % × 48 %
-2. Misaligned icon · ~12 % × 22 %
+## Markers
+M1, M2… are the numbers drawn on the image; the code in brackets is a stable ID for that marker.
+“UI” lines name the interface element found under the marker in the macOS accessibility tree at capture time — its role, its label, the app owning it, and its box in this image. “Path” is the chain of containers around it.
+“Text” lines are what Pinpoint read in the pixels under the marker, on this Mac. A marker’s description may have been pre-filled from such a read and then edited by the user.
+
+- M1 [5a5421] · overflows its card at this width — (1264, 127) px · (74 %, 12 %)
+  - UI: AXButton “Export CSV” · id=export-csv · com.apple.Safari · box (1178, 99) 162×52 px
+  - Path: AXWindow “Orders — Admin” › AXButton “Export CSV”
+- M2 [010661] · error stays after a valid range is picked — (249, 254) px · (14 %, 24 %)
+  - UI: AXWindow “Orders — Admin” · com.apple.Safari · box (0, 0) 1720×1046 px
+  - Path: AXWindow “Orders — Admin”
+  - Text: “Invalid date range: end must be after start”
+
+## Task — Bug
+The markers point at a defect. Find its cause before proposing anything: locate the code that produces what is marked, explain why it behaves this way, then propose the smallest change that addresses the cause rather than the symptom. If the capture isn’t enough to be sure, say what you would need to look at.
 
 ## Instructions
-Make the CTA full-width on mobile and fix the icon alignment.`,
+The Export CSV button overflows its card at this width, and the date-range error stays on screen after picking a valid range.`,
+      access: 'Reachable without the editor too: `pinpoint capture` from a script or a hook, or `pinpoint mcp` as a stdio MCP server exposing capture_region, get_last_capture and list_recent.',
     },
     download: {
       title: 'Get Pinpoint',
@@ -135,19 +152,22 @@ Make the CTA full-width on mobile and fix the icon alignment.`,
       items: [
         { n: '1', t: 'Capture une région', d: 'Appuie sur ⌘⇧1 et trace un rectangle. Résolution native, multi-écran et Retina.' },
         { n: '2', t: 'Pose des repères numérotés', d: 'Clique pour placer des repères et ajoute une note à chacun. Flèches et rectangles pour appuyer.' },
-        { n: '3', t: 'Copie pour ton agent', d: '⌘C copie l’image annotée et un texte structuré qui référence chaque repère.' },
+        { n: '3', t: 'Copie pour ton agent', d: '⌘C copie l’image annotée et un texte structuré qui référence chaque repère — et dépose les mêmes fichiers à un chemin stable que ton agent peut lire seul.' },
       ],
     },
     features: {
       title: 'Conçu pour la précision',
       subtitle: 'Tout ce qu’il faut pour pointer un agent sur le bon pixel.',
       items: [
-        { t: 'Repères numérotés', d: 'Des pastilles numérotées et cerclées, lisibles sur n’importe quel fond — en trois styles.' },
-        { t: 'Flèches & rectangles', d: 'Ajoute de l’emphase visuelle directement sur ta capture.' },
+        { t: 'Contexte d’accessibilité', d: 'Chaque repère porte aussi ce que macOS sait de l’élément dessous — rôle, libellé, app propriétaire et son cadre.' },
+        { t: 'Lecture de texte sur l’appareil', d: 'Vision lit le texte sous chaque repère — erreurs, noms de classes, lignes de log — et il voyage avec la capture.' },
+        { t: 'Rédaction', d: 'Glisse sur un jeton ou un secret avant qu’il ne parte. Masqué dans l’image, le texte et le contexte d’accessibilité à la fois.' },
+        { t: 'Annuler, rétablir, toujours modifiable', d: '⌘Z pour revenir sur tout changement. Repères, flèches et rectangles restent sélectionnables, déplaçables et redimensionnables après coup.' },
+        { t: 'Capture de fenêtre', d: 'Maintiens Espace en traçant pour aimanter la sélection à une fenêtre plutôt que de la dessiner à main levée.' },
+        { t: 'Repères, flèches & rectangles', d: 'Des pastilles numérotées et cerclées en trois styles, plus des flèches et des rectangles pour appuyer, dessinés sur la capture.' },
         { t: 'Légende incrustée', d: 'Incruste si tu veux les descriptions et les instructions dans l’image, pour qu’un seul collage transmette tout.' },
-        { t: 'L’étagère', d: 'Parcours, mets en favori et rouvre tes captures depuis une bibliothèque intégrée.' },
-        { t: 'Raccourcis globaux', d: 'Capture ou ouvre l’étagère depuis n’importe où — entièrement reconfigurables.' },
-        { t: 'Natif & privé', d: 'SwiftUI + ScreenCaptureKit, dans ta barre de menus. Tes captures ne quittent jamais ton Mac.' },
+        { t: 'L’étagère', d: 'Parcours, recherche, mets en favori et rouvre tes captures depuis une bibliothèque intégrée.' },
+        { t: 'Natif & privé', d: 'SwiftUI + ScreenCaptureKit, dans ta barre de menus. Captures, lectures OCR et contexte d’accessibilité restent sur ton Mac.' },
       ],
     },
     tour: {
@@ -158,18 +178,32 @@ Make the CTA full-width on mobile and fix the icon alignment.`,
     },
     agents: {
       eyebrow: 'Pensé pour les agents IA',
-      title: 'Un prompt que ton agent sait vraiment lire',
-      body: 'La plupart des interfaces de chat ne collent que l’image et perdent le texte. Pinpoint peut incruster la légende dans l’image — et copie toujours un prompt structuré qu’un agent comme Claude Code ou Codex sait analyser : taille de l’image, description et position de chaque repère, puis tes instructions.',
-      sample: `# Capture annotée — 1280×800 px
+      title: 'Le fichier que ton agent lit directement',
+      body: 'Chaque copie écrit aussi capture.png, capture.md et capture.json à un chemin stable — parce que Claude Code et la plupart des clients MCP ne rendent pas les images renvoyées en ligne (le bug amont a été fermé « not planned »), donc un fichier que l’agent ouvre lui-même est le seul canal qui marche vraiment. capture.md liste la position de chaque repère en pixels et en pourcentage, l’élément d’accessibilité trouvé dessous — rôle, libellé, app propriétaire — et le texte éventuellement lu à cet endroit, sur l’appareil. Rien de tout ça ne dépend du DOM d’une page : ça marche pareil dans n’importe quelle app.',
+      sample: `# Capture annotée — 1720×1046 px
 
 Une image est jointe. Des pastilles numérotées (cerclées) pointent des éléments précis.
-Repères (position en % de l’image, origine haut-gauche) :
+Les positions sont données en pixels depuis le coin haut-gauche (0, 0), puis en pourcentage de la taille de l’image.
 
-1. Bouton d’action principal · ~62 % × 48 %
-2. Icône mal alignée · ~12 % × 22 %
+## Repères
+M1, M2… correspondent aux numéros dessinés sur l’image ; le code entre crochets est un identifiant stable de ce repère.
+Les lignes « UI » nomment l’élément d’interface trouvé sous le repère dans l’arbre d’accessibilité macOS au moment de la capture — son rôle, son libellé, l’app qui le possède et sa boîte dans cette image. « Path » est la chaîne de conteneurs qui l’entoure.
+Les lignes « Text » sont ce que Pinpoint a lu dans les pixels sous le repère, sur ce Mac. La description d’un repère a pu être pré-remplie à partir d’une telle lecture, puis modifiée par l’utilisateur.
+
+- M1 [4ecd13] · déborde de sa carte à cette largeur — (1264, 127) px · (74 %, 12 %)
+  - UI: AXButton “Export CSV” · id=export-csv · com.apple.Safari · box (1178, 99) 162×52 px
+  - Path: AXWindow “Orders — Admin” › AXButton “Export CSV”
+- M2 [6f42cb] · l’erreur reste affichée après une plage valide — (249, 254) px · (14 %, 24 %)
+  - UI: AXWindow “Orders — Admin” · com.apple.Safari · box (0, 0) 1720×1046 px
+  - Path: AXWindow “Orders — Admin”
+  - Text: “Invalid date range: end must be after start”
+
+## Tâche — Bug
+Les repères désignent un défaut. Cherchez-en la cause avant de proposer quoi que ce soit : localisez le code qui produit ce qui est marqué, expliquez pourquoi il se comporte ainsi, puis proposez la plus petite modification qui traite la cause plutôt que le symptôme. Si la capture ne suffit pas à en être sûr, dites ce qu’il faudrait aller regarder.
 
 ## Instructions
-Passe le bouton en pleine largeur sur mobile et corrige l’alignement de l’icône.`,
+Le bouton Exporter en CSV déborde de sa carte à cette largeur, et l’erreur de plage de dates reste affichée après avoir choisi une plage valide.`,
+      access: 'Accessible aussi sans passer par l’éditeur : `pinpoint capture` depuis un script ou un hook, ou `pinpoint mcp` comme serveur MCP en stdio, qui expose capture_region, get_last_capture et list_recent.',
     },
     download: {
       title: 'Obtiens Pinpoint',


### PR DESCRIPTION
## Contexte

La landing (`landing/src/i18n.ts`) date d'avant la roadmap #59 : la section
« For agents » montrait un `sample` de prompt de l'ancienne génération
(coordonnées en % seulement, pas d'ID stable, pas de contexte
d'accessibilité, pas de texte OCR, pas d'en-tête de tâche) et ne mentionnait
ni le handoff par fichier, ni le CLI, ni le serveur MCP. `features.items`
ignorait undo/redo, la rédaction, l'OCR, le contexte d'accessibilité, le
mode fenêtre et l'outillage agent.

## Ce que ça change

**`agents` (title/body/sample/access, nouveau champ `access`)**
- `sample` est un **vrai extrait de `capture.md`**, pas une reconstitution :
  j'ai copié les sources réelles (`Exporter.swift`, `Pin.swift`,
  `Markup.swift`, `AXSnapshot.swift`, `Redaction.swift`, `TaskPreset.swift`,
  etc.) depuis `/Users/croustibat/Projects/PINPOINT/Pinpoint/` dans un
  harnais `swiftc` autonome, construit une capture fabriquée (un bouton
  « Export CSV » qui déborde + une erreur de plage de dates lue par OCR,
  aucun élément AX dessous) et appelé `Exporter.buildText(...)` pour de
  vrai. La version FR n'est pas traduite à la main : le même binaire,
  relancé avec `-AppleLanguages '(fr)'`, charge le vrai
  `fr.lproj/Localizable.strings` compilé de l'app et produit le texte
  localisé authentique (j'ai aussi confirmé au passage que la clé
  `Instructions` n'a pas d'entrée FR dans le catalogue — mais le mot est
  identique dans les deux langues, donc ça ne se voit pas). Seuls le
  contenu tapé par l'utilisateur (note des repères, instructions) est
  écrit par moi, en anglais et en français séparément — le reste (légendes,
  IDs, positions px/%, calculs de boîte) sort du code.
- `body` explique maintenant le handoff par fichier (`capture.png` /
  `.md` / `.json` à un chemin stable) et pourquoi il existe : Claude Code
  et la plupart des clients MCP ne rendent pas les images en ligne, bug
  amont fermé « not planned ».
- Nouveau champ `access` (petite légende sous l'exemple) : mentionne le
  CLI (`pinpoint capture`) et le serveur MCP (`pinpoint mcp`, avec ses
  vrais noms d'outils `capture_region`/`get_last_capture`/`list_recent`,
  vérifiés via `pinpoint --help`).
- **Pas de section dédiée CLI/MCP** : je l'ai pesé, mais une nouvelle
  section aurait dupliqué ce que « For agents » couvre déjà
  thématiquement (comment un agent récupère la capture). Un ajout ciblé
  dans cette section fait le travail sans fragmenter la page.
- Le panneau d'exemple est renommé `clipboard.txt` → `capture.md` (c'est
  le vrai nom de fichier) et passe en scroll interne avec retour à la
  ligne (`max-h-[420px] overflow-y-auto whitespace-pre-wrap`) au lieu du
  défilement horizontal d'origine, l'extrait étant plus long (23 lignes
  contre 10). Je n'ai pas coupé le texte : il est entier, juste scrollable.

**`features.items`** : 6 → 9 entrées (la grille `sm:grid-cols-2
lg:grid-cols-3` tient un multiple de 3 proprement). Ajout : contexte
d'accessibilité, lecture de texte sur l'appareil (OCR), rédaction,
undo/redo + formes éditables, capture de fenêtre. « Repères numérotés »
et « Flèches & rectangles » sont fusionnés en une entrée. « L'étagère »
mentionne maintenant la recherche. « Raccourcis globaux » est retiré
(le moins différenciant du lot) pour faire de la place.

**`steps.items[2]`** (« Copy for your agent ») : une phrase ajoutée pour
mentionner que la copie dépose aussi les trois fichiers à un chemin
stable. Pas de 4ᵉ étape : ça aurait fait doublon avec la section agents
juste en dessous.

**`Landing.astro`** : tableau `featureIcons` étendu à 9 entrées (mêmes 5
existantes réassignées + 4 nouvelles, en Heroicons outline standard).

## Hors périmètre
- `landing/src/changelog.ts` et `landing/public/appcast.xml` : non touchés.
- `README.md` / `docs/` : un autre worker s'en charge en parallèle.

## Vérification
- `npm run build` passe (3 pages générées).
- Vérifié visuellement en local (`astro dev`) sur `/` et `/fr/` : grille de
  9 features, panneau `capture.md` avec scroll + retour à la ligne,
  contenu FR complet et cohérent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)