### PR TITLE
Release v0.7.2 — une description par forme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ Package.resolved
 
 # Throwaway Remotion project for the demo GIF
 .demo-remotion/
+.vercel

--- a/.vercelignore
+++ b/.vercelignore
@@ -4,7 +4,13 @@
 # file `vercel deploy` ships all of it (1.4 GB) before discarding everything but
 # landing/.
 #
-# Keep the root exclusion first and the re-include second: gitignore semantics
+# Keep the root exclusion first and the re-includes second: gitignore semantics
 # can't re-include a path whose parent directory is already excluded.
+#
+# .git must survive. The project's Ignored Build Step runs
+# `git diff --quiet HEAD^ HEAD -- landing/` to skip rebuilds when only the app
+# changed, and that command fails the build outright if the clone isn't a git
+# repository any more.
 /*
 !/landing
+!/.git

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,10 @@
+# Vercel builds this project from the landing/ Root Directory, but the CLI
+# uploads the whole repository as build context first — and this repo carries a
+# 1.2 GB Xcode build directory next to a 500 MB Remotion project. Without this
+# file `vercel deploy` ships all of it (1.4 GB) before discarding everything but
+# landing/.
+#
+# Keep the root exclusion first and the re-include second: gitignore semantics
+# can't re-include a path whose parent directory is already excluded.
+/*
+!/landing

--- a/Pinpoint/EditorView.swift
+++ b/Pinpoint/EditorView.swift
@@ -55,6 +55,10 @@ enum EditorTool: String, CaseIterable, Identifiable {
 /// while the user is typing.
 private enum EditorField: Hashable {
     case note(Pin.ID)
+    /// A shape's description (#93). Tracked exactly like a marker's note: the
+    /// tool shortcuts stand down while it has focus, and `flushTextEdit` folds
+    /// the whole typing session into one undo entry when focus leaves.
+    case shapeNote(Markup.ID)
     case context
 }
 
@@ -541,15 +545,23 @@ struct EditorView: View {
                       defaultValue: "\(x) percent from the left, \(y) percent from the top")
     }
 
+    /// What VoiceOver reads for a shape: its kind, followed by the user's
+    /// description when there is one — the same rule as a marker, minus the
+    /// "no description" ending, which a marker needs because a bare number says
+    /// nothing and a shape's kind already does.
     private func accessibilityLabel(for shape: Markup) -> String {
+        let kind: String
         switch shape.kind {
-        case .arrow: return String(localized: "a11y.shape.arrow", defaultValue: "Arrow annotation")
-        case .rectangle: return String(localized: "a11y.shape.rectangle", defaultValue: "Rectangle annotation")
+        case .arrow: kind = String(localized: "a11y.shape.arrow", defaultValue: "Arrow annotation")
+        case .rectangle: kind = String(localized: "a11y.shape.rectangle", defaultValue: "Rectangle annotation")
         // Announces the bar, not what went under it: VoiceOver is a channel
         // like any other, and the text it reads is the text a screen recording
-        // of this session would carry.
-        case .redaction: return String(localized: "a11y.shape.redaction", defaultValue: "Hidden area")
+        // of this session would carry. What the *user* chose to say about it is
+        // another matter, and is read out below like any other description.
+        case .redaction: kind = String(localized: "a11y.shape.redaction", defaultValue: "Hidden area")
         }
+        guard let note = shape.trimmedNote else { return kind }
+        return String(localized: "a11y.shape.described", defaultValue: "\(kind): \(note)")
     }
 
     /// Drag-to-move a pin. Translation-based so grabbing anywhere on the marker
@@ -997,8 +1009,8 @@ struct EditorView: View {
                 .font(.headline)
                 .accessibilityAddTraits(.isHeader)
 
-            ForEach(shapes) { shape in
-                shapeRow(shape)
+            ForEach($shapes) { $shape in
+                shapeRow($shape)
             }
         }
     }
@@ -1093,22 +1105,35 @@ struct EditorView: View {
             )
     }
 
-    private func shapeRow(_ shape: Markup) -> some View {
-        let isSelected = shape.id == selectedShapeID
+    /// One shape in the side panel: its icon, its description, and a way to
+    /// delete it.
+    ///
+    /// Deliberately the same three columns as `pinRow`, with the icon standing
+    /// in for the numbered badge — a shape and a marker are two ways of
+    /// pointing at something, and the panel shouldn't make them look like two
+    /// different kinds of object. The kind of shape is no longer written out
+    /// next to the icon: it moved into the field's placeholder, where it names
+    /// the row without taking a second column from a panel 260 pt wide.
+    private func shapeRow(_ shape: Binding<Markup>) -> some View {
+        let value = shape.wrappedValue
+        let isSelected = value.id == selectedShapeID
         let deleteLabel = String(localized: "a11y.shape.delete", defaultValue: "Delete this annotation")
 
         return HStack(spacing: 8) {
-            Image(systemName: shape.symbol)
+            Image(systemName: value.symbol)
                 .foregroundStyle(Color.pinpointVermillon)
                 .frame(width: pinBadgeSide, height: pinBadgeSide)
+                // The kind is repeated in the field's label right after it, so
+                // VoiceOver names it once instead of twice.
                 .accessibilityHidden(true)
 
-            Text(shape.label)
-
-            Spacer()
+            TextField(value.notePlaceholder, text: shape.note)
+                .textFieldStyle(.roundedBorder)
+                .focused($focusedField, equals: .shapeNote(value.id))
+                .accessibilityLabel(value.noteAccessibilityLabel)
 
             Button {
-                removeShape(shape)
+                removeShape(value)
             } label: {
                 Image(systemName: "trash")
             }
@@ -1119,10 +1144,10 @@ struct EditorView: View {
         }
         .padding(6)
         .background(rowSelectionBackground(isSelected))
-        .onTapGesture { selectShape(shape.id) }
+        .onTapGesture { selectShape(value.id) }
         .accessibilityElement(children: .contain)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
-        .accessibilityAction { selectShape(shape.id) }
+        .accessibilityAction { selectShape(value.id) }
     }
 
     // MARK: - Actions
@@ -1587,7 +1612,8 @@ struct EditorView: View {
                 // able to undo a redaction.
                 guard shape.rect.intersects(c) else { continue }
                 newShapes.append(
-                    Markup(id: shape.id, kind: shape.kind, start: clamp01(s), end: clamp01(e))
+                    Markup(id: shape.id, kind: shape.kind, start: clamp01(s), end: clamp01(e),
+                           note: shape.note)
                 )
                 continue
             }
@@ -1595,7 +1621,10 @@ struct EditorView: View {
             // Midpoint-or-endpoint rule; straddlers keep what's inside.
             guard inside(s) || inside(e) || inside(CGPoint(x: (s.x+e.x)/2, y: (s.y+e.y)/2)) else { continue }
             newShapes.append(
-                Markup(id: shape.id, kind: shape.kind, start: clamp01(s), end: clamp01(e))
+                // The description rides along: a crop moves a shape into a new
+                // frame, it doesn't turn it into a different annotation.
+                Markup(id: shape.id, kind: shape.kind, start: clamp01(s), end: clamp01(e),
+                       note: shape.note)
             )
         }
 

--- a/Pinpoint/Exporter.swift
+++ b/Pinpoint/Exporter.swift
@@ -375,6 +375,14 @@ enum Exporter {
             if !mask.isEmpty {
                 lines.append(String(localized: "export.shapes.redaction.legend", defaultValue: "A hidden area is a region the user painted over before sharing: its pixels are not in the image, and nothing was collected about what sat under it. Ask the user rather than guessing."))
             }
+            // Said only when at least one shape actually carries a description
+            // (#93) — same rule as every other legend line here: no promise of
+            // details that never come. Without it the sentence sitting between
+            // "Rectangle" and a pair of coordinates has no stated provenance,
+            // and a reader weighing it has to guess whether Pinpoint wrote it.
+            if shapes.contains(where: { $0.trimmedNote != nil }) {
+                lines.append(String(localized: "export.shapes.note.legend", defaultValue: "The sentence between a shape’s kind and its coordinates is what the user wrote about that shape."))
+            }
             lines.append("")
             for (index, shape) in shapes.enumerated() {
                 let box = shape.rect
@@ -389,7 +397,13 @@ enum Exporter {
                 }
                 let boxWidth = Int((box.width * imageSize.width).rounded())
                 let boxHeight = Int((box.height * imageSize.height).rounded())
-                lines.append("- S\(index + 1) [\(shape.id.shortToken)] · \(shape.label) — "
+                // The user's own words about this shape (#93), in the same slot
+                // a marker's description occupies — right after the identifier,
+                // before the geometry. Left out entirely when there is none, so
+                // the export of a capture without descriptions stays exactly the
+                // text it was before this field existed.
+                let described = shape.trimmedNote.map { " · \($0)" } ?? ""
+                lines.append("- S\(index + 1) [\(shape.id.shortToken)] · \(shape.label)\(described) — "
                              + "\(pixels(from, in: imageSize)) → \(pixels(to, in: imageSize)) px · "
                              + "\(percent(from)) → \(percent(to)) · \(boxWidth)×\(boxHeight) px")
             }
@@ -567,7 +581,7 @@ enum Exporter {
     static func exportImage(base: NSImage, pins: [Pin], shapes: [Markup], context: String,
                             style: PinStyle, includeLegend: Bool, preset: TaskPreset = .raw) -> NSImage {
         let annotated = annotatedImage(base: base, pins: pins, shapes: shapes, style: style)
-        guard includeLegend, let legend = legendString(pins: pins, context: context,
+        guard includeLegend, let legend = legendString(pins: pins, shapes: shapes, context: context,
                                                        preset: preset, width: annotated.size.width) else {
             return annotated
         }
@@ -609,12 +623,23 @@ enum Exporter {
     private static let legendDrawingOptions: NSString.DrawingOptions = [.usesLineFragmentOrigin]
 
     /// The legend rendered into the exported image, or nil if there's nothing to
-    /// show (no pins, no instructions and no task framing).
-    private static func legendString(pins: [Pin], context: String, preset: TaskPreset,
-                                     width: CGFloat) -> NSAttributedString? {
+    /// show (no pins, no described shapes, no instructions and no task framing).
+    ///
+    /// Shapes appear here only once they carry a description (#93). The reason
+    /// they have to appear at all is that `includeLegend` defaults to `true`,
+    /// and in that mode `copyToPasteboard` puts the PNG on the pasteboard and
+    /// nothing else — so anything left out of this strip never reaches the
+    /// agent in the default configuration (#69). A shape with nothing written
+    /// about it stays out: its outline is already on the image, and a line
+    /// saying "Rectangle" and no more would be the caption repeating the
+    /// picture.
+    private static func legendString(pins: [Pin], shapes: [Markup], context: String,
+                                     preset: TaskPreset, width: CGFloat) -> NSAttributedString? {
         let trimmedContext = context.trimmingCharacters(in: .whitespacesAndNewlines)
         let orderedPins = pins.sorted { $0.number < $1.number }
-        guard !orderedPins.isEmpty || !trimmedContext.isEmpty || preset.guidance != nil else { return nil }
+        let describedShapes = shapes.filter { $0.trimmedNote != nil }
+        guard !orderedPins.isEmpty || !describedShapes.isEmpty
+                || !trimmedContext.isEmpty || preset.guidance != nil else { return nil }
 
         let bodySize = max(15, width * 0.016)
         let body = NSFont.systemFont(ofSize: bodySize)
@@ -634,12 +659,34 @@ enum Exporter {
             ]))
         }
 
+        // Every section but the first is preceded by a blank line. Tracked
+        // rather than restated at each step: the conditions were already a
+        // cascade of "is anything above me?", and a fourth section would have
+        // made every later one wrong the day it was added.
+        var needsSeparator = false
+        func startSection(_ title: String) {
+            if needsSeparator { add("\n", body, dark) }
+            add(title + "\n", heading, secondary)
+            needsSeparator = true
+        }
+
         if !orderedPins.isEmpty {
-            add(String(localized: "legend.markers", defaultValue: "MARKERS") + "\n", heading, secondary)
+            startSection(String(localized: "legend.markers", defaultValue: "MARKERS"))
             for pin in orderedPins {
                 let note = pin.note.trimmingCharacters(in: .whitespacesAndNewlines)
                 add("\(pin.number)", number, .pinpointVermillon)
                 add("   \(note.isEmpty ? String(localized: "(no description)") : note)\n", body, dark)
+            }
+        }
+        // What the user wrote about the arrows, rectangles and hidden areas
+        // (#93). Named by kind rather than by the "S1"/"S2" codes `buildText`
+        // uses: those codes are nowhere on the image, so printing them here
+        // would invite a reader to look for labels that were never drawn.
+        if !describedShapes.isEmpty {
+            startSection(String(localized: "legend.shapes", defaultValue: "ANNOTATIONS"))
+            for shape in describedShapes {
+                add(shape.label, number, .pinpointVermillon)
+                add("   \(shape.trimmedNote ?? "")\n", body, dark)
             }
         }
         // The task framing belongs here for the same reason the legend exists at
@@ -647,13 +694,11 @@ enum Exporter {
         // nothing else, so anything left out of the strip never reaches the
         // agent. Same order as `buildText` — framing, then the user's own words.
         if let guidance = preset.guidance {
-            if !orderedPins.isEmpty { add("\n", body, dark) }
-            add(preset.heading.uppercased(with: .current) + "\n", heading, secondary)
+            startSection(preset.heading.uppercased(with: .current))
             add(guidance + "\n", body, dark)
         }
         if !trimmedContext.isEmpty {
-            if !orderedPins.isEmpty || preset.guidance != nil { add("\n", body, dark) }
-            add(String(localized: "legend.instructions", defaultValue: "INSTRUCTIONS") + "\n", heading, secondary)
+            startSection(String(localized: "legend.instructions", defaultValue: "INSTRUCTIONS"))
             add(trimmedContext, body, dark)
         }
         return result

--- a/Pinpoint/HandoffDocument.swift
+++ b/Pinpoint/HandoffDocument.swift
@@ -292,6 +292,19 @@ extension FileHandoff {
             /// consumer that knows a region is unreadable asks instead of
             /// guessing.
             let kind: String
+            /// What the user wrote about this shape (#93), trimmed. Absent when
+            /// they wrote nothing rather than present and empty — the key is
+            /// new, and a consumer reading a file written by an older Pinpoint
+            /// would otherwise have to tell "no description" from "this version
+            /// couldn't carry one". Absent also keeps a capture without
+            /// descriptions serializing byte for byte as it did before.
+            ///
+            /// Unlike a marker's `note` this never has a machine-read twin:
+            /// nothing pre-fills it, so what is here is the user's own words
+            /// and nothing else. On a "redaction" it is the one statement about
+            /// a hidden area that can be made without undoing the redaction —
+            /// again, because the user is the one making it.
+            let note: String?
             /// Arrow: the tail. Rectangle/redaction: its top-left corner.
             let from: Point
             /// Arrow: the tip, where the head is drawn. Rectangle/redaction:

--- a/Pinpoint/HandoffDocumentBuilder.swift
+++ b/Pinpoint/HandoffDocumentBuilder.swift
@@ -92,6 +92,7 @@ extension FileHandoff.Document {
                 id: shape.id.shortToken,
                 label: "S\(index + 1)",
                 kind: kind,
+                note: shape.trimmedNote,
                 from: Point(from, in: imageSize),
                 to: Point(to, in: imageSize),
                 boundingBox: Box(shape.rect, in: imageSize)

--- a/Pinpoint/Localizable.xcstrings
+++ b/Pinpoint/Localizable.xcstrings
@@ -238,6 +238,30 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Supprimer cette annotation" } }
       }
     },
+    "a11y.shape.described" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "%1$@: %2$@" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "%1$@ : %2$@" } }
+      }
+    },
+    "a11y.shape.note.arrow" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Description of this arrow" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Description de cette flèche" } }
+      }
+    },
+    "a11y.shape.note.rectangle" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Description of this rectangle" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Description de ce rectangle" } }
+      }
+    },
+    "a11y.shape.note.redaction" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Description of this hidden area" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Description de cette zone masquée" } }
+      }
+    },
     "a11y.shape.rectangle" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Rectangle annotation" } },
@@ -681,6 +705,12 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Tracés non numérotés dessinés sur l’image : les rectangles sont donnés haut-gauche → bas-droite, les flèches base → pointe, suivis de la taille de leur boîte englobante." } }
       }
     },
+    "export.shapes.note.legend" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "The sentence between a shape’s kind and its coordinates is what the user wrote about that shape." } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "La phrase entre le type d’une forme et ses coordonnées est ce que l’utilisateur a écrit à propos de cette forme." } }
+      }
+    },
     "export.shapes.redaction.legend" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "A hidden area is a region the user painted over before sharing: its pixels are not in the image, and nothing was collected about what sat under it. Ask the user rather than guessing." } },
@@ -789,6 +819,12 @@
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "REPÈRES" } }
       }
     },
+    "legend.shapes" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "ANNOTATIONS" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "ANNOTATIONS" } }
+      }
+    },
     "Light outline" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Contour léger" } }
@@ -827,6 +863,24 @@
     "Markers (position in % of the image, top-left origin):" : {
       "localizations" : {
         "fr" : { "stringUnit" : { "state" : "translated", "value" : "Repères (position en % de l’image, origine haut-gauche) :" } }
+      }
+    },
+    "markup.note.placeholder.arrow" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Describe this arrow…" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Décris cette flèche…" } }
+      }
+    },
+    "markup.note.placeholder.rectangle" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Describe this rectangle…" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Décris ce rectangle…" } }
+      }
+    },
+    "markup.note.placeholder.redaction" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Describe this hidden area…" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Décris cette zone masquée…" } }
       }
     },
     "markup.redaction" : {

--- a/Pinpoint/Markup.swift
+++ b/Pinpoint/Markup.swift
@@ -4,9 +4,12 @@ import Foundation
 /// A non-numbered visual annotation (arrow, rectangle or redaction) drawn on
 /// the capture.
 ///
-/// Unlike `Pin`, markups carry no number and no user description: they're
-/// visual emphasis. The agent-ready text still describes each of them (kind,
-/// endpoints and bounding box) so an agent can situate them without the image.
+/// Unlike `Pin`, markups carry no number: they are listed under their own
+/// heading in the export rather than in the numbered sequence drawn on the
+/// image. They do carry a description (#93) — see `note` — so a circled region
+/// can say *why* it was circled and not only where it is; the agent-ready text
+/// states each one's kind, endpoints and bounding box either way, so an agent
+/// can situate them without the image.
 /// Coordinates are normalized (0...1) in image space, top-left origin (same
 /// convention as `Pin`), so they scale with the canvas and export correctly.
 struct Markup: Identifiable, Equatable, Codable {
@@ -29,6 +32,21 @@ struct Markup: Identifiable, Equatable, Codable {
     var start: CGPoint
     /// Arrow: tip (where the arrowhead is). Rectangle/redaction: opposite corner.
     var end: CGPoint
+
+    /// What the user wrote about this shape (#93). Empty when they wrote
+    /// nothing, which stays the common case — a shape is worth drawing on its
+    /// own, and the field is an offer rather than a form to fill in.
+    ///
+    /// Always the user's own words, with no machine-read twin: nothing
+    /// pre-fills it the way a marker's note can be pre-filled from an OCR read,
+    /// so there is no second provenance to keep apart here — which is precisely
+    /// what `Pin.recognized` exists for, and why nothing like it belongs on
+    /// this type.
+    ///
+    /// A redaction carries one too, deliberately. "What I hid, and why" is the
+    /// one thing that can be said about a hidden area without undoing the
+    /// redaction — and it is said by the user, never read out of the pixels.
+    var note: String = ""
 
     /// Order-independent normalized rect (for rectangle and redaction markups).
     var rect: CGRect {
@@ -60,6 +78,80 @@ struct Markup: Identifiable, Equatable, Codable {
         case .rectangle: return "rectangle"
         case .redaction: return "eye.slash"
         }
+    }
+
+    /// The description with its surrounding whitespace gone, or nil when there
+    /// is nothing left of it.
+    ///
+    /// Every consumer asks the same question — "is there something to print
+    /// here?" — so it is asked once, in one place. Nil rather than an empty
+    /// string because that is the shape of the answer: the exporters, the
+    /// legend and the JSON contract all omit the description entirely when
+    /// there is none, which is what keeps a capture without descriptions
+    /// exporting exactly as it did before this field existed.
+    var trimmedNote: String? {
+        let trimmed = note.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Placeholder of this shape's description field in the side panel.
+    ///
+    /// Names the shape it belongs to, because the panel shows a column of
+    /// otherwise identical fields and the icon beside them is the only other
+    /// thing telling them apart. One string per kind rather than one string
+    /// interpolating `label`: French agrees the determiner with the noun
+    /// ("ce rectangle", "cette flèche"), and a single template can't.
+    var notePlaceholder: String {
+        switch kind {
+        case .arrow:
+            return String(localized: "markup.note.placeholder.arrow",
+                          defaultValue: "Describe this arrow…")
+        case .rectangle:
+            return String(localized: "markup.note.placeholder.rectangle",
+                          defaultValue: "Describe this rectangle…")
+        case .redaction:
+            return String(localized: "markup.note.placeholder.redaction",
+                          defaultValue: "Describe this hidden area…")
+        }
+    }
+
+    /// What VoiceOver calls that field. Without it the placeholder becomes the
+    /// label, and two rectangles announce themselves identically.
+    var noteAccessibilityLabel: String {
+        switch kind {
+        case .arrow:
+            return String(localized: "a11y.shape.note.arrow",
+                          defaultValue: "Description of this arrow")
+        case .rectangle:
+            return String(localized: "a11y.shape.note.rectangle",
+                          defaultValue: "Description of this rectangle")
+        case .redaction:
+            return String(localized: "a11y.shape.note.redaction",
+                          defaultValue: "Description of this hidden area")
+        }
+    }
+}
+
+extension Markup {
+    /// Decodes a markup, tolerating a file written before `note` existed (#93).
+    ///
+    /// Hand-written rather than left to the synthesized initializer, which
+    /// would `decode` a non-optional `String` and throw on every markup
+    /// recorded by an earlier version. That throw would not stay local:
+    /// `CaptureHistory.load()` decodes the whole `index.json` as one array with
+    /// `try?`, so a single old shape would empty the history — and the next
+    /// `saveIndex()` would write that emptiness back to disk. The upgrade would
+    /// silently delete the user's recent captures.
+    ///
+    /// In an extension so the memberwise initializer survives; `CodingKeys` and
+    /// `encode(to:)` are still synthesized from the stored properties.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(UUID.self, forKey: .id)
+        self.kind = try container.decode(Kind.self, forKey: .kind)
+        self.start = try container.decode(CGPoint.self, forKey: .start)
+        self.end = try container.decode(CGPoint.self, forKey: .end)
+        self.note = try container.decodeIfPresent(String.self, forKey: .note) ?? ""
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -73,13 +73,17 @@ relaunch Pinpoint once.
   alert rather than a blank image.
 - **Numbered markers & shapes** — click to drop ringed, numbered pins (drag to
   move, a note per marker); add arrows and rectangles for emphasis. Every
-  shape is selectable, movable and resizable after the fact, with full
-  **undo/redo** (**⌘Z** / **⇧⌘Z**) and keyboard delete.
+  shape takes a description of its own too, so a circled region can say *why*
+  it was circled — it travels in the copied text, in the JSON and in the
+  embedded legend. Every shape is selectable, movable and resizable after the
+  fact, with full **undo/redo** (**⌘Z** / **⇧⌘Z**) and keyboard delete.
 - **Three marker styles** — filled disc, pointer pin, light outline — applied on
   screen *and* in the export.
 - **Redact before you share** — **⌘4**, then drag over a token, password or API
   key: it's blacked out in the exported image, and stripped from the copied
-  text *and* the accessibility context below, not just visually covered.
+  text *and* the accessibility context below, not just visually covered. A
+  hidden area can still be described in your own words ("my API key"), which is
+  the only thing about it that reaches the agent.
 - **On-device OCR** — Vision reads the text sitting under each marker (an
   error message, a log line, a class name) with no network call, and can
   pre-fill a marker's note when nothing else already named the element.
@@ -101,9 +105,9 @@ relaunch Pinpoint once.
   of framing ("find the cause before proposing anything…") is written above
   your instructions, so the same scaffolding doesn't get retyped on every
   capture.
-- **Legend baked in** (optional) — embeds the marker descriptions + instructions
-  into the image, so a single paste carries everything (most chat UIs drop the
-  clipboard text).
+- **Legend baked in** (optional) — embeds the marker and shape descriptions +
+  instructions into the image, so a single paste carries everything (most chat
+  UIs drop the clipboard text).
 - **The shelf** — a built-in library of your screenshots: search, browse,
   favorite, sort, rename, Quick Look, and reopen any capture with its
   annotations (deleting one asks first).

--- a/docs/capture-schema.json
+++ b/docs/capture-schema.json
@@ -208,6 +208,7 @@
         "id": { "type": "string" },
         "label": { "type": "string", "description": "\"S1\", \"S2\"… matching capture.md." },
         "kind": { "type": "string", "enum": ["arrow", "rectangle", "redaction"], "description": "A redaction is a region the user painted over before sharing: its pixels are gone from the PNG, and nothing under it — no accessibility element, no recognized text — is described anywhere in this file. Its box is still given: where something was hidden is not itself a secret, and a consumer that knows a region is unreadable asks rather than guessing." },
+        "note": { "type": "string", "minLength": 1, "description": "What the user wrote about this shape. Absent when they wrote nothing, and absent from every file written before Pinpoint 0.7.2 — so its absence means \"nothing to say\", never \"said elsewhere\". Unlike a marker's note this has no machine-read twin: nothing pre-fills it, so it is the user's own words and nothing else. On a redaction it is the one thing that can be said about a hidden area without undoing the redaction, because the user is the one saying it." },
         "from": { "$ref": "#/$defs/point", "description": "Arrow: the tail. Rectangle/redaction: its top-left corner." },
         "to": { "$ref": "#/$defs/point", "description": "Arrow: the tip, where the head is drawn. Rectangle/redaction: its bottom-right corner." },
         "boundingBox": { "$ref": "#/$defs/box" }

--- a/landing/src/changelog.ts
+++ b/landing/src/changelog.ts
@@ -16,9 +16,17 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: '0.7.2',
+    date: '2026-08-24',
+    latest: true,
+    changes: [
+      { type: 'added', text: 'Every shape can carry its own description now — rectangles, arrows and redacted areas each get a field beside them, so circling a misaligned button finally has somewhere to say why. Until now only a numbered marker could hold a note, and describing a shape meant dropping a marker on top of it or pushing the explanation into the general instructions.' },
+      { type: 'added', text: 'Those descriptions travel wherever the capture goes: into capture.md, into an optional note on each shape in capture.json, and into a new ANNOTATIONS section of the baked-in legend. It matters most on a redacted area — “what I hid, and why” is exactly what an agent needs to know, and it was the one part of the handoff that had no way to say it.' },
+    ],
+  },
+  {
     version: '0.7.1',
     date: '2026-08-21',
-    latest: true,
     changes: [
       { type: 'added', text: 'Install the pinpoint command from the app — Settings ▸ Capture now has a “Command line tool” section that puts pinpoint on your PATH in one click, asking for permission once. It was already there if you installed with Homebrew; this is for everyone who downloaded the DMG and would otherwise have had to symlink it by hand.' },
     ],

--- a/project.yml
+++ b/project.yml
@@ -69,8 +69,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: app.croustibat.Pinpoint
-        MARKETING_VERSION: "0.7.1"
-        CURRENT_PROJECT_VERSION: "8"
+        MARKETING_VERSION: "0.7.2"
+        CURRENT_PROJECT_VERSION: "9"
         GENERATE_INFOPLIST_FILE: NO
         SWIFT_VERSION: "5.0"
         CODE_SIGN_STYLE: Automatic
@@ -114,8 +114,8 @@ targets:
       base:
         PRODUCT_NAME: pinpoint
         PRODUCT_BUNDLE_IDENTIFIER: app.croustibat.Pinpoint.cli
-        MARKETING_VERSION: "0.7.1"
-        CURRENT_PROJECT_VERSION: "8"
+        MARKETING_VERSION: "0.7.2"
+        CURRENT_PROJECT_VERSION: "9"
         # A tool has no Info.plist of its own; this embeds one in the binary so
         # `pinpoint --version` can read the version it was built with.
         GENERATE_INFOPLIST_FILE: YES

--- a/scripts/verify-shape-notes.sh
+++ b/scripts/verify-shape-notes.sh
@@ -1,18 +1,21 @@
 #!/usr/bin/env bash
-# Builds and runs the redaction check of #49 against the app's own sources.
+# Builds and runs the shape-description checks of #93 against the app's own
+# sources.
 #
-# Not part of the CI build: it exercises Vision's text recognizer, whose exact
-# output is a model's and not a contract's, and a check that can go amber on an
-# OS update has no business gating a merge. Run it when the recognizer, the
-# mask, or either exporter is touched.
+# Not part of the CI build, for the same reason as its sibling: the app has no
+# test target, and this is a standalone executable rather than a scheme
+# xcodebuild knows about. Run it when `Markup`, either exporter, the handoff
+# contract or the stored history is touched — the first case in it is what
+# stands between an added field and a deleted capture history.
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-out="$(mktemp -d)/verify-ocr-redaction"
+out="$(mktemp -d)/verify-shape-notes"
 
 xcrun swiftc -O -target "$(uname -m)-apple-macos15.0" -o "$out" \
     Pinpoint/AgentTextFormat.swift \
     Pinpoint/AXSnapshot.swift \
+    Pinpoint/CaptureRecord.swift \
     Pinpoint/Exporter.swift \
     Pinpoint/FileHandoff.swift \
     Pinpoint/HandoffContract.swift \
@@ -26,6 +29,6 @@ xcrun swiftc -O -target "$(uname -m)-apple-macos15.0" -o "$out" \
     Pinpoint/TaskPreset.swift \
     Pinpoint/TextRecognizer.swift \
     Pinpoint/Theme.swift \
-    scripts/verify-ocr-redaction.swift
+    scripts/verify-shape-notes.swift
 
 exec "$out"

--- a/scripts/verify-shape-notes.swift
+++ b/scripts/verify-shape-notes.swift
@@ -1,0 +1,229 @@
+import AppKit
+import Foundation
+
+// Proves, against the real code, that a shape's description (#93) reaches every
+// surface a capture is handed over on — and that adding it broke none of the
+// three things it could have broken: the stored history, the text of a capture
+// that carries no description, and the image of one.
+//
+// The app has no test target (see `scripts/verify-ocr-redaction.swift`), so
+// this is a small executable compiled from the very same sources — `Markup`,
+// `CaptureRecord`, `Exporter`, `FileHandoff.Document` — rather than a
+// reimplementation of them. What it asserts is what actually ships.
+//
+//   scripts/verify-shape-notes.sh
+//
+// The first case is the one with teeth. `CaptureHistory.load()` decodes the
+// whole `index.json` as one array with `try?`: a markup recorded before this
+// field existed must still decode, or a single old shape would empty the user's
+// history — and the next `saveIndex()` would write that emptiness back to disk.
+
+@main
+struct VerifyShapeNotes {
+
+    static var failures = 0
+
+    static func main() {
+        historyStillDecodes()
+        textCarriesTheDescription()
+        textIsUnchangedWithoutOne()
+        jsonCarriesTheDescription()
+        legendGrowsOnlyWhenThereIsSomethingToSay()
+
+        print("")
+        if failures == 0 {
+            print("✅ every check passed")
+        } else {
+            print("❌ \(failures) check(s) failed")
+            exit(1)
+        }
+    }
+
+    // MARK: - The history written by an earlier version
+
+    /// `index.json` as Pinpoint 0.7.1 wrote it: two shapes and a marker, and no
+    /// `note` key anywhere on the shapes because the field did not exist.
+    /// Hand-written rather than round-tripped, so it can't silently follow the
+    /// model it is supposed to be older than.
+    static let legacyIndex = """
+    [{
+      "id": "8B0F8B7E-2A1C-4C4B-9E2E-5C3D9A1F0001",
+      "date": 776000000,
+      "imageFileName": "8B0F8B7E-2A1C-4C4B-9E2E-5C3D9A1F0001.png",
+      "width": 1280, "height": 800,
+      "context": "the sidebar collapses on hover",
+      "pins": [{
+        "id": "8B0F8B7E-2A1C-4C4B-9E2E-5C3D9A1F0002",
+        "number": 1, "position": [0.4, 0.5], "note": "this button"
+      }],
+      "shapes": [
+        { "id": "8B0F8B7E-2A1C-4C4B-9E2E-5C3D9A1F0003", "kind": "rectangle",
+          "start": [0.1, 0.2], "end": [0.3, 0.4] },
+        { "id": "8B0F8B7E-2A1C-4C4B-9E2E-5C3D9A1F0004", "kind": "redaction",
+          "start": [0.6, 0.7], "end": [0.8, 0.9] }
+      ]
+    }]
+    """
+
+    static func historyStillDecodes() {
+        print("\n── an index.json written before the field existed ──")
+        guard let records = try? JSONDecoder().decode([CaptureRecord].self,
+                                                      from: Data(legacyIndex.utf8)) else {
+            check("the stored history still decodes", false)
+            print("   (this is the case that would delete the user's recent captures)")
+            return
+        }
+        check("the stored history still decodes", true)
+        check("both shapes came back", records.first?.shapes.count == 2)
+        check("a shape with no stored description reads as having none",
+              records.first?.shapes.allSatisfy { $0.note.isEmpty && $0.trimmedNote == nil } == true)
+        // The stored coordinates, not the derived `rect`: 0.3 − 0.1 is not 0.2
+        // in binary floating point, and a check that says so is a check about
+        // Swift rather than about this field.
+        let record = records.first
+        let marker = record?.pins.first
+        let rectangle = record?.shapes.first
+        let markerSurvived = marker?.note == "this button" && marker?.position == CGPoint(x: 0.4, y: 0.5)
+        let shapeSurvived = rectangle?.start == CGPoint(x: 0.1, y: 0.2)
+            && rectangle?.end == CGPoint(x: 0.3, y: 0.4)
+            && record?.shapes.last?.kind == .redaction
+        check("everything else survived untouched",
+              markerSurvived && shapeSurvived && record?.context == "the sidebar collapses on hover")
+
+        // And the other direction: what this version writes, this version reads.
+        let written = [Markup(kind: .arrow, start: CGPoint(x: 0, y: 0), end: CGPoint(x: 1, y: 1),
+                              note: "  the arrow points at the wrong row  ")]
+        let round = (try? JSONEncoder().encode(written)).flatMap {
+            try? JSONDecoder().decode([Markup].self, from: $0)
+        }
+        check("a description survives a save and a reload",
+              round?.first?.note == "  the arrow points at the wrong row  ")
+        check("it is trimmed only where it is read, never where it is stored",
+              round?.first?.trimmedNote == "the arrow points at the wrong row")
+    }
+
+    // MARK: - capture.md
+
+    static func textCarriesTheDescription() {
+        print("\n── capture.md ──")
+        let rectangle = Markup(kind: .rectangle, start: CGPoint(x: 0.1, y: 0.2),
+                               end: CGPoint(x: 0.3, y: 0.4), note: "  this box is 4 px too wide  ")
+        let hidden = Markup(kind: .redaction, start: CGPoint(x: 0.6, y: 0.7),
+                            end: CGPoint(x: 0.8, y: 0.9), note: "my API key")
+        let text = Exporter.buildText(pins: [], shapes: [rectangle, hidden], context: "",
+                                      imageSize: CGSize(width: 1000, height: 800))
+
+        check("the description sits between the shape's kind and its geometry",
+              text.contains("- S1 [\(rectangle.id.shortToken)] · \(rectangle.label) · this box is 4 px too wide — "))
+        check("it is trimmed on the way out",
+              !text.contains("·   this box is 4 px too wide"))
+        check("a hidden area says what the user chose to say about it",
+              text.contains("- S2 [\(hidden.id.shortToken)] · \(hidden.label) · my API key — "))
+        check("the reader is told where that sentence comes from",
+              occurrences(of: "is what the user wrote about that shape", in: text) == 1)
+    }
+
+    static func textIsUnchangedWithoutOne() {
+        print("\n── capture.md, for a capture nobody described ──")
+        let shapes = [
+            Markup(kind: .rectangle, start: CGPoint(x: 0.1, y: 0.2), end: CGPoint(x: 0.3, y: 0.4)),
+            // Whitespace only: the same thing as nothing, everywhere downstream.
+            Markup(kind: .arrow, start: CGPoint(x: 0.5, y: 0.5), end: CGPoint(x: 0.9, y: 0.1),
+                   note: "   \n  ")
+        ]
+        let text = Exporter.buildText(pins: [Pin(number: 1, position: CGPoint(x: 0.4, y: 0.5))],
+                                      shapes: shapes, context: "look at this",
+                                      imageSize: CGSize(width: 1000, height: 800))
+
+        check("the shape lines carry no empty slot",
+              text.contains("- S1 [\(shapes[0].id.shortToken)] · \(shapes[0].label) — ")
+                  && text.contains("- S2 [\(shapes[1].id.shortToken)] · \(shapes[1].label) — "))
+        check("no provenance line promises a description that never comes",
+              !text.contains("is what the user wrote about that shape"))
+    }
+
+    // MARK: - capture.json
+
+    static func jsonCarriesTheDescription() {
+        print("\n── capture.json ──")
+        let described = Markup(kind: .rectangle, start: CGPoint(x: 0.1, y: 0.2),
+                               end: CGPoint(x: 0.3, y: 0.4), note: "  the empty state  ")
+        let bare = Markup(kind: .arrow, start: CGPoint(x: 0.5, y: 0.5), end: CGPoint(x: 0.9, y: 0.1))
+
+        let document = FileHandoff.Document(
+            pins: [], shapes: [described, bare], context: "",
+            imageSize: CGSize(width: 1000, height: 800), directory: nil,
+            style: .disc, preset: .raw
+        )
+        check("the description is carried, trimmed", document.shapes.first?.note == "the empty state")
+        check("a shape with none carries no key at all", document.shapes.last?.note == nil)
+
+        guard let data = try? FileHandoff.encoder.encode(document),
+              let json = String(data: data, encoding: .utf8) else {
+            check("the document encodes", false)
+            return
+        }
+        check("the encoded file names it once", occurrences(of: "\"note\" : \"the empty state\"", in: json) == 1)
+        check("and writes nothing where there is nothing", occurrences(of: "\"note\"", in: json) == 1)
+
+        // The contract is read by the `pinpoint` CLI, including one built before
+        // this key existed — and a file written by an older app is read by the
+        // CLI shipping today. Both directions have to survive.
+        let older = json.replacingOccurrences(of: "\"note\" : \"the empty state\",\n", with: "")
+        check("a capture.json written before the key still decodes",
+              (try? JSONDecoder().decode(FileHandoff.Document.self,
+                                         from: Data(older.utf8)))?.shapes.first?.note == nil)
+    }
+
+    // MARK: - The legend baked into the image
+
+    static func legendGrowsOnlyWhenThereIsSomethingToSay() {
+        print("\n── the legend strip ──")
+        let base = blankImage(width: 400, height: 300)
+        let bare = Markup(kind: .rectangle, start: CGPoint(x: 0.1, y: 0.2), end: CGPoint(x: 0.3, y: 0.4))
+        var described = bare
+        described.note = "the tab bar wraps at this width"
+
+        func height(_ shapes: [Markup]) -> CGFloat {
+            Exporter.exportImage(base: base, pins: [], shapes: shapes, context: "",
+                                 style: .disc, includeLegend: true).size.height
+        }
+
+        // No markers, no instructions, no described shape: there is nothing to
+        // write, and the export must be the annotated capture and nothing else —
+        // exactly the image this build's predecessor produced.
+        check("an undescribed shape adds no strip", height([bare]) == base.size.height)
+        check("a described one does", height([described]) > base.size.height)
+        check("and a description in whitespace alone counts as none",
+              height([Markup(kind: .arrow, start: .zero, end: CGPoint(x: 1, y: 1), note: " \n ")])
+                  == base.size.height)
+    }
+
+    // MARK: - Harness
+
+    static func check(_ what: String, _ passed: Bool) {
+        print("   \(passed ? "✓" : "✗") \(what)")
+        if !passed { failures += 1 }
+    }
+
+    static func occurrences(of needle: String, in haystack: String) -> Int {
+        haystack.components(separatedBy: needle).count - 1
+    }
+
+    /// A plain white capture. The pixels are irrelevant here — only how much
+    /// taller the export gets than what it started from.
+    static func blankImage(width: Int, height: Int) -> NSImage {
+        let rep = NSBitmapImageRep(bitmapDataPlanes: nil, pixelsWide: width, pixelsHigh: height,
+                                   bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true,
+                                   isPlanar: false, colorSpaceName: .deviceRGB,
+                                   bytesPerRow: 0, bitsPerPixel: 0)!
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: rep)
+        NSColor.white.setFill()
+        NSRect(x: 0, y: 0, width: width, height: height).fill()
+        NSGraphicsContext.restoreGraphicsState()
+        let image = NSImage(size: NSSize(width: width, height: height))
+        image.addRepresentation(rep)
+        return image
+    }
+}


### PR DESCRIPTION
Release **v0.7.2**. Merge de `develop` dans `main`, préalable au flux de publication.

Une seule fonctionnalité, plus un correctif d'outillage de déploiement.

## Ce qui arrive (#94, refs #93)

Chaque forme — rectangle, flèche, zone masquée — porte désormais sa propre description, dans le panneau latéral, sur le modèle de la ligne d'un repère.

Jusqu'ici seul un repère numéroté pouvait porter une note. Entourer un bouton mal aligné n'offrait aucun endroit où écrire *pourquoi* : il fallait poser un repère par-dessus la forme, ou renvoyer l'explication dans les instructions générales et espérer que l'agent la rattache au bon cadre. Le manque était le plus criant sur la zone masquée — « ce que j'ai caché, et pourquoi » est exactement ce qu'un agent a besoin de savoir, et c'était le seul élément de l'export à ne rien pouvoir dire.

La description voyage ensuite partout :

- **`capture.md`** — la description s'intercale entre le type de la forme et sa géométrie, avec une ligne de provenance écrite seulement s'il y a au moins une description.
- **`capture.json`** — clé `note` optionnelle sur `shape`, écrite seulement quand elle est renseignée.
- **La légende gravée** — nouvelle section ANNOTATIONS.

Une capture que personne n'a décrite s'exporte exactement comme avant : pas de segment vide, pas de ligne de provenance promettant un détail qui ne vient jamais.

## Compatibilité

`schemaVersion` ne bouge pas. La clé est optionnelle des deux côtés et la règle publiée est que les clés s'ajoutent entre versions, donc le binaire `pinpoint` continue de lire les captures 0.7.1. `docs/capture-schema.json` est à jour.

Le point le plus risqué était ailleurs : `CaptureHistory.load()` décode `index.json` d'un seul `try?`, donc une clé absente aurait fait échouer le tableau entier et le `saveIndex()` suivant aurait écrit ce vide sur le disque — la mise à jour aurait silencieusement supprimé les captures récentes. `Markup` reçoit un `init(from:)` écrit à la main pour cette raison, et `scripts/verify-shape-notes.sh` couvre le cas.

## Aussi dans cette release

- **Préparation de version** — `MARKETING_VERSION` 0.7.1 → 0.7.2, `CURRENT_PROJECT_VERSION` 8 → 9 sur la target app **et** `PinpointCLI`, entrée `0.7.2` en tête du changelog.
- **Déploiement de la landing** — `.vercelignore` : le projet Vercel a `landing/` comme Root Directory, appliqué depuis la racine du dépôt, donc `vercel deploy` part de la racine et envoyait jusqu'ici 1,4 Go de contexte (`build/`, `.demo-remotion/`, `.claude/`) avant de ne garder que `landing/`. `.git` est explicitement préservé : l'Ignored Build Step du projet (`git diff --quiet HEAD^ HEAD -- landing/`) échoue sans dépôt git.

## Vérifié

- `scripts/install-local.sh` — build Release + signature Developer ID, `valid on disk`, Designated Requirement satisfait. App et CLI rapportent `0.7.2` (build 9).
- `scripts/verify-shape-notes.sh` — vert, historique existant relu intact.
- `scripts/verify-ocr-redaction.sh` — vert.
- `npm run build` de la landing — vert, `/changelog` liste la 0.7.2 en version courante.
- CI `Build (macOS)` verte sur la #95.

## Après ce merge

Tag `v0.7.2` depuis `main`, puis `scripts/release.sh`, la release GitHub, `update-cask.sh`, `update-appcast.sh` et le redéploiement de la landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)