### PR TITLE
Installer l'outil en ligne de commande depuis l'app (#89)

### DIFF
--- a/Pinpoint/AppDelegate.swift
+++ b/Pinpoint/AppDelegate.swift
@@ -184,6 +184,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         let settingsItem = NSMenuItem(title: String(localized: "Settings…"), action: #selector(openSettings), keyEquivalent: ",")
         settingsItem.target = self
         menu.addItem(settingsItem)
+
+        // Opens the same Settings window rather than installing on the spot
+        // (#89): the elevation prompt and the install/remove state belong
+        // together in one place, not split between a menu click and a
+        // separate window. This item exists purely for discoverability — someone
+        // who never opens Settings still sees that the CLI can be installed.
+        let installCLIItem = NSMenuItem(title: String(localized: "Install Command Line Tool…"), action: #selector(openSettings), keyEquivalent: "")
+        installCLIItem.target = self
+        menu.addItem(installCLIItem)
         menu.addItem(.separator())
 
         menu.addItem(NSMenuItem(title: String(localized: "Quit Pinpoint"), action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q"))

--- a/Pinpoint/CLIInstaller.swift
+++ b/Pinpoint/CLIInstaller.swift
@@ -1,0 +1,265 @@
+import AppKit
+import Foundation
+
+/// Puts the bundled `pinpoint` CLI (#56) on a Terminal's `PATH` after a plain
+/// DMG install (#89).
+///
+/// The Homebrew cask already does this with a `binary` stanza, but someone who
+/// dragged Pinpoint.app out of a DMG has no such thing — the README used to
+/// tell them to `ln -s` it into `/usr/local/bin` themselves, which fails for
+/// most people (root-owned directory, often missing outright on a fresh Mac).
+/// This is that same one `ln -s`, done for them, modelled on VS Code's
+/// "Install 'code' command in PATH".
+///
+/// Three rules shape everything below:
+/// - Never write into `/opt/homebrew/bin` — that is Homebrew's territory, read
+///   only to notice it already did the job.
+/// - Never touch a `pinpoint` we didn't create ourselves, even one that
+///   happens to resolve to the exact same bundle (see `computeStatus`).
+/// - Never claim success without actually running the installed command.
+@MainActor
+final class CLIInstaller: ObservableObject {
+    static let shared = CLIInstaller()
+
+    enum Status: Equatable {
+        case checking
+        case notInstalled
+        /// A symlink Pinpoint created itself, still resolving to a real CLI.
+        case installedByPinpoint
+        /// Something already answers to `pinpoint` on the PATH that Pinpoint
+        /// did not put there — Homebrew's cask, or a manual link from the old
+        /// README. Left alone.
+        case installedExternally
+        /// Pinpoint's own link now points at a bundle that moved or was
+        /// deleted. Offered the same "Install" action to re-point it.
+        case brokenPinpointLink
+        /// The last install/remove attempt failed; the message is already
+        /// user-facing and localized.
+        case failed(String)
+    }
+
+    /// Where Pinpoint installs its own link. Chosen over `/opt/homebrew/bin`
+    /// because it needs no Homebrew installation to already exist, and it is
+    /// the directory the old README instructions (and most "install a CLI
+    /// tool by hand" advice) already point at.
+    ///
+    /// `nonisolated`: these are immutable constants read from the detached
+    /// tasks below (privileged execution and verification must not block the
+    /// main actor), not app state that needs actor protection.
+    private nonisolated static let installDirectory = URL(fileURLWithPath: "/usr/local/bin")
+    private nonisolated static let linkURL = installDirectory.appendingPathComponent("pinpoint")
+    /// The other place a `pinpoint` might already live. Read-only: this is how
+    /// an existing Homebrew install is recognized, never a second target to
+    /// write to.
+    private nonisolated static let homebrewCandidatePath = "/opt/homebrew/bin/pinpoint"
+
+    private static let recordedLinkKey = "cliInstall.linkPath"
+
+    @Published private(set) var status: Status = .checking
+    @Published private(set) var isWorking = false
+
+    private init() {
+        refresh()
+    }
+
+    /// Re-reads the filesystem. Cheap local `stat` calls, so this is called
+    /// every time the Settings section appears rather than cached — Homebrew
+    /// or a Terminal session could have changed things since Pinpoint last
+    /// looked.
+    func refresh() {
+        let recorded = UserDefaults.standard.string(forKey: Self.recordedLinkKey)
+        status = Self.computeStatus(recordedLinkPath: recorded)
+    }
+
+    /// Creates (or repairs) the link, asking for administrator privileges
+    /// exactly once for the whole operation, then proves it actually works
+    /// before calling it installed.
+    func install() async {
+        isWorking = true
+        defer { isWorking = false }
+
+        let target = Bundle.main.bundleURL.appendingPathComponent("Contents/Helpers/pinpoint")
+        guard FileManager.default.fileExists(atPath: target.path) else {
+            status = .failed(String(
+                localized: "settings.cli.error.missingBinary",
+                defaultValue: "The pinpoint tool couldn’t be found inside this app. Try reinstalling Pinpoint."
+            ))
+            return
+        }
+
+        // One privileged call for both steps (#89 pitfall 3): `/usr/local/bin`
+        // may not exist yet, and a second dialog right after the first would
+        // read as the app being confused rather than thorough.
+        let shell = "mkdir -p \(Self.shellQuote(Self.installDirectory.path))"
+            + " && ln -sf \(Self.shellQuote(target.path)) \(Self.shellQuote(Self.linkURL.path))"
+
+        do {
+            try await Self.runElevated(shell)
+        } catch ElevationError.cancelled {
+            // #89 pitfall 4: closing the auth dialog is a normal "never mind",
+            // not a failure — back to whatever was true before, no alert.
+            refresh()
+            return
+        } catch {
+            status = .failed(String(
+                localized: "settings.cli.error.install",
+                defaultValue: "Couldn’t install the command line tool: \(error.localizedDescription)"
+            ))
+            return
+        }
+
+        UserDefaults.standard.set(Self.linkURL.path, forKey: Self.recordedLinkKey)
+
+        // #89 pitfall 5: a symlink that exists is not the same claim as "the
+        // command works". Run the thing a Terminal would run.
+        guard await Self.verifyInstalledCLIResponds() else {
+            try? FileManager.default.removeItem(at: Self.linkURL)
+            UserDefaults.standard.removeObject(forKey: Self.recordedLinkKey)
+            status = .failed(String(
+                localized: "settings.cli.error.verify",
+                defaultValue: "The link was created, but pinpoint --version didn’t respond. Nothing was left in place."
+            ))
+            return
+        }
+
+        refresh()
+    }
+
+    /// Removes Pinpoint's own link. Never reachable from the UI unless
+    /// `status == .installedByPinpoint`, so there is nothing to re-check here
+    /// (#89 pitfall 6) — the gate lives in `computeStatus`, once, not twice.
+    func remove() async {
+        isWorking = true
+        defer { isWorking = false }
+
+        let shell = "rm -f \(Self.shellQuote(Self.linkURL.path))"
+
+        do {
+            try await Self.runElevated(shell)
+        } catch ElevationError.cancelled {
+            refresh()
+            return
+        } catch {
+            status = .failed(String(
+                localized: "settings.cli.error.remove",
+                defaultValue: "Couldn’t remove the command line tool: \(error.localizedDescription)"
+            ))
+            return
+        }
+
+        UserDefaults.standard.removeObject(forKey: Self.recordedLinkKey)
+        refresh()
+    }
+
+    // MARK: - State
+
+    private nonisolated static func computeStatus(recordedLinkPath: String?) -> Status {
+        let fileManager = FileManager.default
+
+        // Pinpoint's own record wins first. This is the only way to tell
+        // "Pinpoint installed this" from "Homebrew installed this" apart when
+        // both would resolve to the very same `/Applications/Pinpoint.app` —
+        // the path alone can't disambiguate that (#89 pitfall 2).
+        if let recordedLinkPath {
+            if let resolved = resolvedTarget(ofSymlinkAt: recordedLinkPath) {
+                return isValidCLIBinary(at: resolved) ? .installedByPinpoint : .brokenPinpointLink
+            }
+            // Recorded, but nothing is there anymore (removed outside
+            // Pinpoint, e.g. `brew uninstall` clobbering the same path) — fall
+            // through and look at the world fresh.
+        }
+
+        for path in [linkURL.path, homebrewCandidatePath] {
+            guard let resolved = resolvedTarget(ofSymlinkAt: path), isValidCLIBinary(at: resolved) else { continue }
+            return .installedExternally
+        }
+
+        return .notInstalled
+
+        func resolvedTarget(ofSymlinkAt path: String) -> String? {
+            guard let destination = try? fileManager.destinationOfSymbolicLink(atPath: path) else { return nil }
+            if destination.hasPrefix("/") { return destination }
+            return (path as NSString).deletingLastPathComponent + "/" + destination
+        }
+
+        func isValidCLIBinary(at path: String) -> Bool {
+            fileManager.fileExists(atPath: path) && path.contains(".app/Contents/Helpers/pinpoint")
+        }
+    }
+
+    // MARK: - Privileged execution
+
+    private enum ElevationError: Error {
+        case cancelled
+        case failed(String)
+    }
+
+    /// Runs `shellCommand` with `do shell script … with administrator
+    /// privileges` — the standard macOS auth dialog, and the one route that
+    /// works from a notarized, non-sandboxed app without a separate
+    /// `SMJobBless` helper (overkill for a single symlink) or the long-
+    /// deprecated `AuthorizationExecuteWithPrivileges`.
+    ///
+    /// Runs off the main actor: `NSAppleScript.executeAndReturnError` blocks
+    /// for as long as the auth dialog is on screen, which must not freeze the
+    /// Settings window's spinner.
+    private nonisolated static func runElevated(_ shellCommand: String) async throws {
+        try await Task.detached(priority: .userInitiated) {
+            let source = "do shell script \"\(appleScriptQuote(shellCommand))\" with administrator privileges"
+            guard let script = NSAppleScript(source: source) else {
+                throw ElevationError.failed("Couldn’t build the privileged command.")
+            }
+            var errorInfo: NSDictionary?
+            script.executeAndReturnError(&errorInfo)
+            guard let errorInfo else { return }
+
+            // -128 is AppleScript's "user cancelled" across every flavor of
+            // `with administrator privileges` dialog, closed button or Esc alike.
+            if (errorInfo[NSAppleScript.errorNumber] as? Int) == -128 {
+                throw ElevationError.cancelled
+            }
+            let message = errorInfo[NSAppleScript.errorMessage] as? String ?? "Unknown error."
+            throw ElevationError.failed(message)
+        }.value
+    }
+
+    /// Runs the link a Terminal would run and checks it actually answers —
+    /// not just that a file with the right name exists at the right path.
+    private nonisolated static func verifyInstalledCLIResponds() async -> Bool {
+        await Task.detached(priority: .userInitiated) {
+            let process = Process()
+            process.executableURL = linkURL
+            process.arguments = ["--version"]
+            let stdout = Pipe()
+            process.standardOutput = stdout
+            process.standardError = Pipe()
+
+            do {
+                try process.run()
+            } catch {
+                return false
+            }
+            process.waitUntilExit()
+
+            let output = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            return process.terminationStatus == 0 && output.lowercased().contains("pinpoint")
+        }.value
+    }
+
+    /// Quotes `value` as a single-quoted shell literal — the standard POSIX
+    /// trick of closing the quote, escaping a literal `'`, and reopening it —
+    /// so a bundle path containing a space or an apostrophe (the app can run
+    /// from anywhere, including a messily-named folder in ~/Downloads) can't
+    /// break the command it's embedded in.
+    private nonisolated static func shellQuote(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    /// Escapes an already shell-quoted command so it can sit inside the
+    /// double-quoted AppleScript string literal `do shell script "…"` needs.
+    private nonisolated static func appleScriptQuote(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+}

--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -758,6 +758,11 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Survole une fenêtre · clique pour capturer · Espace pour un rectangle · Échap pour annuler" } }
       }
     },
+    "Install Command Line Tool…" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Installer l’outil en ligne de commande…" } }
+      }
+    },
     "Instructions for the agent" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Instructions pour l’agent" } }
@@ -1075,6 +1080,72 @@
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Describe the element under each marker" } },
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Décrire l’élément sous chaque repère" } }
+      }
+    },
+    "settings.cli.action.remove" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Remove Command Line Tool…" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Retirer l’outil en ligne de commande…" } }
+      }
+    },
+    "settings.cli.error.install" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Couldn’t install the command line tool: %@" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Impossible d’installer l’outil en ligne de commande : %@" } }
+      }
+    },
+    "settings.cli.error.missingBinary" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "The pinpoint tool couldn’t be found inside this app. Try reinstalling Pinpoint." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Impossible de trouver l’outil pinpoint dans cette app. Essayez de réinstaller Pinpoint." } }
+      }
+    },
+    "settings.cli.error.remove" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Couldn’t remove the command line tool: %@" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Impossible de retirer l’outil en ligne de commande : %@" } }
+      }
+    },
+    "settings.cli.error.verify" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "The link was created, but pinpoint --version didn’t respond. Nothing was left in place." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Le lien a été créé, mais pinpoint --version n’a pas répondu. Rien n’a été laissé en place." } }
+      }
+    },
+    "settings.cli.explanation" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Puts pinpoint on your Terminal’s PATH by creating one link in /usr/local/bin, so scripts and AI agents can call it directly — the same tool the Homebrew cask already provides this way. Needs administrator approval once, to create the link." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Place pinpoint dans le PATH de votre Terminal en créant un lien dans /usr/local/bin, pour que les scripts et les agents IA puissent l’appeler directement — le même outil que fournit déjà le cask Homebrew de cette façon. Nécessite une autorisation d’administrateur, une seule fois, pour créer le lien." } }
+      }
+    },
+    "settings.cli.section" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Command line tool" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Outil en ligne de commande" } }
+      }
+    },
+    "settings.cli.status.broken" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "This link points to a copy of Pinpoint that’s no longer there." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Ce lien pointe vers une copie de Pinpoint qui n’est plus là." } }
+      }
+    },
+    "settings.cli.status.external" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Already available — installed by Homebrew, or linked by hand. Pinpoint leaves it as is." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Déjà disponible — installé par Homebrew, ou lié à la main. Pinpoint n’y touche pas." } }
+      }
+    },
+    "settings.cli.status.installed" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Installed — pinpoint runs from any Terminal (/usr/local/bin/pinpoint)." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Installé — pinpoint fonctionne depuis n’importe quel Terminal (/usr/local/bin/pinpoint)." } }
+      }
+    },
+    "settings.cli.status.notInstalled" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Not installed — Terminal commands and AI agents can’t find pinpoint yet." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Non installé — les commandes de Terminal et les agents IA ne trouvent pas encore pinpoint." } }
       }
     },
     "settings.format.explanation" : {

--- a/Pinpoint/PinpointApp.swift
+++ b/Pinpoint/PinpointApp.swift
@@ -69,6 +69,8 @@ struct CaptureSettingsView: View {
     /// there's nothing to observe here beyond "the user came back to us".
     @State private var isTrusted = AXPermission.isTrusted
 
+    @ObservedObject private var cli = CLIInstaller.shared
+
     var body: some View {
         Form {
             Section("Shortcuts") {
@@ -122,6 +124,7 @@ struct CaptureSettingsView: View {
             }
             accessibilitySection
             textRecognitionSection
+            commandLineSection
         }
         .formStyle(.grouped)
         // Coming back from System Settings is the moment the answer can have
@@ -129,6 +132,7 @@ struct CaptureSettingsView: View {
         .onReceive(NotificationCenter.default.publisher(
             for: NSApplication.didBecomeActiveNotification)) { _ in
             isTrusted = AXPermission.isTrusted
+            cli.refresh()
         }
     }
 
@@ -191,6 +195,80 @@ struct CaptureSettingsView: View {
                         defaultValue: "Pre-fills a marker’s description with the line of text it points at, and writes that line into the files for the agent — so small text an agent would misread from the image travels as text. Read on this Mac; nothing is sent anywhere. Areas you have hidden are never read."))
                 .foregroundStyle(.secondary)
                 .font(.callout)
+        }
+    }
+
+    /// Puts `pinpoint` on a Terminal's `PATH` after a plain DMG install (#89):
+    /// the Homebrew cask already does this itself, so the whole section is
+    /// about the download that doesn't come with a `binary` stanza.
+    ///
+    /// Modelled on the ax/ocr sections above: state first, one button whose
+    /// label follows that state, nothing else to configure.
+    private var commandLineSection: some View {
+        Section(String(localized: "settings.cli.section", defaultValue: "Command line tool")) {
+            Text(String(
+                localized: "settings.cli.explanation",
+                defaultValue: "Puts pinpoint on your Terminal’s PATH by creating one link in /usr/local/bin, so scripts and AI agents can call it directly — the same tool the Homebrew cask already provides this way. Needs administrator approval once, to create the link."
+            ))
+            .foregroundStyle(.secondary)
+            .font(.callout)
+
+            switch cli.status {
+            case .checking:
+                ProgressView()
+
+            case .notInstalled, .brokenPinpointLink:
+                if case .brokenPinpointLink = cli.status {
+                    Label(String(
+                        localized: "settings.cli.status.broken",
+                        defaultValue: "This link points to a copy of Pinpoint that’s no longer there."
+                    ), systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                } else {
+                    Label(String(
+                        localized: "settings.cli.status.notInstalled",
+                        defaultValue: "Not installed — Terminal commands and AI agents can’t find pinpoint yet."
+                    ), systemImage: "xmark.circle")
+                    .foregroundStyle(.secondary)
+                }
+                installButton
+
+            case .installedByPinpoint:
+                Label(String(
+                    localized: "settings.cli.status.installed",
+                    defaultValue: "Installed — pinpoint runs from any Terminal (/usr/local/bin/pinpoint)."
+                ), systemImage: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+                Button(String(localized: "settings.cli.action.remove", defaultValue: "Remove Command Line Tool…")) {
+                    Task { await cli.remove() }
+                }
+                .disabled(cli.isWorking)
+
+            case .installedExternally:
+                Label(String(
+                    localized: "settings.cli.status.external",
+                    defaultValue: "Already available — installed by Homebrew, or linked by hand. Pinpoint leaves it as is."
+                ), systemImage: "checkmark.circle")
+                .foregroundStyle(.secondary)
+
+            case .failed(let message):
+                Text(message)
+                    .foregroundStyle(.red)
+                installButton
+            }
+        }
+    }
+
+    private var installButton: some View {
+        HStack {
+            Button(String(localized: "Install Command Line Tool…")) {
+                Task { await cli.install() }
+            }
+            .disabled(cli.isWorking)
+            if cli.isWorking {
+                ProgressView()
+                    .controlSize(.small)
+            }
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -277,8 +277,14 @@ A file path is the channel that reliably works.
 
 Pinpoint ships a small command-line tool **inside the app bundle**, at
 `Pinpoint.app/Contents/Helpers/pinpoint`, so it is signed and notarized with the
-app. The Homebrew cask symlinks it onto your `PATH`; after a direct download,
-link it yourself:
+app. The Homebrew cask symlinks it onto your `PATH` automatically. After a
+direct DMG download, open **Pinpoint ▸ Settings ▸ Capture ▸ Command line
+tool ▸ Install Command Line Tool…** — it creates the same link in
+`/usr/local/bin`, asks for administrator approval once, and confirms the
+command actually responds before calling it done.
+
+Prefer doing it by hand, or scripting the install itself? The manual version
+still works:
 
 ```sh
 ln -s "/Applications/Pinpoint.app/Contents/Helpers/pinpoint" /usr/local/bin/pinpoint


### PR DESCRIPTION
## Résumé

Depuis la 0.7.0, `pinpoint` (CLI + `pinpoint mcp`) vit dans
`Pinpoint.app/Contents/Helpers/pinpoint`. Le cask Homebrew le met sur le
`PATH` via une stanza `binary`, mais un DMG direct ne fait rien de tel — le
README ne proposait qu'un `ln -s /usr/local/bin/pinpoint` manuel, qui échoue
pour la plupart des gens (`/usr/local/bin` appartient à `root` et n'existe
pas toujours sur un Mac récent sans Homebrew).

Ajoute une action **« Installer l'outil en ligne de commande… »**, sur le
modèle de VS Code (« Install 'code' command in PATH »).

## Où : Réglages (état) + menu (découvrabilité)

Nouvelle section **« Command line tool »** dans **Réglages ▸ Capture** —
c'est là que vit déjà « Agent sharing », et c'est une action ponctuelle dont
l'**état** (installé / non installé / fourni par Homebrew) compte autant que
l'action ; un `Form` sait afficher cet état, une entrée de menu non.

Le menu de la barre d'état gagne aussi une entrée du même nom, qui **ouvre
Réglages** plutôt que d'installer sur-le-champ : le dialogue d'élévation et
l'état installé/retiré doivent rester au même endroit, pas être scindés
entre un clic de menu et une fenêtre séparée. Elle existe uniquement pour la
découvrabilité — quelqu'un qui n'ouvre jamais Réglages voit quand même que
le CLI peut s'installer.

## Comment (`Pinpoint/CLIInstaller.swift`)

- **Jamais de chemin en dur** : la cible est toujours
  `Bundle.main.bundleURL.appendingPathComponent("Contents/Helpers/pinpoint")`
  — fonctionne depuis `~/Downloads`, un volume externe ou un worktree de dev.
- **Détection Homebrew (et lien manuel)** : si `/usr/local/bin/pinpoint` ou
  `/opt/homebrew/bin/pinpoint` résout déjà vers un `Pinpoint.app` valide,
  affiché comme « déjà disponible » et **jamais écrasé**. Le seul moyen fiable
  de distinguer « posé par Pinpoint » de « posé par Homebrew » quand les deux
  résoudraient vers le même `/Applications/Pinpoint.app` est un enregistrement
  explicite (`UserDefaults`) du chemin que Pinpoint a lui-même créé — sans
  cet enregistrement, tout ce qui occupe déjà la place est traité comme
  externe et laissé intact.
- **`/usr/local/bin` peut être à créer** : `mkdir -p … && ln -sf …` passe dans
  **un seul** `do shell script … with administrator privileges`
  (`NSAppleScript`), donc une seule demande d'élévation pour toute
  l'opération. Jamais d'écriture dans `/opt/homebrew/bin` : c'est le
  territoire de Homebrew, seulement lu pour détecter son travail.
- **Annulation = état normal** : `-128` (utilisateur ferme le dialogue) revient
  à l'état précédent, sans alerte.
- **Succès vérifié, pas supposé** : après la création du lien, exécute
  vraiment `pinpoint --version` sur le lien installé et vérifie la sortie
  avant d'afficher « Installé » (cf. #38 — jamais annoncer un succès non
  vérifié). Si ça ne répond pas, le lien est retiré et une erreur s'affiche.
- **Retrait symétrique** : seulement proposé quand `status ==
  .installedByPinpoint`, donc jamais sur un lien que Pinpoint n'a pas posé.
- Quoting shell/AppleScript propre (le bundle peut vivre dans un dossier au
  nom quelconque, espaces ou apostrophes compris) pour éviter toute injection
  shell dans la commande privilégiée.

Pas d'entitlement touché : l'app reste non sandboxée avec
`ENABLE_HARDENED_RUNTIME: YES` (grant TCC Enregistrement de l'écran) —
`NSAppleScript` + `with administrator privileges` fonctionne tel quel dans
une app notariée non sandboxée, pas besoin d'entitlement supplémentaire.

## i18n

Toutes les chaînes visibles passent par `String(localized:)`, présentes en
`en` et `fr` dans `Localizable.xcstrings`, insérées à leur place alphabétique
dans le catalogue (`settings.cli.*` entre `settings.ax.*` et
`settings.format.*`).

## README

La section CLI pointe maintenant vers Réglages ▸ Capture ▸ Command line
tool, en gardant le `ln -s` manuel en repli pour qui préfère.

## Vérification

- `xcodegen generate` + `xcodebuild -scheme Pinpoint -destination
  'platform=macOS' CODE_SIGNING_ALLOWED=NO build` : **vert**.
- Build local (DerivedData de ce worktree, jamais `/Applications`) : le CLI
  embarqué répond bien (`pinpoint --version` → `pinpoint 0.7.0`) ; le
  catalogue de strings compilé a été inspecté directement (`plutil -p` sur
  les `.strings` compilés) et porte bien les bonnes clés/traductions en et fr.
- **Limite honnête** : je n'ai pas pu boucler le clic-à-clic complet dans cet
  environnement. Une vraie instance 0.7.0 de Pinpoint tournait déjà sur la
  machine de test avec le **même bundle identifier** que le build de ce
  worktree ; l'automation de la barre de menu s'est avérée ambiguë entre les
  deux process (elle a fini par lire le menu de la **vraie** app plutôt que
  celui du build de dev, sans rien y cliquer ni la perturber — juste ouvert
  puis refermé au clavier). Compléter l'installation réelle demanderait par
  ailleurs le mot de passe administrateur de la machine, que je n'ai pas et
  ne demanderai pas. Aucun lien n'a été créé sur la machine
  (`/usr/local/bin/pinpoint` et `/opt/homebrew/bin/pinpoint` toujours absents
  après coup, aucune clé `UserDefaults` écrite), et l'app réelle tourne
  encore normalement. À vérifier manuellement en local avant de merger :
  clic sur le bouton, dialogue d'authentification, `pinpoint --version`
  répond, puis retrait.

Closes #89