### PR TITLE
Communication v0.7.0 — landing et README à jour

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,43 +63,109 @@ relaunch Pinpoint once.
 ## Features
 
 - **Region capture** — press **⌘⇧1** (rebindable) → the screen dims; drag a
-  rectangle (live dimensions, `Esc` to cancel). Native resolution, multi-display
-  and Retina aware. A "capture full screen" fallback lives in the menu.
-- **Numbered markers** — click to drop ringed, numbered pins (drag to move, a
-  note per marker). Add arrows and rectangles for emphasis.
+  rectangle (live dimensions). It doesn't capture on release: resize it from
+  its eight handles or nudge it with the arrow keys, then **Return** (or a
+  click inside it) confirms, `Esc` cancels. Hold **Space** while selecting to
+  switch to window mode instead — click any window and it's captured with its
+  real edges. Native resolution, multi-display and Retina aware. A "capture
+  full screen" fallback lives in the menu, and every capture checks the
+  Screen Recording permission first, so a missing grant surfaces as a clear
+  alert rather than a blank image.
+- **Numbered markers & shapes** — click to drop ringed, numbered pins (drag to
+  move, a note per marker); add arrows and rectangles for emphasis. Every
+  shape is selectable, movable and resizable after the fact, with full
+  **undo/redo** (**⌘Z** / **⇧⌘Z**) and keyboard delete.
 - **Three marker styles** — filled disc, pointer pin, light outline — applied on
   screen *and* in the export.
+- **Redact before you share** — **⌘4**, then drag over a token, password or API
+  key: it's blacked out in the exported image, and stripped from the copied
+  text *and* the accessibility context below, not just visually covered.
+- **On-device OCR** — Vision reads the text sitting under each marker (an
+  error message, a log line, a class name) with no network call, and can
+  pre-fill a marker's note when nothing else already named the element.
+- **Accessibility context** — while a region is captured, Pinpoint also reads
+  the macOS accessibility tree. A marker that lands on a UI element carries
+  its role, its label, its identifier, its exact frame, and the chain of
+  containers around it — "marker 1 is the `AXButton` 'Login' inside Safari",
+  not "marker 1 is at 62%, 48%". This is what turns a marker into something an
+  agent can act on in your source rather than just look at. Optional: needs
+  the **Accessibility** permission (see below); without it a marker still
+  carries its pixel and percent position, just no interface detail.
 - **A prompt your agent can read** — **⌘C** copies the annotated PNG **and** a
-  structured text: image size, each marker's description and position (in %),
-  then your instructions. Parses cleanly in Claude Code, Codex, and the like.
+  structured text or JSON (your choice): image size, then per marker a stable
+  ID, your note, its pixel and percent position, the accessibility element
+  under it when there's one, and anything Pinpoint read there with OCR that
+  your note didn't already say — followed by your instructions. Parses
+  cleanly in Claude Code, Codex, and the like.
+- **Task presets** — Bug, Review or Implement: pick one and a short paragraph
+  of framing ("find the cause before proposing anything…") is written above
+  your instructions, so the same scaffolding doesn't get retyped on every
+  capture.
 - **Legend baked in** (optional) — embeds the marker descriptions + instructions
   into the image, so a single paste carries everything (most chat UIs drop the
   clipboard text).
