### PR TITLE
Prépare la v0.7.2 — changelog et bump de version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ Package.resolved
 
 # Throwaway Remotion project for the demo GIF
 .demo-remotion/
+.vercel

--- a/.vercelignore
+++ b/.vercelignore
@@ -4,7 +4,13 @@
 # file `vercel deploy` ships all of it (1.4 GB) before discarding everything but
 # landing/.
 #
-# Keep the root exclusion first and the re-include second: gitignore semantics
+# Keep the root exclusion first and the re-includes second: gitignore semantics
 # can't re-include a path whose parent directory is already excluded.
+#
+# .git must survive. The project's Ignored Build Step runs
+# `git diff --quiet HEAD^ HEAD -- landing/` to skip rebuilds when only the app
+# changed, and that command fails the build outright if the clone isn't a git
+# repository any more.
 /*
 !/landing
+!/.git

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,10 @@
+# Vercel builds this project from the landing/ Root Directory, but the CLI
+# uploads the whole repository as build context first — and this repo carries a
+# 1.2 GB Xcode build directory next to a 500 MB Remotion project. Without this
+# file `vercel deploy` ships all of it (1.4 GB) before discarding everything but
+# landing/.
+#
+# Keep the root exclusion first and the re-include second: gitignore semantics
+# can't re-include a path whose parent directory is already excluded.
+/*
+!/landing

--- a/landing/src/changelog.ts
+++ b/landing/src/changelog.ts
@@ -16,9 +16,17 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.7.2',
+    date: '2026-08-24',
+    latest: true,
+    changes: [
+      { type: 'added', text: 'Every shape can carry its own description now — rectangles, arrows and redacted areas each get a field beside them, so circling a misaligned button finally has somewhere to say why. Until now only a numbered marker could hold a note, and describing a shape meant dropping a marker on top of it or pushing the explanation into the general instructions.' },
+      { type: 'added', text: 'Those descriptions travel wherever the capture goes: into capture.md, into an optional note on each shape in capture.json, and into a new ANNOTATIONS section of the baked-in legend. It matters most on a redacted area — “what I hid, and why” is exactly what an agent needs to know, and it was the one part of the handoff that had no way to say it.' },
+    ],
+  },
+  {
     version: '0.7.1',
     date: '2026-08-21',
-    latest: true,
     changes: [
       { type: 'added', text: 'Install the pinpoint command from the app — Settings ▸ Capture now has a “Command line tool” section that puts pinpoint on your PATH in one click, asking for permission once. It was already there if you installed with Homebrew; this is for everyone who downloaded the DMG and would otherwise have had to symlink it by hand.' },
     ],

--- a/project.yml
+++ b/project.yml
@@ -69,8 +69,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: app.croustibat.Pinpoint
-        MARKETING_VERSION: "0.7.1"
-        CURRENT_PROJECT_VERSION: "8"
+        MARKETING_VERSION: "0.7.2"
+        CURRENT_PROJECT_VERSION: "9"
         GENERATE_INFOPLIST_FILE: NO
         SWIFT_VERSION: "5.0"
         CODE_SIGN_STYLE: Automatic
@@ -114,8 +114,8 @@ targets:
       base:
         PRODUCT_NAME: pinpoint
         PRODUCT_BUNDLE_IDENTIFIER: app.croustibat.Pinpoint.cli
-        MARKETING_VERSION: "0.7.1"
-        CURRENT_PROJECT_VERSION: "8"
+        MARKETING_VERSION: "0.7.2"
+        CURRENT_PROJECT_VERSION: "9"
         # A tool has no Info.plist of its own; this embeds one in the binary so
         # `pinpoint --version` can read the version it was built with.
         GENERATE_INFOPLIST_FILE: YES


### PR DESCRIPTION
Préparation de la **v0.7.2**, à merger dans `develop` avant la PR `develop` → `main`.

- Entrée `0.7.2` en tête de `landing/src/changelog.ts` (`latest: true`), `0.7.1` perd `latest`.
- `MARKETING_VERSION` 0.7.1 → **0.7.2**, `CURRENT_PROJECT_VERSION` 8 → **9**, sur la target app **et** `PinpointCLI`.

## Contenu de la 0.7.2

Une seule fonctionnalité : **#94** (refs #93) donne une description propre à chaque forme — rectangle, flèche et zone masquée.

Jusqu'ici seul un repère numéroté pouvait porter une note. Entourer un bouton mal aligné n'offrait aucun endroit où écrire *pourquoi* : il fallait poser un repère par-dessus la forme, ou renvoyer l'explication dans les instructions générales. Le manque était le plus criant sur la zone masquée — « ce que j'ai caché, et pourquoi » est exactement ce qu'un agent a besoin de savoir, et c'était le seul élément de l'export à ne rien pouvoir dire.

La description voyage ensuite dans `capture.md`, dans une clé `note` optionnelle sur chaque forme de `capture.json`, et dans une nouvelle section ANNOTATIONS de la légende gravée.

`schemaVersion` ne bouge pas : la clé est optionnelle des deux côtés et la règle publiée est que les clés s'ajoutent entre versions, donc le binaire `pinpoint` continue de lire les captures 0.7.1.

## Vérifié

- `scripts/install-local.sh` — build Release + signature Developer ID, `valid on disk`, Designated Requirement satisfait. App et CLI rapportent bien `0.7.2` (build 9).
- `scripts/verify-shape-notes.sh` — vert, y compris le cas qui compte le plus : un `index.json` écrit avant la clé `note` se relit intact, sans vider l'historique.
- `scripts/verify-ocr-redaction.sh` — vert.
- `npm run build` de la landing — vert, `/changelog` liste bien la 0.7.2 en version courante.

## ⚠️ Avant de notariser

Les vérifications ci-dessus s'exécutent sur les sources, pas sur l'UI. Le champ de description par forme dans le panneau latéral (et son rendu dans la légende gravée) mérite un smoke-test humain dans l'app fraîchement installée avant de lancer `scripts/release.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)