### PR TITLE
Prépare la v0.7.1 — changelog et bump de version

### DIFF
--- a/landing/src/changelog.ts
+++ b/landing/src/changelog.ts
@@ -16,9 +16,16 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
-    version: '0.7.0',
+    version: '0.7.1',
     date: '2026-08-21',
     latest: true,
+    changes: [
+      { type: 'added', text: 'Install the pinpoint command from the app — Settings ▸ Capture now has a “Command line tool” section that puts pinpoint on your PATH in one click, asking for permission once. It was already there if you installed with Homebrew; this is for everyone who downloaded the DMG and would otherwise have had to symlink it by hand.' },
+    ],
+  },
+  {
+    version: '0.7.0',
+    date: '2026-08-21',
     changes: [
       { type: 'added', text: 'Pinpoint now hands your capture to an AI agent as files. Every copy also writes capture.png, capture.md and capture.json to a stable folder, so an agent opens the real image with its own Read tool instead of choking on an inline one.' },
       { type: 'added', text: 'Accessibility context under every marker — a pin is no longer just a percentage but “AXButton ‘Login’ in Safari”, turning a spot on your screen into an anchor an agent can act on. Optional, and off until you grant the permission.' },

--- a/project.yml
+++ b/project.yml
@@ -69,8 +69,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: app.croustibat.Pinpoint
-        MARKETING_VERSION: "0.7.0"
-        CURRENT_PROJECT_VERSION: "7"
+        MARKETING_VERSION: "0.7.1"
+        CURRENT_PROJECT_VERSION: "8"
         GENERATE_INFOPLIST_FILE: NO
         SWIFT_VERSION: "5.0"
         CODE_SIGN_STYLE: Automatic
@@ -114,8 +114,8 @@ targets:
       base:
         PRODUCT_NAME: pinpoint
         PRODUCT_BUNDLE_IDENTIFIER: app.croustibat.Pinpoint.cli
-        MARKETING_VERSION: "0.7.0"
-        CURRENT_PROJECT_VERSION: "7"
+        MARKETING_VERSION: "0.7.1"
+        CURRENT_PROJECT_VERSION: "8"
         # A tool has no Info.plist of its own; this embeds one in the binary so
         # `pinpoint --version` can read the version it was built with.
         GENERATE_INFOPLIST_FILE: YES


### PR DESCRIPTION
Préparation de la **v0.7.1**, à merger dans `develop` avant la PR `develop` → `main`.

- Entrée `0.7.1` en tête de `landing/src/changelog.ts` (`latest: true`), `0.7.0` perd `latest`.
- `MARKETING_VERSION` 0.7.0 → **0.7.1**, `CURRENT_PROJECT_VERSION` 7 → **8**, sur la target app **et** `PinpointCLI`.

## Contenu de la 0.7.1

Une seule fonctionnalité, mais elle répare une promesse de la 0.7.0 : **#90** ajoute l'installation de la commande `pinpoint` depuis l'app (issue #89).

La 0.7.0 livre le CLI et le serveur MCP dans le bundle, et ses notes de release les mettent en avant — mais seul le cask Homebrew les met sur le `PATH`. Un utilisateur qui installe par DMG devait taper un `ln -s` dans `/usr/local/bin`, qui appartient à `root` et n'existe pas toujours. Réglages ▸ Capture porte désormais une section « Command line tool » qui pose le lien en un clic.

Vérifié : `xcodegen` + `xcodebuild` verts, `npm run build` de la landing vert.

## ⚠️ Avant de notariser

Le dialogue d'authentification admin de #90 n'a pas pu être déclenché en environnement automatisé. C'est la seule fonctionnalité de cette version : un smoke-test humain du bouton Installer, puis Retirer, est à faire avant de publier.