-- **The shelf** — a built-in library of your screenshots: browse, favorite, sort,
-  rename, Quick Look, and reopen any capture with its annotations.
+- **The shelf** — a built-in library of your screenshots: search, browse,
+  favorite, sort, rename, Quick Look, and reopen any capture with its
+  annotations (deleting one asks first).
 - **Global shortcuts** — capture or open the shelf from anywhere, fully rebindable.
 - **Scriptable** — a `pinpoint` CLI, a `pinpoint://` URL scheme, and an
   [MCP](https://modelcontextprotocol.io) server (`pinpoint mcp`) so agents,
   hooks and `!`-commands can ask for a capture and read the result directly —
   the file path and structured Markdown, never an inline image.
 - **Bilingual** — follows your macOS language (English / French).
-- **Native & private** — SwiftUI + ScreenCaptureKit, living in your menu bar.
-  Your captures never leave your Mac.
+- **Native, private & accessible** — SwiftUI + ScreenCaptureKit, living in
+  your menu bar. Captures, OCR and the accessibility read all happen on your
+  Mac and never leave it. VoiceOver, Dynamic Type and reduce-motion are
+  supported throughout the app itself.
 
-A copied prompt looks like this:
+### What to allow
+
+| Permission | Required? | What it's for | Without it |
+| --- | --- | --- | --- |
+| **Screen Recording** | Yes | Taking a capture at all | Pinpoint can't take a screenshot — it checks before it tries and walks you to System Settings ▸ Privacy & Security ▸ Screen Recording rather than failing silently. |
+| **Accessibility** | No, opt-in | The `UI:` / `Path:` lines under each marker | Everything else keeps working exactly the same — capture, markers, OCR, redaction. A marker just carries its pixel/percent position and nothing about the element under it. |
+
+Neither is requested eagerly: Screen Recording is checked right before your
+first capture, and Accessibility is never asked for until you turn it on
+yourself from Pinpoint's Settings, which deep-links straight to the right
+System Settings pane.
+
+This is real output — produced by feeding fabricated markers into this repo's
+own, unmodified `Exporter.buildText` (not hand-written), at the coordinates of
+the staged bug that [the demo script](docs/demo-script.md) walks through
+recording a capture against:
 
 ```text
 # Annotated capture — 1280×800 px
 
 An image is attached. Numbered (ringed) badges point to specific elements.
-Markers (position in % of the image, top-left origin):
+Positions are given in pixels from the top-left corner (0, 0), then as a percentage of the image size.
 
-1. Primary CTA button · ~62 % × 48 %
-2. Misaligned icon · ~12 % × 22 %
+## Markers
+M1, M2… are the numbers drawn on the image; the code in brackets is a stable ID for that marker.
+“UI” lines name the interface element found under the marker in the macOS accessibility tree at capture time — its role, its label, the app owning it, and its box in this image. “Path” is the chain of containers around it.
+“Text” lines are what Pinpoint read in the pixels under the marker, on this Mac. A marker’s description may have been pre-filled from such a read and then edited by the user.
+
+- M1 [a074e5] · Doesn't stay full-width once the layout stacks on mobile — (794, 384) px · (62 %, 48 %)
+  - UI: AXButton “Start free trial” · com.apple.Safari · box (740, 360) 170×56 px
+  - Path: AXWindow “Nimbus — Demo for Pinpoint capture” › AXButton “Start free trial”
+  - Text: “Start free trial”
+- M2 [239cc7] · Logo mark sits a few pixels below the wordmark baseline — (90, 44) px · (7 %, 6 %)
+  - UI: AXWindow “Nimbus — Demo for Pinpoint capture” · com.apple.Safari · box (0, 0) 1280×800 px
+  - Path: AXWindow “Nimbus — Demo for Pinpoint capture”
+
+## Task — Bug
+The markers point at a defect. Find its cause before proposing anything: locate the code that produces what is marked, explain why it behaves this way, then propose the smallest change that addresses the cause rather than the symptom. If the capture isn’t enough to be sure, say what you would need to look at.
 
 ## Instructions
 Make the CTA full-width on mobile and fix the icon alignment.
 ```
+
+M2 resolves to nothing more specific than the window because the icon it sits
+on is marked `aria-hidden` in that page's markup — nothing more specific was
+under the pixel. That's the graceful-degradation path in the bullet above,
+not a bug in this example: the marker still carries an exact position, and an
+agent still has the image itself to look at.
 
 ## Build from source
 
@@ -148,14 +214,22 @@ Pinpoint/
   CaptureHistory.swift            # recent captures (Application Support + JSON index)
   EditorView.swift                # annotation canvas + side panel
   EditorWindowController.swift    # AppKit window hosting the SwiftUI editor
-  Pin.swift / Markup.swift        # marker + arrow/rectangle models
+  Pin.swift / Markup.swift        # marker + arrow/rectangle/redaction models
   PinStyle.swift                  # marker styles (disc / pointer / outline)
+  TaskPreset.swift                # Bug / Review / Implement framing (#53)
+  EditorHistory.swift             # undo/redo stack for the annotation model (#44)
+  Redaction.swift                 # what a hidden region strips from the export (#50)
+  TextRecognizer.swift            # on-device OCR under each marker, Vision (#49)
+  AXSnapshot.swift                # a frozen slice of the macOS accessibility tree (#55)
+  AXSnapshotCollector.swift       # walks that tree at capture time
+  AXPermission.swift              # the (optional) Accessibility permission grant
   Theme.swift                     # vermillon palette
   Exporter.swift                  # annotated PNG render + structured text + clipboard
   FileHandoff.swift               # writes capture.{png,md,json} where an agent can read them
   HandoffContract.swift           # where those files live + how to read one back (shared with the CLI)
   HandoffDocument.swift           # the JSON contract for capture.json (schemaVersion 1)
   HandoffDocumentBuilder.swift    # fills that contract in from the annotation model
+  AgentTextFormat.swift           # Markdown vs JSON on the clipboard (#52)
   URLCommand.swift                # pinpoint:// deep links — what is accepted, and what isn't
   SettingsWindowController.swift  # AppKit settings window (works around the macOS 14+ SettingsLink bug)
   ShelfWindowController.swift     # the shelf window
@@ -195,7 +269,9 @@ A file path is the channel that reliably works.
 - **The archive keeps the 10 most recent handoffs**, oldest deleted first. Each
   folder holds a full-resolution PNG, so the cap is deliberately low.
 - `capture.json` carries a `schemaVersion`. New keys can appear without bumping
-  it — consumers must ignore what they don't know.
+  it — consumers must ignore what they don't know. The full contract is
+  published as a JSON Schema at
+  [`docs/capture-schema.json`](docs/capture-schema.json).
 
 ## Scripting: the `pinpoint` CLI
 

--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -1,0 +1,208 @@
+# Demo script — v0.7.0
+
+`docs/demo.gif` still shows the pre-0.7.0 flow (capture → percentage markers →
+copy). This is the shot list to replace it: a script to *play*, not prose to
+adapt. It can't be recorded from here — capturing the screen and driving the
+Pinpoint UI is interactive and has to happen on your own Mac — so everything
+below is written to be followed step by step, key by key.
+
+## The story it has to tell
+
+Pinpoint's whole pitch for v0.7.0 is bet #1 (#55): a marker isn't a percentage
+anymore, it's an anchor into the app's own accessibility tree. The demo has to
+*show* that, not describe it:
+
+1. A real, visible bug in a real, running app.
+2. One capture, one marker, a one-line instruction.
+3. An agent that never saw a screenshot pasted into it — it reads
+   `capture.md` (and looks at `capture.png` itself) from the fixed path on
+   disk, and fixes the right thing because the marker told it *which element*,
+   not just *which pixels*.
+
+Resist the urge to add more markers, more shapes, or a tour of the Shelf.
+One clean bug, one marker, one fix is more convincing than a feature tour —
+and it's what actually happened in the file handoff this whole release is
+built around.
+
+## What's already in the repo for this
+
+Both are gitignored (never committed — see `.gitignore`), so they only exist
+in a checkout that made them, but they're real and worth knowing about before
+you improvise new assets:
+
+- **`.capture-demo/index.html`** — a small, self-contained fake product page
+  ("Nimbus"). It stages exactly one bug on purpose: the logo mark carries
+  `transform: translateY(5px)` (see the comment right above `.brand .mark` in
+  the CSS), so it sits visibly below the "Nimbus" wordmark's baseline.
+  **Use this as the bug.** It needs no setup — open the file in a browser —
+  and it's already the bug the old (pre-0.7.0) `demo.gif` pointed at, so
+  reusing it keeps continuity with the README's copied-prompt example, which
+  was regenerated against this same file for this PR.
+
+- **`.demo-remotion/`** — a Remotion project (`npm run studio` / `npm run
+  render`, see its `package.json`) that rendered the *current* `demo.gif`.
+  Worth knowing what it actually is: **not a screen recording tool** — it's a
+  from-scratch React animation (`src/Demo.tsx`) that *redraws* a fake
+  Pinpoint window, a fake cursor, and fake clipboard text by hand-tuned
+  keyframes. The content it renders (percent-only markers, no accessibility
+  line, no OCR, "Copy for the agent" wording) is the exact pre-0.7.0 format
+  this task exists to retire. It is reusable *as a rendering pipeline* — it
+  could composite a real screen recording into a branded frame, add a
+  cursor-click pulse, export a `.gif`/`.mp4` — but not as-is: `Demo.tsx` would
+  need a full rewrite of its timeline and its hard-coded UI/text to match
+  what v0.7.0 actually shows, and at that point it is doing the same job as
+  a real screen recording while being one step further from the truth.
+  **Recommendation: record a real screen capture (below) rather than
+  rescripting `Demo.tsx`.** The whole point of this refresh is that the tool
+  now shows real, verifiable output — a hand-animated recreation is exactly
+  the kind of "plausible but not real" artifact the current landing page and
+  README examples got flagged for. If a polish pass is wanted later
+  (branded intro card, smoother cursor), it should composite on top of a real
+  recording, not replace it.
+
+## Before you hit record
+
+- **Permissions.** Screen Recording must already be granted (Pinpoint will
+  otherwise interrupt the take with its own permission alert). If you want
+  the accessibility line in `capture.md` for the demo marker, grant
+  **Accessibility** too, from Pinpoint's own Settings — it deep-links to
+  System Settings ▸ Privacy & Security ▸ Accessibility. Do this *before*
+  recording; the OS grant dialog is not something you want mid-take.
+- **Dry run.** Take one throwaway capture of `.capture-demo/index.html`'s
+  header first, drop a marker on the logo mark, and read the result with
+  `pinpoint last --format md` in a terminal. Check what you get. Browsers
+  vary in what they expose to the accessibility tree, and the mark carries
+  `aria-hidden="true"` in the HTML, which can hide it specifically — if the
+  marker resolves to nothing more than the enclosing window, try nudging it
+  a few pixels toward the "Nimbus" wordmark (OCR only picks up text within
+  about 1.5 marker-radii, so it has to be genuinely close) or dropping it on
+  the `.brand` container as a whole instead — either still gets you a role
+  and a path. Whatever you actually see in the dry run is what should be in
+  the take — don't hand-edit `capture.md` to make it look richer than what
+  the app produced.
+- **Clean `last/` folder.** Delete
+  `~/Library/Application Support/Pinpoint/last/` (or just don't worry about
+  it — the next copy replaces it atomically) so `pinpoint last` can't
+  accidentally show a stale capture from earlier testing while you're
+  checking things.
+- **Reset the editor's remembered settings** so the recording starts from a
+  clean, legible state: Task preset → **Raw** (you'll pick **Bug** on
+  camera), marker style → the default filled disc, text format → Markdown
+  (Settings ▸ the agent-text-format picker). These are `@AppStorage`, so
+  whatever you last used is what a fresh capture opens with.
+- **Agent ready.** Have your terminal open with Claude Code (or whichever
+  agent) already running — not launching cold on camera. If you've set up
+  the MCP server (`claude mcp add pinpoint -- pinpoint mcp`), the short
+  version below can lean on it; otherwise the long version's plain
+  file-path prompt works with anything that can read a file, no setup
+  required.
+- **Window sizing.** Resize the browser and the Pinpoint editor to a
+  consistent, deliberate size before recording — 1280×800 keeps the numbers
+  in `capture.md` round and matches the dimensions already used in the
+  README's example. Bump the terminal and browser zoom up a notch: a GIF
+  embedded in a README is usually viewed shrunk, and small text disappears
+  first.
+- **Quiet the rest of the screen.** Turn on Focus/Do Not Disturb so no
+  notification banner drifts across the recording — see **Privacy** below,
+  this is the easiest way to avoid ever needing a retake for it.
+- **Recording tool.** Nothing fancy needed: QuickTime Player ▸ File ▸ New
+  Screen Recording, selecting just the window/region you're demoing. Save as
+  `.mov`.
+
+## Long take — for the README (~30–40s)
+
+One continuous take. Timings are targets, not a metronome — a beat either way
+is fine, but don't let any single step run long enough to feel like dead air
+in a README-embedded clip.
+
+| Time | Action | What must be on screen |
+| --- | --- | --- |
+| 0:00–0:03 | Nothing yet — just sit on the browser window. | `.capture-demo/index.html` open, full page, the misaligned logo mark visible near the top-left. |
+| 0:03–0:04 | Press **⌘⇧1**. | Screen dims; crosshair cursor; the hint *"Drag a rectangle · Space to pick a window · Esc to cancel"*. |
+| 0:04–0:06 | Drag a rectangle around the header (roughly the logo + nav area). | Live width×height readout following the drag. |
+| 0:06–0:08 | Release. Nudge one corner handle a few pixels, to show it's adjustable. Press **Return**. | The 8 resize handles on the rectangle, briefly, before it commits. |
+| 0:08–0:09 | — | The editor window opens on the annotated capture; the Marker tool is already active (it's the default). |
+| 0:09–0:10 | Click once, directly on the logo mark. | Marker **1** drops (ringed badge animates in). |
+| 0:10–0:12 | Type a short note in the marker's field. | e.g. `Icon sits too low` appearing character by character in the Markers list. |
+| 0:12–0:14 | Click the **Task:** picker, choose **Bug**. | The picker's value changing; no need to open its tooltip. |
+| 0:14–0:16 | Click into "Instructions for the agent", type one line. | e.g. `Fix the icon alignment.` |
+| 0:16–0:17 | Press **⌘C**. | The Copy button flashes to **"Copied!"** with a checkmark. |
+| 0:17–0:20 | Cut to the terminal. | Claude Code already running, prompt idle. |
+| 0:20–0:22 | Type the prompt, press Return. | `Open ~/Library/Application Support/Pinpoint/last/capture.md, look at capture.png, and fix the bug it describes.` (If MCP is configured, `Fix the bug I just captured with Pinpoint.` is the shorter equivalent — the agent calls `get_last_capture` itself instead of being told the path.) |
+| 0:22–0:27 | Let the agent's tool calls play out (speed this segment up in editing if it runs long — nobody needs to read every line). | Reads of `capture.md` / `capture.png`, then it opens `.capture-demo/index.html`. |
+| 0:27–0:31 | Cut to the diff. | The edit removing (or zeroing) `transform: translateY(5px);` on `.brand .mark`, clearly readable. |
+| 0:31–0:35 | Cut back to the browser, reload (**⌘R**). | The logo mark now sits flush with the wordmark baseline — the visible payoff. |
+
+That's the whole story: bug → one marker → one instruction → an agent that
+read a file path, not a pasted image, and knew which CSS rule to touch
+because the marker carried more than a percentage.
+
+## Short take — for a social post (~10s)
+
+Same beats, compressed to the point where several of them have to happen
+off-camera or sped up. Pre-typing the note and instruction (paste them in
+rather than typing live) buys back real seconds:
+
+| Time | Action |
+| --- | --- |
+| 0:00–0:02 | ⌘⇧1, drag the rectangle, Return — sped up 2× is fine here, nobody needs to see the drag in real time. |
+| 0:02–0:04 | Click the marker onto the icon; note and instruction already prefilled (pasted, not typed). |
+| 0:04–0:05 | ⌘C — the "Copied!" flash is the beat to hold on. |
+| 0:05–0:07 | Terminal, prompt already typed, hit Return. Tool calls sped up or cut entirely — jump straight past them. |
+| 0:07–0:10 | The fixed page, reloaded, icon aligned. Hold the last frame — this is the payoff people should screenshot. |
+
+If 10 seconds feels impossible to fit honestly, that's a sign to cut the Task
+preset step and the visible tool-call scroll first — they're the least
+essential beats, not the marker or the fix.
+
+## Privacy — don't film anything real
+
+- Turn on Focus/Do Not Disturb before recording (see above) so Mail, Slack,
+  Messages, or calendar notifications can't drift across the shot.
+- Close anything with real data in it — your actual browser tabs/bookmarks
+  bar, real email in a mail client badge, a real Wi-Fi network name if it's
+  identifying. `.capture-demo/index.html` is fake on purpose; keep the rest
+  of the screen that way too.
+- If something real *does* end up in a take and a retake isn't practical:
+  this is exactly what the **Hide** tool (**⌘4**, #50) is for — drag over it,
+  and it's removed from the image *and* stripped out of `capture.md` /
+  `capture.json`, not just visually covered.
+
+## Bonus: a second demo (redaction)
+
+If a take ever needs the Hide tool for real, that's worth keeping as its own
+short clip rather than throwing away — it's a complete demo in its own right
+and nobody has scripted it yet:
+
+1. Put something obviously fake but secret-shaped on screen — a terminal
+   line like `export API_KEY=sk-fake-1234567890` works well, it reads as a
+   real secret at a glance without being one.
+2. Capture, press **⌘4**, drag over the value.
+3. Show the exported image: a solid bar, not a blur — nothing recoverable
+   underneath.
+4. Cut to `capture.md` (or `capture.json`): the field reads *"withheld (the
+   user painted over this element — its name and its contents were left
+   out)"* rather than silently vanishing or leaking the string anyway.
+
+That last beat — the file explicitly saying a value was withheld, not just
+omitting it — is the part worth lingering on; it's what stops a redacted
+capture from quietly leaking through the text half of the handoff while the
+image looks clean.
+
+## Post-production
+
+Trim in QuickTime (⌘T) or `ffmpeg -ss … -to … -i in.mov -c copy trimmed.mov`,
+then convert to GIF with a proper palette pass — a direct `.mov` → `.gif`
+without one looks banded on the vermillon marker color:
+
+```sh
+ffmpeg -i trimmed.mov -vf "fps=15,scale=1280:-1:flags=lanczos,palettegen" palette.png
+ffmpeg -i trimmed.mov -i palette.png \
+  -filter_complex "fps=15,scale=1280:-1:flags=lanczos[x];[x][1:v]paletteuse" \
+  -loop 0 docs/demo.gif
+```
+
+Keep the long take as `docs/demo.gif` (what the README embeds) and the short
+take as a separate file (`docs/demo-short.gif`) rather than overwriting one
+with the other — the social clip is cropped too tight to double as the
+README's.

--- a/landing/src/components/Landing.astro
+++ b/landing/src/components/Landing.astro
@@ -9,11 +9,23 @@ const t = content[lang];
 const alt = otherLang[lang];
 
 const featureIcons = [
+  // Accessibility context — tag
+  'M6 3a3 3 0 00-3 3v4.586a3 3 0 00.879 2.121l7.5 7.5a3 3 0 004.242 0l4.586-4.586a3 3 0 000-4.242l-7.5-7.5A3 3 0 0010.586 3H6z',
+  // On-device text reading — eye
+  'M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z M15 12a3 3 0 11-6 0 3 3 0 016 0z',
+  // Redaction — eye-slash
+  'M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88',
+  // Undo, redo, still editable — u-turn arrow
+  'M9 15L4 10m0 0l5-5m-5 5h11a4 4 0 014 4v2',
+  // Window capture — app window
+  'M4 5a2 2 0 012-2h12a2 2 0 012 2v14a2 2 0 01-2 2H6a2 2 0 01-2-2V5z M4 9h16',
+  // Markers, arrows & rectangles — ringed marker
   'M12 2a10 10 0 100 20 10 10 0 000-20zm0 6a4 4 0 110 8 4 4 0 010-8z',
-  'M5 19L19 5M19 5h-7M19 5v7',
+  // Legend baked in — lines
   'M4 7h16M4 12h16M4 17h10',
+  // The shelf — grid
   'M4 5h7v7H4zM13 5h7v4h-7zM13 12h7v7h-7zM4 15h7v4H4z',
-  'M9 9V7a3 3 0 10-3 3h12a3 3 0 10-3-3v2m-6 0h6m-6 0v6m6-6v6m-6 0a3 3 0 103 3v-2m0-1h0',
+  // Native & private — shield
   'M12 2l8 4v6c0 5-3.5 8-8 10-4.5-2-8-5-8-10V6l8-4z',
 ];
 ---
@@ -175,12 +187,15 @@ const featureIcons = [
       <h2 class="mt-3 text-3xl font-semibold tracking-tight text-white md:text-4xl">{t.agents.title}</h2>
       <p class="mt-5 text-lg leading-relaxed text-zinc-400">{t.agents.body}</p>
     </div>
-    <div class="overflow-hidden rounded-2xl border border-white/10 bg-ink-2 shadow-xl">
-      <div class="flex items-center gap-2 border-b border-white/5 px-4 py-2.5">
-        <span class="h-2.5 w-2.5 rounded-full bg-white/15"></span>
-        <span class="text-xs text-zinc-500">clipboard.txt</span>
+    <div>
+      <div class="overflow-hidden rounded-2xl border border-white/10 bg-ink-2 shadow-xl">
+        <div class="flex items-center gap-2 border-b border-white/5 px-4 py-2.5">
+          <span class="h-2.5 w-2.5 rounded-full bg-white/15"></span>
+          <span class="text-xs text-zinc-500">capture.md</span>
+        </div>
+        <pre class="max-h-[420px] overflow-y-auto whitespace-pre-wrap break-words p-5 text-[13px] leading-relaxed text-zinc-300"><code style="font-family: var(--font-mono)">{t.agents.sample}</code></pre>
       </div>
-      <pre class="overflow-x-auto p-5 text-[13px] leading-relaxed text-zinc-300"><code style="font-family: var(--font-mono)">{t.agents.sample}</code></pre>
+      <p class="mt-4 text-xs leading-relaxed text-zinc-500">{t.agents.access}</p>
     </div>
   </div>
 </section>

--- a/landing/src/i18n.ts
+++ b/landing/src/i18n.ts
@@ -30,7 +30,7 @@ type Content = {
   steps: { title: string; subtitle: string; items: { n: string; t: string; d: string }[] };
   features: { title: string; subtitle: string; items: { t: string; d: string }[] };
   tour: { title: string; subtitle: string; shelf: string; settings: string };
-  agents: { eyebrow: string; title: string; body: string; sample: string };
+  agents: { eyebrow: string; title: string; body: string; sample: string; access: string };
   download: { title: string; body: string; cta: string; req: string; source: string; brew: string };
   footer: { tagline: string; rights: string; os: string };
 };
@@ -62,19 +62,22 @@ export const content: Record<Lang, Content> = {
       items: [
         { n: '1', t: 'Capture a region', d: 'Press ⌘⇧1 and drag a rectangle. Native resolution, multi-display and Retina aware.' },
         { n: '2', t: 'Drop numbered markers', d: 'Click to place pins and add a note to each. Add arrows and rectangles for emphasis.' },
-        { n: '3', t: 'Copy for your agent', d: '⌘C copies the annotated image and a structured text that references every marker.' },
+        { n: '3', t: 'Copy for your agent', d: '⌘C copies the annotated image and a structured text that references every marker — and drops the same three files at a stable path your agent can read on its own.' },
       ],
     },
     features: {
       title: 'Built to be precise',
       subtitle: 'Everything you need to point an agent at the right pixel.',
       items: [
-        { t: 'Numbered markers', d: 'Ringed, numbered pins that stay legible on any background — in three styles.' },
-        { t: 'Arrows & rectangles', d: 'Add visual emphasis right on top of your capture.' },
+        { t: 'Accessibility context', d: 'Each marker also carries what macOS knows about the element under it — role, label, owning app and its frame.' },
+        { t: 'On-device text reading', d: 'Vision reads the text under each marker — errors, class names, log lines — and it travels with the capture.' },
+        { t: 'Redaction', d: 'Drag over a token or a secret before it ships. Hidden in the image, the text and the accessibility context alike.' },
+        { t: 'Undo, redo, still editable', d: '⌘Z through any change. Markers, arrows and rectangles stay selectable, movable and resizable after you drop them.' },
+        { t: 'Window capture', d: 'Hold Space while dragging to snap the selection to a window instead of drawing it freehand.' },
+        { t: 'Markers, arrows & rectangles', d: 'Ringed, numbered pins in three styles, plus arrows and rectangles for emphasis, drawn straight on the capture.' },
         { t: 'Legend baked in', d: 'Optionally embed the marker descriptions and instructions into the image, so a single paste carries everything.' },
-        { t: 'The shelf', d: 'Browse, favorite and reopen your screenshots from a built-in library.' },
-        { t: 'Global shortcuts', d: 'Capture or open the shelf from anywhere — fully rebindable.' },
-        { t: 'Native & private', d: 'SwiftUI + ScreenCaptureKit, living in your menu bar. Your captures never leave your Mac.' },
+        { t: 'The shelf', d: 'Browse, search, favorite and reopen your screenshots from a built-in library.' },
+        { t: 'Native & private', d: 'SwiftUI + ScreenCaptureKit, living in your menu bar. Captures, OCR reads and accessibility context stay on your Mac.' },
       ],
     },
     tour: {
@@ -85,18 +88,32 @@ export const content: Record<Lang, Content> = {
     },
     agents: {
       eyebrow: 'Made for AI agents',
-      title: 'A prompt your agent can actually read',
-      body: 'Most chat UIs paste only the image and drop the clipboard text. Pinpoint can bake the legend into the picture — and always copies a structured prompt that an agent like Claude Code or Codex can parse: image size, each marker’s description and position, then your instructions.',
-      sample: `# Annotated capture — 1280×800 px
+      title: 'The file your agent reads directly',
+      body: 'Every copy also writes capture.png, capture.md and capture.json to a stable path — because Claude Code and most MCP clients don’t render inline images (the upstream bug was closed “not planned”), so a file an agent opens itself is the channel that actually works. capture.md lists each marker’s position in pixels and percent, the accessibility element found under it — role, label, owning app — and whatever text was read there on device. None of it depends on a page’s DOM, so it reads the same in any app.',
+      sample: `# Annotated capture — 1720×1046 px
 
 An image is attached. Numbered (ringed) badges point to specific elements.
-Markers (position in % of the image, top-left origin):
+Positions are given in pixels from the top-left corner (0, 0), then as a percentage of the image size.
 
-1. Primary CTA button · ~62 % × 48 %
-2. Misaligned icon · ~12 % × 22 %
+## Markers
+M1, M2… are the numbers drawn on the image; the code in brackets is a stable ID for that marker.
+“UI” lines name the interface element found under the marker in the macOS accessibility tree at capture time — its role, its label, the app owning it, and its box in this image. “Path” is the chain of containers around it.
+“Text” lines are what Pinpoint read in the pixels under the marker, on this Mac. A marker’s description may have been pre-filled from such a read and then edited by the user.
+
+- M1 [5a5421] · overflows its card at this width — (1264, 127) px · (74 %, 12 %)
+  - UI: AXButton “Export CSV” · id=export-csv · com.apple.Safari · box (1178, 99) 162×52 px
+  - Path: AXWindow “Orders — Admin” › AXButton “Export CSV”
+- M2 [010661] · error stays after a valid range is picked — (249, 254) px · (14 %, 24 %)
+  - UI: AXWindow “Orders — Admin” · com.apple.Safari · box (0, 0) 1720×1046 px
+  - Path: AXWindow “Orders — Admin”
+  - Text: “Invalid date range: end must be after start”
+
+## Task — Bug
+The markers point at a defect. Find its cause before proposing anything: locate the code that produces what is marked, explain why it behaves this way, then propose the smallest change that addresses the cause rather than the symptom. If the capture isn’t enough to be sure, say what you would need to look at.
 
 ## Instructions
-Make the CTA full-width on mobile and fix the icon alignment.`,
+The Export CSV button overflows its card at this width, and the date-range error stays on screen after picking a valid range.`,
+      access: 'Reachable without the editor too: `pinpoint capture` from a script or a hook, or `pinpoint mcp` as a stdio MCP server exposing capture_region, get_last_capture and list_recent.',
     },
     download: {
       title: 'Get Pinpoint',
@@ -135,19 +152,22 @@ Make the CTA full-width on mobile and fix the icon alignment.`,
       items: [
         { n: '1', t: 'Capture une région', d: 'Appuie sur ⌘⇧1 et trace un rectangle. Résolution native, multi-écran et Retina.' },
         { n: '2', t: 'Pose des repères numérotés', d: 'Clique pour placer des repères et ajoute une note à chacun. Flèches et rectangles pour appuyer.' },
-        { n: '3', t: 'Copie pour ton agent', d: '⌘C copie l’image annotée et un texte structuré qui référence chaque repère.' },
+        { n: '3', t: 'Copie pour ton agent', d: '⌘C copie l’image annotée et un texte structuré qui référence chaque repère — et dépose les mêmes fichiers à un chemin stable que ton agent peut lire seul.' },
       ],
     },
     features: {
       title: 'Conçu pour la précision',
       subtitle: 'Tout ce qu’il faut pour pointer un agent sur le bon pixel.',
       items: [
-        { t: 'Repères numérotés', d: 'Des pastilles numérotées et cerclées, lisibles sur n’importe quel fond — en trois styles.' },
-        { t: 'Flèches & rectangles', d: 'Ajoute de l’emphase visuelle directement sur ta capture.' },
+        { t: 'Contexte d’accessibilité', d: 'Chaque repère porte aussi ce que macOS sait de l’élément dessous — rôle, libellé, app propriétaire et son cadre.' },
+        { t: 'Lecture de texte sur l’appareil', d: 'Vision lit le texte sous chaque repère — erreurs, noms de classes, lignes de log — et il voyage avec la capture.' },
+        { t: 'Rédaction', d: 'Glisse sur un jeton ou un secret avant qu’il ne parte. Masqué dans l’image, le texte et le contexte d’accessibilité à la fois.' },
+        { t: 'Annuler, rétablir, toujours modifiable', d: '⌘Z pour revenir sur tout changement. Repères, flèches et rectangles restent sélectionnables, déplaçables et redimensionnables après coup.' },
+        { t: 'Capture de fenêtre', d: 'Maintiens Espace en traçant pour aimanter la sélection à une fenêtre plutôt que de la dessiner à main levée.' },
+        { t: 'Repères, flèches & rectangles', d: 'Des pastilles numérotées et cerclées en trois styles, plus des flèches et des rectangles pour appuyer, dessinés sur la capture.' },
         { t: 'Légende incrustée', d: 'Incruste si tu veux les descriptions et les instructions dans l’image, pour qu’un seul collage transmette tout.' },
-        { t: 'L’étagère', d: 'Parcours, mets en favori et rouvre tes captures depuis une bibliothèque intégrée.' },
-        { t: 'Raccourcis globaux', d: 'Capture ou ouvre l’étagère depuis n’importe où — entièrement reconfigurables.' },
-        { t: 'Natif & privé', d: 'SwiftUI + ScreenCaptureKit, dans ta barre de menus. Tes captures ne quittent jamais ton Mac.' },
+        { t: 'L’étagère', d: 'Parcours, recherche, mets en favori et rouvre tes captures depuis une bibliothèque intégrée.' },
+        { t: 'Natif & privé', d: 'SwiftUI + ScreenCaptureKit, dans ta barre de menus. Captures, lectures OCR et contexte d’accessibilité restent sur ton Mac.' },
       ],
     },
     tour: {
@@ -158,18 +178,32 @@ Make the CTA full-width on mobile and fix the icon alignment.`,
     },
     agents: {
       eyebrow: 'Pensé pour les agents IA',
-      title: 'Un prompt que ton agent sait vraiment lire',
-      body: 'La plupart des interfaces de chat ne collent que l’image et perdent le texte. Pinpoint peut incruster la légende dans l’image — et copie toujours un prompt structuré qu’un agent comme Claude Code ou Codex sait analyser : taille de l’image, description et position de chaque repère, puis tes instructions.',
-      sample: `# Capture annotée — 1280×800 px
+      title: 'Le fichier que ton agent lit directement',
+      body: 'Chaque copie écrit aussi capture.png, capture.md et capture.json à un chemin stable — parce que Claude Code et la plupart des clients MCP ne rendent pas les images renvoyées en ligne (le bug amont a été fermé « not planned »), donc un fichier que l’agent ouvre lui-même est le seul canal qui marche vraiment. capture.md liste la position de chaque repère en pixels et en pourcentage, l’élément d’accessibilité trouvé dessous — rôle, libellé, app propriétaire — et le texte éventuellement lu à cet endroit, sur l’appareil. Rien de tout ça ne dépend du DOM d’une page : ça marche pareil dans n’importe quelle app.',
+      sample: `# Capture annotée — 1720×1046 px
 
 Une image est jointe. Des pastilles numérotées (cerclées) pointent des éléments précis.
-Repères (position en % de l’image, origine haut-gauche) :
+Les positions sont données en pixels depuis le coin haut-gauche (0, 0), puis en pourcentage de la taille de l’image.
 
-1. Bouton d’action principal · ~62 % × 48 %
-2. Icône mal alignée · ~12 % × 22 %
+## Repères
+M1, M2… correspondent aux numéros dessinés sur l’image ; le code entre crochets est un identifiant stable de ce repère.
+Les lignes « UI » nomment l’élément d’interface trouvé sous le repère dans l’arbre d’accessibilité macOS au moment de la capture — son rôle, son libellé, l’app qui le possède et sa boîte dans cette image. « Path » est la chaîne de conteneurs qui l’entoure.
+Les lignes « Text » sont ce que Pinpoint a lu dans les pixels sous le repère, sur ce Mac. La description d’un repère a pu être pré-remplie à partir d’une telle lecture, puis modifiée par l’utilisateur.
+
+- M1 [4ecd13] · déborde de sa carte à cette largeur — (1264, 127) px · (74 %, 12 %)
+  - UI: AXButton “Export CSV” · id=export-csv · com.apple.Safari · box (1178, 99) 162×52 px
+  - Path: AXWindow “Orders — Admin” › AXButton “Export CSV”
+- M2 [6f42cb] · l’erreur reste affichée après une plage valide — (249, 254) px · (14 %, 24 %)
+  - UI: AXWindow “Orders — Admin” · com.apple.Safari · box (0, 0) 1720×1046 px
+  - Path: AXWindow “Orders — Admin”
+  - Text: “Invalid date range: end must be after start”
+
+## Tâche — Bug
+Les repères désignent un défaut. Cherchez-en la cause avant de proposer quoi que ce soit : localisez le code qui produit ce qui est marqué, expliquez pourquoi il se comporte ainsi, puis proposez la plus petite modification qui traite la cause plutôt que le symptôme. Si la capture ne suffit pas à en être sûr, dites ce qu’il faudrait aller regarder.
 
 ## Instructions
-Passe le bouton en pleine largeur sur mobile et corrige l’alignement de l’icône.`,
+Le bouton Exporter en CSV déborde de sa carte à cette largeur, et l’erreur de plage de dates reste affichée après avoir choisi une plage valide.`,
+      access: 'Accessible aussi sans passer par l’éditeur : `pinpoint capture` depuis un script ou un hook, ou `pinpoint mcp` comme serveur MCP en stdio, qui expose capture_region, get_last_capture et list_recent.',
     },
     download: {
       title: 'Obtiens Pinpoint',


### PR DESCRIPTION
Suite de la release v0.7.0 : la documentation et le site rattrapent ce que la version apporte réellement.

## Pourquoi
La section « For agents » de la landing et l'exemple de prompt du README montraient encore une sortie d'une génération précédente — repères en pourcentages seuls, sans pixels, sans identifiants, sans description des formes, sans contexte d'accessibilité ni OCR. Autrement dit, les deux vitrines du projet ignoraient le différenciateur de la 0.7.0.

## Contenu

- **Landing** (#87) — section « For agents » réécrite (`title`, `body`, `sample`) et `features.items` passé de 6 à 9 entrées, en anglais **et** en français. L'échantillon de `capture.md` est une vraie sortie, produite en compilant `Exporter.buildText` avec `Pin`/`Markup`/`AXSnapshot`/`TaskPreset` ; la version française vient du même binaire relancé sous `-AppleLanguages '(fr)'`, donc du vrai catalogue de traduction de l'app, sans traduction manuelle. Une légende sous l'exemple cite `pinpoint capture` et `pinpoint mcp` plutôt qu'une section CLI/MCP séparée qui aurait fait doublon.
- **README** (#86) — section Features à jour (undo/redo, rédaction, OCR, contexte d'accessibilité, mode fenêtre, rectangle ajustable, presets), nouvelle section sur les permissions (Enregistrement de l'écran obligatoire, Accessibilité optionnelle et ce qu'on perd sans), et exemple de prompt régénéré par un harnais exécutant le vrai `Exporter.buildText`.
- **`docs/demo-script.md`** (nouveau) — scénario de tournage minuté du GIF de démo, en version courte (~10 s, réseaux) et longue (~30-40 s, README), avec checklist de préparation et pièges de confidentialité. L'enregistrement lui-même reste à faire à la main.

Vérifié : `npm run build` de la landing vert, `xcodegen` + `xcodebuild` verts, CI verte sur les deux PR.

Note issue de l'audit du worker : `.demo-remotion/` est une recréation Remotion de l'ancien flux, pas un outil de capture — à ne pas réutiliser tel quel. `.capture-demo/index.html` contient en revanche un bug réel directement utilisable pour le tournage.