### PR TITLE
Release v0.7.1 — installer la commande pinpoint depuis l'app

### DIFF
--- a/Pinpoint/AppDelegate.swift
+++ b/Pinpoint/AppDelegate.swift
@@ -184,6 +184,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         let settingsItem = NSMenuItem(title: String(localized: "Settings…"), action: #selector(openSettings), keyEquivalent: ",")
         settingsItem.target = self
         menu.addItem(settingsItem)
+
+        // Opens the same Settings window rather than installing on the spot
+        // (#89): the elevation prompt and the install/remove state belong
+        // together in one place, not split between a menu click and a
+        // separate window. This item exists purely for discoverability — someone
+        // who never opens Settings still sees that the CLI can be installed.
+        let installCLIItem = NSMenuItem(title: String(localized: "Install Command Line Tool…"), action: #selector(openSettings), keyEquivalent: "")
+        installCLIItem.target = self
+        menu.addItem(installCLIItem)
         menu.addItem(.separator())
 
         menu.addItem(NSMenuItem(title: String(localized: "Quit Pinpoint"), action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q"))

--- a/Pinpoint/CLIInstaller.swift
+++ b/Pinpoint/CLIInstaller.swift
@@ -1,0 +1,265 @@
+import AppKit
+import Foundation
+
+/// Puts the bundled `pinpoint` CLI (#56) on a Terminal's `PATH` after a plain
+/// DMG install (#89).
+///
+/// The Homebrew cask already does this with a `binary` stanza, but someone who
+/// dragged Pinpoint.app out of a DMG has no such thing — the README used to
+/// tell them to `ln -s` it into `/usr/local/bin` themselves, which fails for
+/// most people (root-owned directory, often missing outright on a fresh Mac).
+/// This is that same one `ln -s`, done for them, modelled on VS Code's
+/// "Install 'code' command in PATH".
+///
+/// Three rules shape everything below:
+/// - Never write into `/opt/homebrew/bin` — that is Homebrew's territory, read
+///   only to notice it already did the job.
+/// - Never touch a `pinpoint` we didn't create ourselves, even one that
+///   happens to resolve to the exact same bundle (see `computeStatus`).
+/// - Never claim success without actually running the installed command.
+@MainActor
+final class CLIInstaller: ObservableObject {
+    static let shared = CLIInstaller()
+
+    enum Status: Equatable {
+        case checking
+        case notInstalled
+        /// A symlink Pinpoint created itself, still resolving to a real CLI.
+        case installedByPinpoint
+        /// Something already answers to `pinpoint` on the PATH that Pinpoint
+        /// did not put there — Homebrew's cask, or a manual link from the old
+        /// README. Left alone.
+        case installedExternally
+        /// Pinpoint's own link now points at a bundle that moved or was
+        /// deleted. Offered the same "Install" action to re-point it.
+        case brokenPinpointLink
+        /// The last install/remove attempt failed; the message is already
+        /// user-facing and localized.
+        case failed(String)
+    }
+
+    /// Where Pinpoint installs its own link. Chosen over `/opt/homebrew/bin`
+    /// because it needs no Homebrew installation to already exist, and it is
+    /// the directory the old README instructions (and most "install a CLI
+    /// tool by hand" advice) already point at.
+    ///
+    /// `nonisolated`: these are immutable constants read from the detached
+    /// tasks below (privileged execution and verification must not block the
+    /// main actor), not app state that needs actor protection.
+    private nonisolated static let installDirectory = URL(fileURLWithPath: "/usr/local/bin")
+    private nonisolated static let linkURL = installDirectory.appendingPathComponent("pinpoint")
+    /// The other place a `pinpoint` might already live. Read-only: this is how
+    /// an existing Homebrew install is recognized, never a second target to
+    /// write to.
+    private nonisolated static let homebrewCandidatePath = "/opt/homebrew/bin/pinpoint"
+
+    private static let recordedLinkKey = "cliInstall.linkPath"
+
+    @Published private(set) var status: Status = .checking
+    @Published private(set) var isWorking = false
+
+    private init() {
+        refresh()
+    }
+
+    /// Re-reads the filesystem. Cheap local `stat` calls, so this is called
+    /// every time the Settings section appears rather than cached — Homebrew
+    /// or a Terminal session could have changed things since Pinpoint last
+    /// looked.
+    func refresh() {
+        let recorded = UserDefaults.standard.string(forKey: Self.recordedLinkKey)
+        status = Self.computeStatus(recordedLinkPath: recorded)
+    }
+
+    /// Creates (or repairs) the link, asking for administrator privileges
+    /// exactly once for the whole operation, then proves it actually works
+    /// before calling it installed.
+    func install() async {
+        isWorking = true
+        defer { isWorking = false }
+
+        let target = Bundle.main.bundleURL.appendingPathComponent("Contents/Helpers/pinpoint")
+        guard FileManager.default.fileExists(atPath: target.path) else {
+            status = .failed(String(
+                localized: "settings.cli.error.missingBinary",
+                defaultValue: "The pinpoint tool couldn’t be found inside this app. Try reinstalling Pinpoint."
+            ))
+            return
+        }
+
+        // One privileged call for both steps (#89 pitfall 3): `/usr/local/bin`
+        // may not exist yet, and a second dialog right after the first would
+        // read as the app being confused rather than thorough.
+        let shell = "mkdir -p \(Self.shellQuote(Self.installDirectory.path))"
+            + " && ln -sf \(Self.shellQuote(target.path)) \(Self.shellQuote(Self.linkURL.path))"
+
+        do {
+            try await Self.runElevated(shell)
+        } catch ElevationError.cancelled {
+            // #89 pitfall 4: closing the auth dialog is a normal "never mind",
+            // not a failure — back to whatever was true before, no alert.
+            refresh()
+            return
+        } catch {
+            status = .failed(String(
+                localized: "settings.cli.error.install",
+                defaultValue: "Couldn’t install the command line tool: \(error.localizedDescription)"
+            ))
+            return
+        }
+
+        UserDefaults.standard.set(Self.linkURL.path, forKey: Self.recordedLinkKey)
+
+        // #89 pitfall 5: a symlink that exists is not the same claim as "the
+        // command works". Run the thing a Terminal would run.
+        guard await Self.verifyInstalledCLIResponds() else {
+            try? FileManager.default.removeItem(at: Self.linkURL)
+            UserDefaults.standard.removeObject(forKey: Self.recordedLinkKey)
+            status = .failed(String(
+                localized: "settings.cli.error.verify",
+                defaultValue: "The link was created, but pinpoint --version didn’t respond. Nothing was left in place."
+            ))
+            return
+        }
+
+        refresh()
+    }
+
+    /// Removes Pinpoint's own link. Never reachable from the UI unless
+    /// `status == .installedByPinpoint`, so there is nothing to re-check here
+    /// (#89 pitfall 6) — the gate lives in `computeStatus`, once, not twice.
+    func remove() async {
+        isWorking = true
+        defer { isWorking = false }
+
+        let shell = "rm -f \(Self.shellQuote(Self.linkURL.path))"
+
+        do {
+            try await Self.runElevated(shell)
+        } catch ElevationError.cancelled {
+            refresh()
+            return
+        } catch {
+            status = .failed(String(
+                localized: "settings.cli.error.remove",
+                defaultValue: "Couldn’t remove the command line tool: \(error.localizedDescription)"
+            ))
+            return
+        }
+
+        UserDefaults.standard.removeObject(forKey: Self.recordedLinkKey)
+        refresh()
+    }
+
+    // MARK: - State
+
+    private nonisolated static func computeStatus(recordedLinkPath: String?) -> Status {
+        let fileManager = FileManager.default
+
+        // Pinpoint's own record wins first. This is the only way to tell
+        // "Pinpoint installed this" from "Homebrew installed this" apart when
+        // both would resolve to the very same `/Applications/Pinpoint.app` —
+        // the path alone can't disambiguate that (#89 pitfall 2).
+        if let recordedLinkPath {
+            if let resolved = resolvedTarget(ofSymlinkAt: recordedLinkPath) {
+                return isValidCLIBinary(at: resolved) ? .installedByPinpoint : .brokenPinpointLink
+            }
+            // Recorded, but nothing is there anymore (removed outside
+            // Pinpoint, e.g. `brew uninstall` clobbering the same path) — fall
+            // through and look at the world fresh.
+        }
+
+        for path in [linkURL.path, homebrewCandidatePath] {
+            guard let resolved = resolvedTarget(ofSymlinkAt: path), isValidCLIBinary(at: resolved) else { continue }
+            return .installedExternally
+        }
+
+        return .notInstalled
+
+        func resolvedTarget(ofSymlinkAt path: String) -> String? {
+            guard let destination = try? fileManager.destinationOfSymbolicLink(atPath: path) else { return nil }
+            if destination.hasPrefix("/") { return destination }
+            return (path as NSString).deletingLastPathComponent + "/" + destination
+        }
+
+        func isValidCLIBinary(at path: String) -> Bool {
+            fileManager.fileExists(atPath: path) && path.contains(".app/Contents/Helpers/pinpoint")
+        }
+    }
+
+    // MARK: - Privileged execution
+
+    private enum ElevationError: Error {
+        case cancelled
+        case failed(String)
+    }
+
+    /// Runs `shellCommand` with `do shell script … with administrator
+    /// privileges` — the standard macOS auth dialog, and the one route that
+    /// works from a notarized, non-sandboxed app without a separate
+    /// `SMJobBless` helper (overkill for a single symlink) or the long-
+    /// deprecated `AuthorizationExecuteWithPrivileges`.
+    ///
+    /// Runs off the main actor: `NSAppleScript.executeAndReturnError` blocks
+    /// for as long as the auth dialog is on screen, which must not freeze the
+    /// Settings window's spinner.
+    private nonisolated static func runElevated(_ shellCommand: String) async throws {
+        try await Task.detached(priority: .userInitiated) {
+            let source = "do shell script \"\(appleScriptQuote(shellCommand))\" with administrator privileges"
+            guard let script = NSAppleScript(source: source) else {
+                throw ElevationError.failed("Couldn’t build the privileged command.")
+            }
+            var errorInfo: NSDictionary?
+            script.executeAndReturnError(&errorInfo)
+            guard let errorInfo else { return }
+
+            // -128 is AppleScript's "user cancelled" across every flavor of
+            // `with administrator privileges` dialog, closed button or Esc alike.
+            if (errorInfo[NSAppleScript.errorNumber] as? Int) == -128 {
+                throw ElevationError.cancelled
+            }
+            let message = errorInfo[NSAppleScript.errorMessage] as? String ?? "Unknown error."
+            throw ElevationError.failed(message)
+        }.value
+    }
+
+    /// Runs the link a Terminal would run and checks it actually answers —
+    /// not just that a file with the right name exists at the right path.
+    private nonisolated static func verifyInstalledCLIResponds() async -> Bool {
+        await Task.detached(priority: .userInitiated) {
+            let process = Process()
+            process.executableURL = linkURL
+            process.arguments = ["--version"]
+            let stdout = Pipe()
+            process.standardOutput = stdout
+            process.standardError = Pipe()
+
+            do {
+                try process.run()
+            } catch {
+                return false
+            }
+            process.waitUntilExit()
+
+            let output = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            return process.terminationStatus == 0 && output.lowercased().contains("pinpoint")
+        }.value
+    }
+
+    /// Quotes `value` as a single-quoted shell literal — the standard POSIX
+    /// trick of closing the quote, escaping a literal `'`, and reopening it —
+    /// so a bundle path containing a space or an apostrophe (the app can run
+    /// from anywhere, including a messily-named folder in ~/Downloads) can't
+    /// break the command it's embedded in.
+    private nonisolated static func shellQuote(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    /// Escapes an already shell-quoted command so it can sit inside the
+    /// double-quoted AppleScript string literal `do shell script "…"` needs.
+    private nonisolated static func appleScriptQuote(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+}

--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -758,6 +758,11 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Survole une fenêtre · clique pour capturer · Espace pour un rectangle · Échap pour annuler" } }
       }
     },
+    "Install Command Line Tool…" : {
+      "localizations" : {
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Installer l’outil en ligne de commande…" } }
+      }
+    },
     "Instructions for the agent" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Instructions pour l’agent" } }
@@ -1075,6 +1080,72 @@
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Describe the element under each marker" } },
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Décrire l’élément sous chaque repère" } }
+      }
+    },
+    "settings.cli.action.remove" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Remove Command Line Tool…" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Retirer l’outil en ligne de commande…" } }
+      }
+    },
+    "settings.cli.error.install" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Couldn’t install the command line tool: %@" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Impossible d’installer l’outil en ligne de commande : %@" } }
+      }
+    },
+    "settings.cli.error.missingBinary" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "The pinpoint tool couldn’t be found inside this app. Try reinstalling Pinpoint." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Impossible de trouver l’outil pinpoint dans cette app. Essayez de réinstaller Pinpoint." } }
+      }
+    },
+    "settings.cli.error.remove" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Couldn’t remove the command line tool: %@" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Impossible de retirer l’outil en ligne de commande : %@" } }
+      }
+    },
+    "settings.cli.error.verify" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "The link was created, but pinpoint --version didn’t respond. Nothing was left in place." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Le lien a été créé, mais pinpoint --version n’a pas répondu. Rien n’a été laissé en place." } }
+      }
+    },
+    "settings.cli.explanation" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Puts pinpoint on your Terminal’s PATH by creating one link in /usr/local/bin, so scripts and AI agents can call it directly — the same tool the Homebrew cask already provides this way. Needs administrator approval once, to create the link." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Place pinpoint dans le PATH de votre Terminal en créant un lien dans /usr/local/bin, pour que les scripts et les agents IA puissent l’appeler directement — le même outil que fournit déjà le cask Homebrew de cette façon. Nécessite une autorisation d’administrateur, une seule fois, pour créer le lien." } }
+      }
+    },
+    "settings.cli.section" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Command line tool" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Outil en ligne de commande" } }
+      }
+    },
+    "settings.cli.status.broken" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "This link points to a copy of Pinpoint that’s no longer there." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Ce lien pointe vers une copie de Pinpoint qui n’est plus là." } }
+      }
+    },
+    "settings.cli.status.external" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Already available — installed by Homebrew, or linked by hand. Pinpoint leaves it as is." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Déjà disponible — installé par Homebrew, ou lié à la main. Pinpoint n’y touche pas." } }
+      }
+    },
+    "settings.cli.status.installed" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Installed — pinpoint runs from any Terminal (/usr/local/bin/pinpoint)." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Installé — pinpoint fonctionne depuis n’importe quel Terminal (/usr/local/bin/pinpoint)." } }
+      }
+    },
+    "settings.cli.status.notInstalled" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Not installed — Terminal commands and AI agents can’t find pinpoint yet." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Non installé — les commandes de Terminal et les agents IA ne trouvent pas encore pinpoint." } }
       }
     },
     "settings.format.explanation" : {

--- a/Pinpoint/PinpointApp.swift
+++ b/Pinpoint/PinpointApp.swift
@@ -69,6 +69,8 @@ struct CaptureSettingsView: View {
     /// there's nothing to observe here beyond "the user came back to us".
     @State private var isTrusted = AXPermission.isTrusted
 
+    @ObservedObject private var cli = CLIInstaller.shared
+
     var body: some View {
         Form {
             Section("Shortcuts") {
@@ -122,6 +124,7 @@ struct CaptureSettingsView: View {
             }
             accessibilitySection
             textRecognitionSection
+            commandLineSection
         }
         .formStyle(.grouped)
         // Coming back from System Settings is the moment the answer can have
@@ -129,6 +132,7 @@ struct CaptureSettingsView: View {
         .onReceive(NotificationCenter.default.publisher(
             for: NSApplication.didBecomeActiveNotification)) { _ in
             isTrusted = AXPermission.isTrusted
+            cli.refresh()
         }
     }
 
@@ -191,6 +195,80 @@ struct CaptureSettingsView: View {
                         defaultValue: "Pre-fills a marker’s description with the line of text it points at, and writes that line into the files for the agent — so small text an agent would misread from the image travels as text. Read on this Mac; nothing is sent anywhere. Areas you have hidden are never read."))
                 .foregroundStyle(.secondary)
                 .font(.callout)
+        }
+    }
+
+    /// Puts `pinpoint` on a Terminal's `PATH` after a plain DMG install (#89):
+    /// the Homebrew cask already does this itself, so the whole section is
+    /// about the download that doesn't come with a `binary` stanza.
+    ///
+    /// Modelled on the ax/ocr sections above: state first, one button whose
+    /// label follows that state, nothing else to configure.
+    private var commandLineSection: some View {
+        Section(String(localized: "settings.cli.section", defaultValue: "Command line tool")) {
+            Text(String(
+                localized: "settings.cli.explanation",
+                defaultValue: "Puts pinpoint on your Terminal’s PATH by creating one link in /usr/local/bin, so scripts and AI agents can call it directly — the same tool the Homebrew cask already provides this way. Needs administrator approval once, to create the link."
+            ))
+            .foregroundStyle(.secondary)
+            .font(.callout)
+
+            switch cli.status {
+            case .checking:
+                ProgressView()
+
+            case .notInstalled, .brokenPinpointLink:
+                if case .brokenPinpointLink = cli.status {
+                    Label(String(
+                        localized: "settings.cli.status.broken",
+                        defaultValue: "This link points to a copy of Pinpoint that’s no longer there."
+                    ), systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                } else {
+                    Label(String(
+                        localized: "settings.cli.status.notInstalled",
+                        defaultValue: "Not installed — Terminal commands and AI agents can’t find pinpoint yet."
+                    ), systemImage: "xmark.circle")
+                    .foregroundStyle(.secondary)
+                }
+                installButton
+
+            case .installedByPinpoint:
+                Label(String(
+                    localized: "settings.cli.status.installed",
+                    defaultValue: "Installed — pinpoint runs from any Terminal (/usr/local/bin/pinpoint)."
+                ), systemImage: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+                Button(String(localized: "settings.cli.action.remove", defaultValue: "Remove Command Line Tool…")) {
+                    Task { await cli.remove() }
+                }
+                .disabled(cli.isWorking)
+
+            case .installedExternally:
+                Label(String(
+                    localized: "settings.cli.status.external",
+                    defaultValue: "Already available — installed by Homebrew, or linked by hand. Pinpoint leaves it as is."
+                ), systemImage: "checkmark.circle")
+                .foregroundStyle(.secondary)
+
+            case .failed(let message):
+                Text(message)
+                    .foregroundStyle(.red)
+                installButton
+            }
+        }
+    }
+
+    private var installButton: some View {
+        HStack {
+            Button(String(localized: "Install Command Line Tool…")) {
+                Task { await cli.install() }
+            }
+            .disabled(cli.isWorking)
+            if cli.isWorking {
+                ProgressView()
+                    .controlSize(.small)
+            }
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -277,8 +277,14 @@ A file path is the channel that reliably works.
 
 Pinpoint ships a small command-line tool **inside the app bundle**, at
 `Pinpoint.app/Contents/Helpers/pinpoint`, so it is signed and notarized with the
-app. The Homebrew cask symlinks it onto your `PATH`; after a direct download,
-link it yourself:
+app. The Homebrew cask symlinks it onto your `PATH` automatically. After a
+direct DMG download, open **Pinpoint ▸ Settings ▸ Capture ▸ Command line
+tool ▸ Install Command Line Tool…** — it creates the same link in
+`/usr/local/bin`, asks for administrator approval once, and confirms the
+command actually responds before calling it done.
+
+Prefer doing it by hand, or scripting the install itself? The manual version
+still works:
 
 ```sh
 ln -s "/Applications/Pinpoint.app/Contents/Helpers/pinpoint" /usr/local/bin/pinpoint

--- a/landing/src/changelog.ts
+++ b/landing/src/changelog.ts
@@ -16,9 +16,16 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
-    version: '0.7.0',
+    version: '0.7.1',
     date: '2026-08-21',
     latest: true,
+    changes: [
+      { type: 'added', text: 'Install the pinpoint command from the app — Settings ▸ Capture now has a “Command line tool” section that puts pinpoint on your PATH in one click, asking for permission once. It was already there if you installed with Homebrew; this is for everyone who downloaded the DMG and would otherwise have had to symlink it by hand.' },
+    ],
+  },
+  {
+    version: '0.7.0',
+    date: '2026-08-21',
     changes: [
       { type: 'added', text: 'Pinpoint now hands your capture to an AI agent as files. Every copy also writes capture.png, capture.md and capture.json to a stable folder, so an agent opens the real image with its own Read tool instead of choking on an inline one.' },
       { type: 'added', text: 'Accessibility context under every marker — a pin is no longer just a percentage but “AXButton ‘Login’ in Safari”, turning a spot on your screen into an anchor an agent can act on. Optional, and off until you grant the permission.' },

--- a/project.yml
+++ b/project.yml
@@ -69,8 +69,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: app.croustibat.Pinpoint
-        MARKETING_VERSION: "0.7.0"
-        CURRENT_PROJECT_VERSION: "7"
+        MARKETING_VERSION: "0.7.1"
+        CURRENT_PROJECT_VERSION: "8"
         GENERATE_INFOPLIST_FILE: NO
         SWIFT_VERSION: "5.0"
         CODE_SIGN_STYLE: Automatic
@@ -114,8 +114,8 @@ targets:
       base:
         PRODUCT_NAME: pinpoint
         PRODUCT_BUNDLE_IDENTIFIER: app.croustibat.Pinpoint.cli
-        MARKETING_VERSION: "0.7.0"
-        CURRENT_PROJECT_VERSION: "7"
+        MARKETING_VERSION: "0.7.1"
+        CURRENT_PROJECT_VERSION: "8"
         # A tool has no Info.plist of its own; this embeds one in the binary so
         # `pinpoint --version` can read the version it was built with.
         GENERATE_INFOPLIST_FILE: YES


### PR DESCRIPTION
Release **v0.7.1**. Merge de `develop` dans `main`, préalable au flux de publication.

Une seule fonctionnalité, qui répare une promesse de la 0.7.0.

## Le problème qu'elle règle

La 0.7.0 livre le CLI `pinpoint` et le serveur MCP dans le bundle, et ses notes de release les mettent en avant. Mais seul le cask Homebrew les pose sur le `PATH` : un utilisateur qui installe par DMG devait taper un `ln -s` dans `/usr/local/bin`, répertoire appartenant à `root` et absent de bien des Macs sans Homebrew. La commande échouait donc en « Permission denied » ou « No such file or directory » pour une part importante des utilisateurs.

## Ce qui arrive (#90, issue #89)

Réglages ▸ Capture porte une section « Outil en ligne de commande » qui pose le lien en un clic, avec une seule demande d'autorisation, et une entrée de menu qui y mène.

- Le lien vise le **bundle réellement lancé** (`Bundle.main.bundleURL`) — l'app peut tourner depuis `~/Downloads` ou un volume externe.
- Cinq états distincts, recalculés à chaque affichage : non installé · installé par Pinpoint · installé par un tiers · lien cassé · échec.
- `/opt/homebrew/bin` est **lu, jamais écrit** : écraser un lien géré par Homebrew casserait son `brew uninstall`.
- Le succès est **vérifié** et non supposé : après la pose, l'app exécute `pinpoint --version` ; si la commande reste muette, le lien est retiré et l'échec annoncé.
- L'annulation du dialogue d'authentification est traitée comme un cas normal, sans alerte.
- Retrait symétrique depuis le même endroit ; jamais un lien que Pinpoint n'a pas posé.

## Vérifications

`xcodegen` + `xcodebuild` verts, `npm run build` de la landing vert, CI verte sur #90 et #91.

Le parcours complet a été **testé à la main** sur un build de cette branche : dialogue d'autorisation, bascule de l'état, et `pinpoint --version` répondant `0.7.1` depuis un Terminal.

## Après le merge

Flux de release habituel. La 0.7.0 n'ayant reçu ni cask ni appcast, ceux-ci pointeront directement vers la 0.7.1 : les utilisateurs en 0.6.0 y sauteront en une fois. **La stanza `binary` du cask reste à ajouter** dans `croustibat/homebrew-tap` — d'autant plus utile que cette version existe précisément pour les utilisateurs qui n'installent pas par Homebrew.