### PR TITLE
Appcast Sparkle : entrée v0.7.2

### DIFF
--- a/landing/public/appcast.xml
+++ b/landing/public/appcast.xml
@@ -7,6 +7,14 @@
     <language>en</language>
     <!-- NEWEST-ITEM-ANCHOR — scripts/update-appcast.sh inserts each release below this line. -->
     <item>
+      <title>Version 0.7.2</title>
+      <pubDate>Mon, 24 Aug 2026 15:00:43 +0200</pubDate>
+      <sparkle:version>9</sparkle:version>
+      <sparkle:shortVersionString>0.7.2</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
+      <enclosure url="https://github.com/croustibat/Pinpoint/releases/download/v0.7.2/Pinpoint.dmg" sparkle:edSignature="au5JV+KKl83zpB3Fd7p3gl4rtxJqZHAomgyXOHaWP0XJaCDk2JwYi2dPp0Dw+v37lG90hb9IHi7dxTDXyS0jCg==" length="3954649" type="application/octet-stream" />
+    </item>
+    <item>
       <title>Version 0.7.1</title>
       <pubDate>Fri, 21 Aug 2026 15:59:43 +0200</pubDate>
       <sparkle:version>8</sparkle:version>


### PR DESCRIPTION
Entrée `0.7.2` dans `landing/public/appcast.xml`, générée par `scripts/update-appcast.sh` après la publication de la [release v0.7.2](https://github.com/croustibat/Pinpoint/releases/tag/v0.7.2).

C'est ce fichier qui déclenche la mise à jour automatique : une fois déployé, chaque Pinpoint installé se voit proposer la 0.7.2.

## Cohérence vérifiée

- `sparkle:shortVersionString` **0.7.2** et `sparkle:version` **9** — les mêmes que le `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` de la build publiée.
- `length` **3 954 649** — la taille exacte de l'asset `Pinpoint.dmg` de la release.
- `url` pointe sur l'asset GitHub de `v0.7.2`.
- `sparkle:minimumSystemVersion` **15.0**, inchangé.
- Signature EdDSA produite avec la clé privée du trousseau de la machine de release, appariée au `SUPublicEDKey` de `project.yml`.

## Portée

Le commit ne touche que `appcast.xml`. La migration pnpm en cours sur `landing/` reste hors de cette PR.

Après merge, `develop` doit repasser dans `main` pour que la landing de production serve le nouvel appcast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)